### PR TITLE
Revert "CI: SonarCloud Analysis"

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -35,12 +35,6 @@ jobs:
         run: |
           chmod +x mvnw
           ./mvnw clean verify
-      - name: 'Analysis: SonarCloud'
-        if: github.repository == 'jhipster/jhipster-lite' && github.ref == 'refs/heads/main'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: ./mvnw initialize sonar:sonar -Dsonar.host.url=https://sonarcloud.io -Dsonar.projectKey=jhipster_jhipster-lite -Dsonar.organization=jhipster
       - name: 'Artifact: upload JaCoCo report'
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
Reverts jhipster/jhipster-lite#370

Following https://sonarcloud.io/documentation/enriching/coverage/

> SonarCloud itself does not calculate coverage. To include coverage results in your analysis, you must set up a third-party coverage tool and configure SonarCloud to import the results produced by that tool. This feature is only available for CI-based analysis. It is not available for automatic analysis.

So the coverage will be done by codecov.
And the other metrics by SonarCloud
