### PR TITLE
Fix windows breaking paths

### DIFF
--- a/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
@@ -4,6 +4,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -119,4 +120,9 @@ public class FileUtils {
   public static String replace(String text, String regexp, String replacement) {
     return Pattern.compile(regexp).matcher(text).replaceAll(replacement);
   }
+
+  public static boolean isPosix() {
+    return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+  }
+
 }

--- a/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
@@ -19,6 +19,7 @@ import tech.jhipster.lite.error.domain.GeneratorException;
 public class FileUtils {
 
   private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
+  private static final CharSequence FILE_SEPARATOR = "/";
 
   private FileUtils() {}
 
@@ -43,7 +44,7 @@ public class FileUtils {
   }
 
   public static String getPath(String... paths) {
-    return String.join(File.separator, paths).replaceAll("/", File.separator).replaceAll("\\\\", File.separator);
+    return String.join(FILE_SEPARATOR, paths);
   }
 
   public static Path getPathOf(String... paths) {
@@ -51,7 +52,7 @@ public class FileUtils {
   }
 
   public static InputStream getInputStream(String... paths) {
-    InputStream in = FileUtils.class.getResourceAsStream(File.separator + getPath(paths));
+    InputStream in = FileUtils.class.getResourceAsStream(FILE_SEPARATOR + getPath(paths));
     if (in == null) {
       throw new GeneratorException("File not found in classpath");
     }

--- a/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
@@ -19,7 +19,7 @@ import tech.jhipster.lite.error.domain.GeneratorException;
 public class FileUtils {
 
   private static final Logger log = LoggerFactory.getLogger(FileUtils.class);
-  private static final CharSequence FILE_SEPARATOR = "/";
+  private static final String FILE_SEPARATOR = "/";
 
   private FileUtils() {}
 
@@ -44,7 +44,7 @@ public class FileUtils {
   }
 
   public static String getPath(String... paths) {
-    return String.join(FILE_SEPARATOR, paths);
+    return String.join(FILE_SEPARATOR, paths).replaceAll("\\\\", FILE_SEPARATOR);
   }
 
   public static Path getPathOf(String... paths) {

--- a/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
@@ -124,5 +124,4 @@ public class FileUtils {
   public static boolean isPosix() {
     return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
   }
-
 }

--- a/src/main/java/tech/jhipster/lite/generator/project/domain/Project.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/domain/Project.java
@@ -108,7 +108,7 @@ public class Project {
   }
 
   public Optional<String> getPackageNamePath() {
-    return getPackageName().map(packageName -> packageName.replaceAll("\\.", File.separator));
+    return getPackageName().map(packageName -> packageName.replaceAll("\\.", "/"));
   }
 
   public Optional<String> getStringConfig(String key) {

--- a/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
@@ -128,7 +128,6 @@ public class ProjectLocalRepository implements ProjectRepository {
 
     perms.add(PosixFilePermission.OTHERS_READ);
     perms.add(PosixFilePermission.OTHERS_EXECUTE);
-    System.out.println(getPath(project.getFolder()));
     File file = new File(getPath(project.getFolder(), source, sourceFilename));
     try {
       Files.setPosixFilePermissions(file.toPath(), perms);

--- a/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
@@ -28,8 +28,6 @@ public class ProjectLocalRepository implements ProjectRepository {
 
   private final Logger log = LoggerFactory.getLogger(ProjectLocalRepository.class);
 
-  private final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
-
   @Override
   public void create(Project project) {
     try {
@@ -116,7 +114,7 @@ public class ProjectLocalRepository implements ProjectRepository {
 
   @Override
   public void setExecutable(Project project, String source, String sourceFilename) {
-    if (!isPosix) {
+    if (!FileUtils.isPosix()) {
       return;
     }
     Set<PosixFilePermission> perms = new HashSet<>();
@@ -130,7 +128,7 @@ public class ProjectLocalRepository implements ProjectRepository {
 
     perms.add(PosixFilePermission.OTHERS_READ);
     perms.add(PosixFilePermission.OTHERS_EXECUTE);
-
+    System.out.println(getPath(project.getFolder()));
     File file = new File(getPath(project.getFolder(), source, sourceFilename));
     try {
       Files.setPosixFilePermissions(file.toPath(), perms);

--- a/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepository.java
@@ -6,6 +6,7 @@ import static tech.jhipster.lite.generator.project.domain.Constants.TEMPLATE_FOL
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
@@ -26,6 +27,8 @@ import tech.jhipster.lite.generator.project.domain.ProjectRepository;
 public class ProjectLocalRepository implements ProjectRepository {
 
   private final Logger log = LoggerFactory.getLogger(ProjectLocalRepository.class);
+
+  private final boolean isPosix = FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
 
   @Override
   public void create(Project project) {
@@ -113,6 +116,9 @@ public class ProjectLocalRepository implements ProjectRepository {
 
   @Override
   public void setExecutable(Project project, String source, String sourceFilename) {
+    if (!isPosix) {
+      return;
+    }
     Set<PosixFilePermission> perms = new HashSet<>();
     perms.add(PosixFilePermission.OWNER_READ);
     perms.add(PosixFilePermission.OWNER_WRITE);

--- a/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
+++ b/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
@@ -5,6 +5,7 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static tech.jhipster.lite.TestUtils.assertFileNotExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.common.domain.FileUtils.isPosix;
 
 import java.io.File;
 import java.io.IOException;
@@ -15,6 +16,9 @@ import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.DisabledOnOs;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.error.domain.MissingMandatoryValueException;
@@ -323,5 +327,22 @@ class FileUtilsTest {
       assertThatThrownBy(() -> FileUtils.replaceInFile(filename, "powered by JHipster", "Hello JHipster Lite"))
         .isInstanceOf(IOException.class);
     }
+  }
+
+  @Nested
+  class FileSystem {
+
+    @Test
+    @EnabledOnOs(OS.WINDOWS)
+    void shouldReturnPosixFalseForWindows(){
+       assertFalse(isPosix());
+    }
+
+    @Test
+    @DisabledOnOs(OS.WINDOWS)
+    void shouldReturnPosixTrueForNonWindows(){
+      assertTrue(isPosix());
+    }
+
   }
 }

--- a/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
+++ b/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
@@ -98,7 +98,7 @@ class FileUtilsTest {
     void shouldGetPath() {
       String result = getPath("chips", "beer");
 
-      assertThat(result).isEqualTo("chips" + File.separator + "beer");
+      assertThat(result).isEqualTo("chips/beer");
     }
 
     @Test

--- a/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
+++ b/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
@@ -112,7 +112,7 @@ class FileUtilsTest {
     void shouldGetPathForWindows() {
       String result = getPath("C:\\chips\\beer");
 
-      assertThat(result).isEqualTo("C:" + File.separator + "chips" + File.separator + "beer");
+      assertThat(result).isEqualTo("C:/chips/beer");
     }
 
     @Test

--- a/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
+++ b/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
@@ -334,15 +334,14 @@ class FileUtilsTest {
 
     @Test
     @EnabledOnOs(OS.WINDOWS)
-    void shouldReturnPosixFalseForWindows(){
-       assertFalse(isPosix());
+    void shouldReturnPosixFalseForWindows() {
+      assertFalse(isPosix());
     }
 
     @Test
     @DisabledOnOs(OS.WINDOWS)
-    void shouldReturnPosixTrueForNonWindows(){
+    void shouldReturnPosixTrueForNonWindows() {
       assertTrue(isPosix());
     }
-
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepositoryTest.java
@@ -215,7 +215,10 @@ class ProjectLocalRepositoryTest {
   @Test
   void shouldNotSetExecutableForNonPosix() {
     Project project = tmpProjectWithPomXml();
-    try (MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class); MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class)) {
+    try (
+      MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class);
+      MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class)
+    ) {
       fileUtilsMock.when(() -> FileUtils.getPath(Mockito.any(String.class))).thenReturn(project.getFolder());
       fileUtilsMock.when(FileUtils::isPosix).thenReturn(false);
 

--- a/src/test/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/project/infrastructure/secondary/ProjectLocalRepositoryTest.java
@@ -4,9 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static tech.jhipster.lite.TestUtils.*;
-import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.common.domain.FileUtils.getPathOf;
+import static tech.jhipster.lite.common.domain.FileUtils.*;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
 import static tech.jhipster.lite.generator.project.domain.Constants.TEST_TEMPLATE_RESOURCES;
 
@@ -209,6 +210,18 @@ class ProjectLocalRepositoryTest {
 
     assertThatThrownBy(() -> repository.write(project, "another hello world", "hello", "hello.world"))
       .isExactlyInstanceOf(GeneratorException.class);
+  }
+
+  @Test
+  void shouldNotSetExecutableForNonPosix() {
+    Project project = tmpProjectWithPomXml();
+    try (MockedStatic<FileUtils> fileUtilsMock = Mockito.mockStatic(FileUtils.class); MockedStatic<Files> filesMock = Mockito.mockStatic(Files.class)) {
+      fileUtilsMock.when(() -> FileUtils.getPath(Mockito.any(String.class))).thenReturn(project.getFolder());
+      fileUtilsMock.when(FileUtils::isPosix).thenReturn(false);
+
+      repository.setExecutable(project, "", "pom.xml");
+      filesMock.verify(() -> Files.setPosixFilePermissions(Mockito.any(), Mockito.any()), never());
+    }
   }
 
   @Test


### PR DESCRIPTION
Getting the generator run in windows:-
1. Using "/" as file separator for windows to avoid conflicts with
mustache.
2. Avoid Posix file executable for non-posix systems

Note:- If using "\\" (File.separator on windows) its not possible to generate the project at all, so replacing it with more universal "/" 
Exception in mustache when using "\" as file separator from
```

java.lang.IllegalArgumentException: Illegal character in path at index 9: generator\init\README.md.mustache
	at java.base/java.net.URI.create(URI.java:906) ~[na:na]
	at com.github.mustachejava.resolver.ClasspathResolver.getReader(ClasspathResolver.java:37) ~[compiler-0.9.10.jar:na]
	at com.github.mustachejava.resolver.DefaultResolver.getReader(DefaultResolver.java:48) ~[compiler-0.9.10.jar:na]
	at com.github.mustachejava.DefaultMustacheFactory.getReader(DefaultMustacheFactory.java:118) ~[compiler-0.9.10.jar:na]
	at com.github.mustachejava.MustacheParser.compile(MustacheParser.java:33) ~[compiler-0.9.10.jar:na]
```