### PR TITLE
Remove pathmatch.matching-strategy property in generator

### DIFF
--- a/src/main/resources/config/application.properties
+++ b/src/main/resources/config/application.properties
@@ -1,5 +1,4 @@
 spring.application.name=jhlite
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=7471
 
 springdoc.swagger-ui.operationsSorter=alpha

--- a/src/test/resources/config/application.properties
+++ b/src/test/resources/config/application.properties
@@ -1,5 +1,4 @@
 spring.main.banner-mode=off
-spring.mvc.pathmatch.matching-strategy=ant_path_matcher
 server.port=0
 
 application.exception.package=org.,java.


### PR DESCRIPTION
Following this: https://github.com/jhipster/jhipster-lite/issues/198#issuecomment-997255122 by @swarajsaaj 

It seems useless property as JH Lite uses springdoc