### PR TITLE
Add Spring Boot Developer Tools

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/Dependency.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/Dependency.java
@@ -7,6 +7,7 @@ public class Dependency {
 
   private final String groupId;
   private final String artifactId;
+  private final boolean optional;
   private final Optional<String> version;
   private final Optional<String> scope;
 
@@ -16,6 +17,7 @@ public class Dependency {
 
     this.groupId = builder.groupId;
     this.artifactId = builder.artifactId;
+    this.optional = builder.optional;
     this.version = optionalNotBlank(builder.version);
     this.scope = optionalNotBlank(builder.scope);
   }
@@ -39,6 +41,10 @@ public class Dependency {
     return artifactId;
   }
 
+  public boolean isOptional() {
+    return optional;
+  }
+
   public Optional<String> getVersion() {
     return version;
   }
@@ -51,6 +57,7 @@ public class Dependency {
 
     private String groupId;
     private String artifactId;
+    private boolean optional;
     private String version;
     private String scope;
 
@@ -61,6 +68,11 @@ public class Dependency {
 
     public Dependency.DependencyBuilder artifactId(String artifactId) {
       this.artifactId = artifactId;
+      return this;
+    }
+
+    public Dependency.DependencyBuilder optional() {
+      this.optional = true;
       return this;
     }
 

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
@@ -35,6 +35,8 @@ public class Maven {
   public static final String ARTIFACT_ID_BEGIN = "<artifactId>";
   public static final String ARTIFACT_ID_END = "</artifactId>";
 
+  public static final String OPTIONAL = "<optional>true</optional>";
+
   public static final String VERSION_BEGIN = "<version>";
   public static final String VERSION_END = "</version>";
 
@@ -122,6 +124,10 @@ public class Maven {
 
   public static String getDependency(Dependency dependency, int indentation, List<Dependency> exclusions) {
     StringBuilder result = new StringBuilder().append(getDependencyHeader(dependency, indentation));
+
+    if (dependency.isOptional()) {
+      result.append(indent(3, indentation)).append(OPTIONAL).append(System.lineSeparator());
+    }
 
     dependency
       .getVersion()

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationService.java
@@ -1,0 +1,27 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.devtools.domain.DevToolsService;
+
+@Service
+public class DevToolsApplicationService {
+
+  private final DevToolsService devToolsService;
+
+  public DevToolsApplicationService(DevToolsService devToolsService) {
+    this.devToolsService = devToolsService;
+  }
+
+  public void init(Project project) {
+    devToolsService.init(project);
+  }
+
+  public void addSpringBootDevTools(Project project) {
+    devToolsService.addSpringBootDevTools(project);
+  }
+
+  public void addProperties(Project project) {
+    devToolsService.addProperties(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsDomainService.java
@@ -34,14 +34,15 @@ public class DevToolsDomainService implements DevToolsService {
 
   @Override
   public void addProperties(Project project) {
-    springPropertiesDevTools().forEach((k, v) -> springBootPropertiesService.addProperties(project, k, v));
+    springPropertiesDevTools(false).forEach((k, v) -> springBootPropertiesService.addProperties(project, k, v));
+    springPropertiesDevTools(true).forEach((k, v) -> springBootPropertiesService.addPropertiesFast(project, k, v));
   }
 
-  private Map<String, Object> springPropertiesDevTools() {
+  private Map<String, Object> springPropertiesDevTools(boolean fast) {
     TreeMap<String, Object> result = new TreeMap<>();
 
-    result.put("spring.devtools.livereload.enabled", true);
-    result.put("spring.devtools.restart.enabled", true);
+    result.put("spring.devtools.livereload.enabled", fast);
+    result.put("spring.devtools.restart.enabled", fast);
 
     return result;
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsDomainService.java
@@ -1,0 +1,48 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.domain;
+
+import java.util.Map;
+import java.util.TreeMap;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+public class DevToolsDomainService implements DevToolsService {
+
+  public static final String SOURCE = "server/springboot/devtools";
+
+  private final BuildToolService buildToolService;
+  private final SpringBootPropertiesService springBootPropertiesService;
+
+  public DevToolsDomainService(BuildToolService buildToolService, SpringBootPropertiesService springBootPropertiesService) {
+    this.buildToolService = buildToolService;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Override
+  public void init(Project project) {
+    addSpringBootDevTools(project);
+    addProperties(project);
+  }
+
+  @Override
+  public void addSpringBootDevTools(Project project) {
+    Dependency dependency = Dependency.builder().groupId("org.springframework.boot").artifactId("spring-boot-devtools").optional().build();
+
+    buildToolService.addDependency(project, dependency);
+  }
+
+  @Override
+  public void addProperties(Project project) {
+    springPropertiesDevTools().forEach((k, v) -> springBootPropertiesService.addProperties(project, k, v));
+  }
+
+  private Map<String, Object> springPropertiesDevTools() {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("spring.devtools.livereload.enabled", true);
+    result.put("spring.devtools.restart.enabled", true);
+
+    return result;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/domain/DevToolsService.java
@@ -1,0 +1,10 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface DevToolsService {
+  void init(Project project);
+
+  void addSpringBootDevTools(Project project);
+  void addProperties(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/config/DevToolsBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/config/DevToolsBeanConfiguration.java
@@ -1,0 +1,25 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.server.springboot.devtools.domain.DevToolsDomainService;
+import tech.jhipster.lite.generator.server.springboot.devtools.domain.DevToolsService;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+@Configuration
+public class DevToolsBeanConfiguration {
+
+  public final BuildToolService buildToolService;
+  public final SpringBootPropertiesService springBootPropertiesService;
+
+  public DevToolsBeanConfiguration(BuildToolService buildToolService, SpringBootPropertiesService springBootPropertiesService) {
+    this.buildToolService = buildToolService;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Bean
+  public DevToolsService devToolsService() {
+    return new DevToolsDomainService(buildToolService, springBootPropertiesService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/primary/rest/DevToolsResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/primary/rest/DevToolsResource.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.infrastructure.primary.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.devtools.application.DevToolsApplicationService;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/devtools")
+@Tag(name = "Spring Boot - Developer Tools")
+class DevToolsResource {
+
+  private final DevToolsApplicationService devToolsApplicationService;
+
+  public DevToolsResource(DevToolsApplicationService devToolsApplicationService) {
+    this.devToolsApplicationService = devToolsApplicationService;
+  }
+
+  @Operation(summary = "Add Developer Tools dependencies")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Developer Tools")
+  @PostMapping
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    devToolsApplicationService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.devtools;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationServiceIT.java
@@ -1,0 +1,95 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class DevToolsApplicationServiceIT {
+
+  @Autowired
+  DevToolsApplicationService devToolsApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    devToolsApplicationService.init(project);
+
+    assertPomContainsDependency(project);
+
+    assertProperties(project);
+  }
+
+  @Test
+  void shouldAddSpringBootDevTools() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    devToolsApplicationService.addSpringBootDevTools(project);
+
+    assertPomContainsDependency(project);
+  }
+
+  @Test
+  void shouldAddProperties() {
+    Project project = tmpProject();
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
+    project.addConfig(BASE_NAME, "chips");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    devToolsApplicationService.addProperties(project);
+
+    assertProperties(project);
+  }
+
+  private List<String> springBootDevTools() {
+    return List.of(
+      "<dependency>",
+      "<groupId>org.springframework.boot</groupId>",
+      "<artifactId>spring-boot-devtools</artifactId>",
+      "<optional>true</optional>",
+      "</dependency>"
+    );
+  }
+
+  private void assertPomContainsDependency(Project project) {
+    assertFileContent(project, "pom.xml", springBootDevTools());
+  }
+
+  private void assertProperties(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
+      List.of("spring.devtools.livereload.enabled=true", "spring.devtools.restart.enabled=true")
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/application/DevToolsApplicationServiceIT.java
@@ -6,6 +6,7 @@ import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_FAST_PROPERTIES;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
 
 import java.util.List;
@@ -89,6 +90,11 @@ class DevToolsApplicationServiceIT {
     assertFileContent(
       project,
       getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
+      List.of("spring.devtools.livereload.enabled=false", "spring.devtools.restart.enabled=false")
+    );
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config", APPLICATION_FAST_PROPERTIES),
       List.of("spring.devtools.livereload.enabled=true", "spring.devtools.restart.enabled=true")
     );
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/config/DevToolsBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/config/DevToolsBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.devtools.domain.DevToolsDomainService;
+
+@IntegrationTest
+class DevToolsBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("devToolsService")).isNotNull().isInstanceOf(DevToolsDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/rest/DevToolsResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/rest/DevToolsResourceIT.java
@@ -1,0 +1,71 @@
+package tech.jhipster.lite.generator.server.springboot.devtools.infrastructure.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class DevToolsResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldInit() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/devtools")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertFileContent(project, "pom.xml", springBootDevTools());
+  }
+
+  private List<String> springBootDevTools() {
+    return List.of(
+      "<dependency>",
+      "<groupId>org.springframework.boot</groupId>",
+      "<artifactId>spring-boot-devtools</artifactId>",
+      "<optional>true</optional>",
+      "</dependency>"
+    );
+  }
+}


### PR DESCRIPTION
#197 

I added this dependency as optional, as recommended:

> Flagging the dependency as optional in Maven or using compileOnly in Gradle is a best practice that prevents devtools from being transitively applied to other modules using your project.

In JHipster, devtools were only present with the dev profile. but I wonder if it's really needed, as the documentation says:

> Developer tools are automatically disabled when running a fully packaged application. If your application is launched using java -jar or if it’s started using a special classloader, then it is considered a “production application”.

and

> repackaged archives do not contain devtools by default.