### PR TITLE
Maven: Add Plugin management and configuration

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/Plugin.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/Plugin.java
@@ -1,5 +1,7 @@
 package tech.jhipster.lite.generator.buildtool.generic.domain;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 import tech.jhipster.lite.error.domain.Assert;
 
@@ -8,6 +10,8 @@ public class Plugin {
   private final String groupId;
   private final String artifactId;
   private final Optional<String> version;
+  private List<PluginExecution> executions;
+  private List<PluginConfiguration> configurations;
 
   private Plugin(PluginBuilder builder) {
     Assert.notBlank("groupId", builder.groupId);
@@ -16,6 +20,8 @@ public class Plugin {
     this.groupId = builder.groupId;
     this.artifactId = builder.artifactId;
     this.version = optionalNotBlank(builder.version);
+    this.executions = builder.executions;
+    this.configurations = builder.configurations;
   }
 
   private Optional<String> optionalNotBlank(String value) {
@@ -41,11 +47,21 @@ public class Plugin {
     return version;
   }
 
+  public List<PluginExecution> getExecutions() {
+    return executions;
+  }
+
+  public List<PluginConfiguration> getConfigurations() {
+    return configurations;
+  }
+
   public static class PluginBuilder {
 
     private String groupId;
     private String artifactId;
     private String version;
+    private List<PluginExecution> executions;
+    private List<PluginConfiguration> configurations;
 
     public PluginBuilder groupId(String groupId) {
       this.groupId = groupId;
@@ -59,6 +75,18 @@ public class Plugin {
 
     public PluginBuilder version(String version) {
       this.version = version;
+      return this;
+    }
+
+    public PluginBuilder execution(PluginExecution execution) {
+      if (executions == null) executions = new ArrayList<>();
+      executions.add(execution);
+      return this;
+    }
+
+    public PluginBuilder configuration(PluginConfiguration configuration) {
+      if (configurations == null) configurations = new ArrayList<>();
+      configurations.add(configuration);
       return this;
     }
 

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfiguration.java
@@ -1,0 +1,3 @@
+package tech.jhipster.lite.generator.buildtool.generic.domain;
+
+public interface PluginConfiguration {}

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfigurationContainer.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfigurationContainer.java
@@ -1,0 +1,22 @@
+package tech.jhipster.lite.generator.buildtool.generic.domain;
+
+import java.util.List;
+
+public class PluginConfigurationContainer implements PluginConfiguration {
+
+  private String name;
+  private List<PluginConfiguration> children;
+
+  public PluginConfigurationContainer(String name, List<PluginConfiguration> children) {
+    this.name = name;
+    this.children = children;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public List<PluginConfiguration> getChildren() {
+    return children;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfigurationValue.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginConfigurationValue.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.buildtool.generic.domain;
+
+public class PluginConfigurationValue implements PluginConfiguration {
+
+  private String name;
+  private String value;
+
+  public PluginConfigurationValue(String name, String value) {
+    this.name = name;
+    this.value = value;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public String getValue() {
+    return value;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginExecution.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/PluginExecution.java
@@ -1,0 +1,72 @@
+package tech.jhipster.lite.generator.buildtool.generic.domain;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class PluginExecution {
+
+  private String id;
+  private String phase;
+  private List<String> goals;
+  private List<PluginConfiguration> configurations;
+
+  private PluginExecution(PluginExecutionBuilder pluginExecutionBuilder) {
+    this.id = pluginExecutionBuilder.id;
+    this.phase = pluginExecutionBuilder.phase;
+    this.goals = pluginExecutionBuilder.goals;
+    this.configurations = pluginExecutionBuilder.configurations;
+  }
+
+  public static PluginExecutionBuilder builder() {
+    return new PluginExecutionBuilder();
+  }
+
+  public String getId() {
+    return id;
+  }
+
+  public String getPhase() {
+    return phase;
+  }
+
+  public List<String> getGoals() {
+    return goals;
+  }
+
+  public List<PluginConfiguration> getConfigurations() {
+    return configurations;
+  }
+
+  public static class PluginExecutionBuilder {
+
+    private String id;
+    private String phase;
+    private List<String> goals;
+    private List<PluginConfiguration> configurations;
+
+    public PluginExecutionBuilder id(String id) {
+      this.id = id;
+      return this;
+    }
+
+    public PluginExecutionBuilder phase(String phase) {
+      this.phase = phase;
+      return this;
+    }
+
+    public PluginExecutionBuilder goals(List<String> goals) {
+      this.goals = goals;
+      return this;
+    }
+
+    public PluginExecutionBuilder configuration(PluginConfiguration configuration) {
+      if (this.configurations == null) this.configurations = new ArrayList<>();
+      this.configurations.add(configuration);
+      return this;
+    }
+
+    public PluginExecution build() {
+      return new PluginExecution(this);
+    }
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationService.java
@@ -37,6 +37,10 @@ public class MavenApplicationService {
     mavenService.addPlugin(project, plugin);
   }
 
+  public void addPluginManagement(Project project, Plugin plugin) {
+    mavenService.addPluginManagement(project, plugin);
+  }
+
   public void addProperty(Project project, String key, String version) {
     mavenService.addProperty(project, key, version);
   }

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
@@ -91,6 +91,21 @@ public class MavenDomainService implements MavenService {
   }
 
   @Override
+  public void addPluginManagement(Project project, Plugin plugin) {
+    project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
+    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
+
+    String pluginNodeNode = Maven.getPluginHeader(plugin, indent);
+    String pluginRegexp = FileUtils.REGEXP_PREFIX_MULTILINE + pluginNodeNode;
+
+    if (!projectRepository.containsRegexp(project, "", POM_XML, pluginRegexp)) {
+      String pluginWithNeedle = Maven.getPlugin(plugin, indent) + System.lineSeparator() + indent(3, indent) + NEEDLE_PLUGIN_MANAGEMENT;
+
+      projectRepository.replaceText(project, "", POM_XML, NEEDLE_PLUGIN_MANAGEMENT, pluginWithNeedle);
+    }
+  }
+
+  @Override
   public void addProperty(Project project, String key, String version) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
     int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenService.java
@@ -12,6 +12,7 @@ public interface MavenService {
   void deleteDependency(Project project, Dependency dependency);
   void addDependency(Project project, Dependency dependency, List<Dependency> exclusions);
   void addPlugin(Project project, Plugin plugin);
+  void addPluginManagement(Project project, Plugin plugin);
   void addProperty(Project project, String key, String version);
   void deleteProperty(Project project, String key);
 

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
@@ -211,6 +211,26 @@ class MavenApplicationServiceIT {
   }
 
   @Test
+  void shouldAddPluginInPluginManagement() {
+    Project project = tmpProjectWithPomXml();
+
+    Plugin plugin = Plugin.builder().groupId("org.springframework.boot").artifactId("spring-boot-maven-plugin").build();
+    mavenApplicationService.addPluginManagement(project, plugin);
+
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<plugin>",
+        "<groupId>org.springframework.boot</groupId>",
+        "<artifactId>spring-boot-maven-plugin</artifactId>",
+        "</plugin>",
+        Maven.NEEDLE_PLUGIN_MANAGEMENT
+      )
+    );
+  }
+
+  @Test
   void shouldAddPluginOnlyOneTime() throws Exception {
     Project project = tmpProjectWithPomXml();
 

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenDomainServiceTest.java
@@ -102,6 +102,16 @@ class MavenDomainServiceTest {
   }
 
   @Test
+  void shouldAddPluginManagement() {
+    Project project = tmpProjectWithPomXml();
+    Plugin plugin = Plugin.builder().groupId("org.springframework.boot").artifactId("spring-boot-maven-plugin").build();
+
+    mavenDomainService.addPluginManagement(project, plugin);
+
+    verify(projectRepository).replaceText(any(Project.class), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
   void shouldAddProperty() {
     Project project = tmpProjectWithPomXml();
 

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
@@ -1,13 +1,14 @@
 package tech.jhipster.lite.generator.buildtool.maven.domain.maven;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.UnitTest;
-import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
-import tech.jhipster.lite.generator.buildtool.generic.domain.Parent;
-import tech.jhipster.lite.generator.buildtool.generic.domain.Plugin;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.*;
 import tech.jhipster.lite.generator.buildtool.maven.domain.Maven;
 
 @UnitTest
@@ -195,6 +196,122 @@ class MavenTest {
     Plugin plugin = fullPluginBuilder().build();
 
     assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldGetPluginWithExecution() {
+    // @formatter:off
+    String expected =
+      "<plugin>" + System.lineSeparator() +
+        "        <groupId>org.springframework.boot</groupId>" + System.lineSeparator() +
+        "        <artifactId>spring-boot-maven-plugin</artifactId>" + System.lineSeparator() +
+        "        <version>2.6.0</version>" + System.lineSeparator() +
+        "        <executions>" + System.lineSeparator() +
+        "          <execution>" + System.lineSeparator() +
+        "            <id>id1</id>" + System.lineSeparator() +
+        "            <phase>initialize</phase>" + System.lineSeparator() +
+        "            <goals>" + System.lineSeparator() +
+        "              <goal>read-project-properties</goal>" + System.lineSeparator() +
+        "            </goals>" + System.lineSeparator() +
+        "          </execution>" + System.lineSeparator() +
+        "        </executions>" + System.lineSeparator() +
+        "      </plugin>";
+    // @formatter:on
+    PluginExecution execution = PluginExecution.builder().id("id1").phase("initialize").goals(List.of("read-project-properties")).build();
+    Plugin plugin = fullPluginBuilder().execution(execution).build();
+
+    assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldGetPluginWithConfiguredExecution() {
+    // @formatter:off
+    String expected =
+      "<plugin>" + System.lineSeparator() +
+        "        <groupId>org.springframework.boot</groupId>" + System.lineSeparator() +
+        "        <artifactId>spring-boot-maven-plugin</artifactId>" + System.lineSeparator() +
+        "        <version>2.6.0</version>" + System.lineSeparator() +
+        "        <executions>" + System.lineSeparator() +
+        "          <execution>" + System.lineSeparator() +
+        "            <id>id1</id>" + System.lineSeparator() +
+        "            <phase>initialize</phase>" + System.lineSeparator() +
+        "            <goals>" + System.lineSeparator() +
+        "              <goal>read-project-properties</goal>" + System.lineSeparator() +
+        "            </goals>" + System.lineSeparator() +
+        "            <configuration>" + System.lineSeparator() +
+        "              <files>" + System.lineSeparator() +
+        "                <file>test.properties</file>" + System.lineSeparator() +
+        "                <file>test2.properties</file>" + System.lineSeparator() +
+        "              </files>" + System.lineSeparator() +
+        "              <source.dir>directory</source.dir>" + System.lineSeparator() +
+        "            </configuration>" + System.lineSeparator() +
+        "          </execution>" + System.lineSeparator() +
+        "        </executions>" + System.lineSeparator() +
+        "      </plugin>";
+    // @formatter:on
+    PluginExecution execution = PluginExecution
+      .builder()
+      .id("id1")
+      .phase("initialize")
+      .goals(List.of("read-project-properties"))
+      .configuration(
+        new PluginConfigurationContainer(
+          "files",
+          List.of(new PluginConfigurationValue("file", "test.properties"), new PluginConfigurationValue("file", "test2.properties"))
+        )
+      )
+      .configuration(new PluginConfigurationValue("source.dir", "directory"))
+      .build();
+    Plugin plugin = fullPluginBuilder().execution(execution).build();
+
+    assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldGetPluginWithConfigurationAndExecution() {
+    // @formatter:off
+    String expected =
+      "<plugin>" + System.lineSeparator() +
+        "        <groupId>org.springframework.boot</groupId>" + System.lineSeparator() +
+        "        <artifactId>spring-boot-maven-plugin</artifactId>" + System.lineSeparator() +
+        "        <version>2.6.0</version>" + System.lineSeparator() +
+        "        <executions>" + System.lineSeparator() +
+        "          <execution>" + System.lineSeparator() +
+        "            <id>id1</id>" + System.lineSeparator() +
+        "            <phase>initialize</phase>" + System.lineSeparator() +
+        "            <goals>" + System.lineSeparator() +
+        "              <goal>read-project-properties</goal>" + System.lineSeparator() +
+        "            </goals>" + System.lineSeparator() +
+        "          </execution>" + System.lineSeparator() +
+        "        </executions>" + System.lineSeparator() +
+        "        <configuration>" + System.lineSeparator() +
+        "          <files>" + System.lineSeparator() +
+        "            <file>test.properties</file>" + System.lineSeparator() +
+        "            <file>test2.properties</file>" + System.lineSeparator() +
+        "          </files>" + System.lineSeparator() +
+        "          <source.dir>directory</source.dir>" + System.lineSeparator() +
+        "        </configuration>" + System.lineSeparator() +
+        "      </plugin>";
+    // @formatter:on
+    PluginExecution execution = PluginExecution.builder().id("id1").phase("initialize").goals(List.of("read-project-properties")).build();
+    Plugin plugin = fullPluginBuilder()
+      .execution(execution)
+      .configuration(
+        new PluginConfigurationContainer(
+          "files",
+          List.of(new PluginConfigurationValue("file", "test.properties"), new PluginConfigurationValue("file", "test2.properties"))
+        )
+      )
+      .configuration(new PluginConfigurationValue("source.dir", "directory"))
+      .build();
+
+    assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
+  }
+
+  @Test
+  void shouldNotGetConfigurationElement() {
+    assertThatThrownBy(() -> Maven.getConfigurationElement(1, 1, new PluginConfiguration() {}))
+      .isExactlyInstanceOf(UnsupportedOperationException.class);
   }
 
   @Test


### PR DESCRIPTION
- Allow maven plugins to be added in `pluginManagement`
- Allow deeper configuration for maven plugins
  - Executions
    - Phase
    - Goals
  - Configuration



This PR is pre-requisite to #284 
