### PR TITLE
add Spring Boot Logstash TCP appender

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashApplicationService.java
@@ -1,0 +1,31 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain.LogstashService;
+
+@Service
+public class LogstashApplicationService {
+
+  private final LogstashService logstashService;
+
+  public LogstashApplicationService(LogstashService logstashService) {
+    this.logstashService = logstashService;
+  }
+
+  public void init(Project project) {
+    logstashService.init(project);
+  }
+
+  public void addDependencies(Project project) {
+    logstashService.addDependencies(project);
+  }
+
+  public void addJavaFiles(Project project) {
+    logstashService.addJavaFiles(project);
+  }
+
+  public void addProperties(Project project) {
+    logstashService.addProperties(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/Logstash.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/Logstash.java
@@ -1,0 +1,23 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class Logstash {
+
+  private static final String LOGSTASH_LOGBACK_ENCODER_VERSION = "7.0.1";
+
+  private Logstash() {}
+
+  public static Dependency logstashLogbackEncoderDependency() {
+    return Dependency
+      .builder()
+      .groupId("net.logstash.logback")
+      .artifactId("logstash-logback-encoder")
+      .version("\\${logstash-logback-encoder.version}")
+      .build();
+  }
+
+  public static String getLogstashLogbackEncoderVersion() {
+    return LOGSTASH_LOGBACK_ENCODER_VERSION;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashDomainService.java
@@ -1,0 +1,84 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain;
+
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+
+import java.util.Map;
+import java.util.TreeMap;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+public class LogstashDomainService implements LogstashService {
+
+  public static final String SOURCE = "server/springboot/logging/logstash/tcp";
+  public static final String DESTINATION = "technical/infrastructure/secondary/logstash";
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+  private final SpringBootPropertiesService springBootPropertiesService;
+
+  public LogstashDomainService(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootPropertiesService springBootPropertiesService
+  ) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Override
+  public void init(Project project) {
+    addDependencies(project);
+    addJavaFiles(project);
+    addProperties(project);
+  }
+
+  @Override
+  public void addDependencies(Project project) {
+    buildToolService.addProperty(project, "logstash-logback-encoder", Logstash.getLogstashLogbackEncoderVersion());
+    buildToolService.addDependency(project, Logstash.logstashLogbackEncoderDependency());
+  }
+
+  @Override
+  public void addJavaFiles(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    project.addDefaultConfig(BASE_NAME);
+    String packageNamePath = project.getPackageNamePath().orElse(getPath("com/mycompany/myapp"));
+
+    templateToLogstash(project, packageNamePath, "src", "LogstashTcpConfiguration.java", MAIN_JAVA);
+    templateToLogstash(project, packageNamePath, "src", "LogstashTcpLifeCycle.java", MAIN_JAVA);
+    templateToLogstash(project, packageNamePath, "src", "LogstashTcpProperties.java", MAIN_JAVA);
+
+    templateToLogstash(project, packageNamePath, "test", "LogstashTcpConfigurationIT.java", TEST_JAVA);
+    templateToLogstash(project, packageNamePath, "test", "LogstashTcpConfigurationTest.java", TEST_JAVA);
+    templateToLogstash(project, packageNamePath, "test", "LogstashTcpLifeCycleTest.java", TEST_JAVA);
+    templateToLogstash(project, packageNamePath, "test", "LogstashTcpPropertiesTest.java", TEST_JAVA);
+  }
+
+  @Override
+  public void addProperties(Project project) {
+    properties().forEach((k, v) -> springBootPropertiesService.addProperties(project, k, v));
+  }
+
+  private Map<String, Object> properties() {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("application.logging.logstash.tcp.enabled", true);
+    result.put("application.logging.logstash.tcp.host", "localhost");
+    result.put("application.logging.logstash.tcp.port", 5000);
+    result.put("application.logging.logstash.tcp.ring-buffer-size", 8192);
+    result.put("application.logging.logstash.tcp.shutdown_grace_period", "PT1M");
+
+    return result;
+  }
+
+  private void templateToLogstash(Project project, String source, String type, String sourceFilename, String destination) {
+    projectRepository.template(project, getPath(SOURCE, type), sourceFilename, getPath(destination, source, DESTINATION));
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashService.java
@@ -1,0 +1,11 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface LogstashService {
+  void init(Project project);
+
+  void addDependencies(Project project);
+  void addJavaFiles(Project project);
+  void addProperties(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/config/LogstashBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/config/LogstashBeanConfiguration.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain.LogstashDomainService;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain.LogstashService;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+@Configuration
+public class LogstashBeanConfiguration {
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+  private final SpringBootPropertiesService springBootPropertiesService;
+
+  public LogstashBeanConfiguration(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootPropertiesService springBootPropertiesService
+  ) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Bean
+  public LogstashService logstashService() {
+    return new LogstashDomainService(buildToolService, projectRepository, springBootPropertiesService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/rest/LogstashResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/rest/LogstashResource.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.infrastructure.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.application.LogstashApplicationService;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/logging/logstash/tcp")
+@Tag(name = "Spring Boot - Logging")
+class LogstashResource {
+
+  private final LogstashApplicationService logstashApplicationService;
+
+  public LogstashResource(LogstashApplicationService logstashApplicationService) {
+    this.logstashApplicationService = logstashApplicationService;
+  }
+
+  @Operation(summary = "Add Logstash TCP appender")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Logstash TCP appender")
+  @PostMapping
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    logstashApplicationService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp;

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpConfiguration.java.mustache
@@ -1,0 +1,47 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configures the Logstash TCP appender
+ */
+@Configuration
+@ConditionalOnProperty(name = "application.logging.logstash.tcp.enabled", havingValue = "true")
+public class LogstashTcpConfiguration {
+
+  public static final String FIELD_APP_NAME = "app_name";
+  public static final String FIELD_APP_PORT = "app_port";
+
+  private final String appName;
+  private final String appPort;
+  private final LogstashTcpProperties properties;
+
+  public LogstashTcpConfiguration(
+    @Value("${spring.application.name}") String appName,
+    @Value("${server.port:#{null}}") String appPort,
+    LogstashTcpProperties properties
+  ) {
+    this.appName = appName;
+    this.appPort = appPort;
+    this.properties = properties;
+  }
+
+  @Bean
+  public LogstashTcpLifeCycle logstashTcpLifeCycle() {
+    return new LogstashTcpLifeCycle(customFields(appName, appPort), properties);
+  }
+
+  private Map<String, String> customFields(String appName, String appPort) {
+    Map<String, String> map = new HashMap<>();
+    map.put(FIELD_APP_NAME, appName);
+    if (appPort != null) {
+      map.put(FIELD_APP_PORT, appPort);
+    }
+    return map;
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpLifeCycle.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpLifeCycle.java.mustache
@@ -1,0 +1,98 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import ch.qos.logback.core.util.Duration;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.InetSocketAddress;
+import java.util.Map;
+import java.util.Optional;
+import net.logstash.logback.appender.LogstashTcpSocketAppender;
+import net.logstash.logback.encoder.LogstashEncoder;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.SmartLifecycle;
+
+public class LogstashTcpLifeCycle implements SmartLifecycle {
+
+  public static final String ASYNC_LOGSTASH_APPENDER_NAME = "ASYNC_LOGSTASH_TCP";
+
+  private static final Logger log = LoggerFactory.getLogger(LogstashTcpLifeCycle.class);
+
+  private final Map<String, String> fields;
+  private final LogstashTcpProperties properties;
+  private final ObjectMapper objectMapper;
+
+  private boolean running;
+
+  public LogstashTcpLifeCycle(Map<String, String> fields, LogstashTcpProperties properties) {
+    this(fields, properties, null);
+  }
+
+  public LogstashTcpLifeCycle(Map<String, String> fields, LogstashTcpProperties properties, ObjectMapper objectMapper) {
+    this.fields = fields;
+    this.properties = properties;
+    this.objectMapper = Optional.ofNullable(objectMapper).orElse(new ObjectMapper());
+  }
+
+  @Override
+  public void start() {
+    log.debug("Adding Logstash TCP appender to {}:{}", properties.getHost(), properties.getPort());
+
+    LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+    LogstashTcpSocketAppender logstashTcpSocketAppender = logstashTcpSocketAppender(context);
+    logstashTcpSocketAppender.start();
+    context.getLogger(Logger.ROOT_LOGGER_NAME).addAppender(logstashTcpSocketAppender);
+    running = true;
+  }
+
+  @Override
+  public void stop() {
+    // nothing to do, lifecycle is handled externally
+  }
+
+  @Override
+  public boolean isRunning() {
+    return running;
+  }
+
+  protected LogstashTcpSocketAppender logstashTcpSocketAppender(LoggerContext context) {
+    // Documentation is available at: https://github.com/logstash/logstash-logback-encoder
+    LogstashTcpSocketAppender logstashAppender = new LogstashTcpSocketAppender();
+    logstashAppender.addDestinations(new InetSocketAddress(properties.getHost(), properties.getPort()));
+    logstashAppender.setContext(context);
+    logstashAppender.setEncoder(logstashEncoder());
+    logstashAppender.setName(ASYNC_LOGSTASH_APPENDER_NAME);
+    if (properties.getRingBufferSize() != null) {
+      logstashAppender.setRingBufferSize(properties.getRingBufferSize());
+    }
+    if (properties.getShutdownGracePeriod() != null) {
+      logstashAppender.setShutdownGracePeriod(Duration.buildByMilliseconds(properties.getShutdownGracePeriod().toMillis()));
+    }
+    return logstashAppender;
+  }
+
+  protected LogstashEncoder logstashEncoder() {
+    final LogstashEncoder logstashEncoder = new LogstashEncoder();
+    logstashEncoder.setThrowableConverter(throwableConverter());
+    logstashEncoder.setCustomFields(serializedFields());
+    return logstashEncoder;
+  }
+
+  protected ThrowableHandlingConverter throwableConverter() {
+    final ShortenedThrowableConverter throwableConverter = new ShortenedThrowableConverter();
+    throwableConverter.setRootCauseFirst(true);
+    return throwableConverter;
+  }
+
+  protected String serializedFields() {
+    try {
+      return objectMapper.writeValueAsString(fields);
+    } catch (JsonProcessingException e) {
+      throw new IllegalStateException("Unable to serialize custom fields", e);
+    }
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpProperties.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/src/LogstashTcpProperties.java.mustache
@@ -1,0 +1,75 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "application.logging.logstash.tcp")
+public class LogstashTcpProperties {
+
+  /**
+   * Enable or disable Logstash
+   */
+  private boolean enabled;
+
+  /**
+   * Host name
+   */
+  private String host;
+
+  /**
+   * Port number
+   */
+  private int port;
+
+  /**
+   * Sets the size of the RingBuffer. Must be a positive power of 2.
+   */
+  private Integer ringBufferSize;
+
+  /**
+   * How long to wait for in-flight events during shutdown.
+   */
+  private Duration shutdownGracePeriod;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getHost() {
+    return host;
+  }
+
+  public void setHost(String host) {
+    this.host = host;
+  }
+
+  public int getPort() {
+    return port;
+  }
+
+  public void setPort(int port) {
+    this.port = port;
+  }
+
+  public Integer getRingBufferSize() {
+    return ringBufferSize;
+  }
+
+  public void setRingBufferSize(Integer ringBufferSize) {
+    this.ringBufferSize = ringBufferSize;
+  }
+
+  public Duration getShutdownGracePeriod() {
+    return shutdownGracePeriod;
+  }
+
+  public void setShutdownGracePeriod(Duration shutdownGracePeriod) {
+    this.shutdownGracePeriod = shutdownGracePeriod;
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
@@ -1,0 +1,91 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.encoder.Encoder;
+import {{packageName}}.IntegrationTest;
+import java.net.InetSocketAddress;
+import net.logstash.logback.appender.LogstashTcpSocketAppender;
+import net.logstash.logback.encoder.LogstashEncoder;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+@IntegrationTest
+class LogstashTcpConfigurationIT {
+
+  @Nested
+  @SpringBootTest(
+    properties = {
+      "spring.application.name=lite",
+      "server.port=8080",
+      "application.logging.logstash.tcp.enabled=true",
+      "application.logging.logstash.tcp.host=127.0.0.1",
+      "application.logging.logstash.tcp.port=50000",
+      "application.logging.logstash.tcp.ring_buffer_size=4096",
+      "application.logging.logstash.tcp.shutdown_grace_period=PT1S",
+    }
+  )
+  class Enabled {
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void shouldEnableLogstash() {
+      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+      Appender<ILoggingEvent> appender = context
+        .getLogger(Logger.ROOT_LOGGER_NAME)
+        .getAppender(LogstashTcpLifeCycle.ASYNC_LOGSTASH_APPENDER_NAME);
+
+      assertThat(appender).isInstanceOf(LogstashTcpSocketAppender.class);
+
+      LogstashTcpSocketAppender logstashTcpSocketAppender = (LogstashTcpSocketAppender) appender;
+
+      assertThat(logstashTcpSocketAppender.getDestinations()).contains(new InetSocketAddress("127.0.0.1", 50000));
+      assertThat(logstashTcpSocketAppender.getRingBufferSize()).isEqualTo(4096);
+      assertThat(logstashTcpSocketAppender.getShutdownGracePeriod().getMilliseconds()).isEqualTo(1000);
+
+      Encoder<ILoggingEvent> encoder = logstashTcpSocketAppender.getEncoder();
+
+      assertThat(encoder).isInstanceOf(LogstashEncoder.class);
+
+      LogstashEncoder logstashEncoder = (LogstashEncoder) encoder;
+
+      assertThat(logstashEncoder.getCustomFields()).contains("lite").contains("8080");
+
+      assertThat(applicationContext.getBean("logstashTcpLifeCycle")).isInstanceOf(LogstashTcpLifeCycle.class);
+    }
+  }
+
+  @Nested
+  @SpringBootTest(properties = { "application.logging.logstash.tcp.enabled=false" })
+  class Disabled {
+
+    @Autowired
+    ApplicationContext applicationContext;
+
+    @Test
+    void shouldDisableLogstash() {
+      LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+      Appender<ILoggingEvent> appender = context
+        .getLogger(Logger.ROOT_LOGGER_NAME)
+        .getAppender(LogstashTcpLifeCycle.ASYNC_LOGSTASH_APPENDER_NAME);
+
+      assertThat(appender).isNull();
+
+      assertThatThrownBy(() -> applicationContext.getBean("logstashTcpLifeCycle")).isInstanceOf(NoSuchBeanDefinitionException.class);
+    }
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationTest.java.mustache
@@ -1,0 +1,28 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import {{packageName}}.UnitTest;
+import java.io.IOException;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.ObjectContent;
+
+@UnitTest
+@JsonTest
+class LogstashTcpConfigurationTest {
+
+  @Autowired
+  private JacksonTester<Map<String, String>> json;
+
+  @Test
+  void shouldAddAppNameOnly() throws IOException {
+    LogstashTcpConfiguration c = new LogstashTcpConfiguration("jhipster-lite", null, new LogstashTcpProperties());
+
+    ObjectContent<Map<String, String>> parsed = json.parse(c.logstashTcpLifeCycle().serializedFields());
+    assertThat(parsed.getObject()).hasSize(1);
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpLifeCycleTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpLifeCycleTest.java.mustache
@@ -1,0 +1,119 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import static {{packageName}}.technical.infrastructure.secondary.logstash.LogstashTcpLifeCycle.ASYNC_LOGSTASH_APPENDER_NAME;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.pattern.ThrowableHandlingConverter;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import {{packageName}}.UnitTest;
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import net.logstash.logback.appender.LogstashTcpSocketAppender;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.json.JsonTest;
+import org.springframework.boot.test.json.JacksonTester;
+import org.springframework.boot.test.json.ObjectContent;
+
+@UnitTest
+@JsonTest
+class LogstashTcpLifeCycleTest {
+
+  @Autowired
+  private JacksonTester<Map<String, String>> json;
+
+  private final LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
+
+  @AfterEach
+  void detachAppenders() {
+    context.getLogger(Logger.ROOT_LOGGER_NAME).detachAndStopAllAppenders();
+  }
+
+  @Test
+  void shouldStartWithMinimumConfig() {
+    LogstashTcpProperties properties = new LogstashTcpProperties();
+    properties.setHost("localhost");
+    properties.setPort(5000);
+
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(null, properties);
+
+    assertThat(logstashTcpLifeCycle.isRunning()).isFalse();
+    assertThat(context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(ASYNC_LOGSTASH_APPENDER_NAME)).isNull();
+
+    logstashTcpLifeCycle.start();
+
+    assertThat(logstashTcpLifeCycle.isRunning()).isTrue();
+    assertThat(context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(ASYNC_LOGSTASH_APPENDER_NAME)).isNotNull();
+    assertThat(context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(ASYNC_LOGSTASH_APPENDER_NAME).isStarted()).isTrue();
+  }
+
+  @Test
+  void shouldSetProperties() {
+    LogstashTcpProperties properties = new LogstashTcpProperties();
+    properties.setHost("127.0.0.1");
+    properties.setPort(50000);
+    properties.setRingBufferSize(4096);
+    properties.setShutdownGracePeriod(Duration.ofMillis(100));
+
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(null, properties, new ObjectMapper());
+
+    LogstashTcpSocketAppender logstashTcpSocketAppender = logstashTcpLifeCycle.logstashTcpSocketAppender(context);
+
+    assertThat(logstashTcpSocketAppender.getDestinations()).contains(new InetSocketAddress("127.0.0.1", 50000));
+    assertThat(logstashTcpSocketAppender.getContext()).isEqualTo(context);
+    assertThat(logstashTcpSocketAppender.getRingBufferSize()).isEqualTo(4096);
+    assertThat(logstashTcpSocketAppender.getShutdownGracePeriod().getMilliseconds()).isEqualTo(100);
+  }
+
+  @Test
+  void shouldShortenedThrowableConverter() {
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(null, new LogstashTcpProperties(), new ObjectMapper());
+    ThrowableHandlingConverter throwableConverter = logstashTcpLifeCycle.throwableConverter();
+    assertThat(throwableConverter).isInstanceOf(ShortenedThrowableConverter.class);
+  }
+
+  @Test
+  void shouldNotStop() {
+    LogstashTcpProperties properties = new LogstashTcpProperties();
+    properties.setHost("localhost");
+    properties.setPort(5000);
+
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(null, properties, new ObjectMapper());
+
+    logstashTcpLifeCycle.start();
+
+    logstashTcpLifeCycle.stop();
+
+    assertThat(logstashTcpLifeCycle.isRunning()).isTrue();
+    assertThat(context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(ASYNC_LOGSTASH_APPENDER_NAME)).isNotNull();
+    assertThat(context.getLogger(Logger.ROOT_LOGGER_NAME).getAppender(ASYNC_LOGSTASH_APPENDER_NAME).isStarted()).isTrue();
+  }
+
+  @Test
+  void shouldSerializeFields() throws IOException {
+    Map<String, String> fields = Map.of("app_name", "jhipster-lite", "app_port", "8080");
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(fields, new LogstashTcpProperties());
+
+    ObjectContent<Map<String, String>> parsed = json.parse(logstashTcpLifeCycle.serializedFields());
+    assertThat(parsed).hasFieldOrPropertyWithValue("app_name", "jhipster-lite").hasFieldOrPropertyWithValue("app_port", "8080");
+  }
+
+  @Test
+  void shouldThrowIllegalStateException() {
+    Map<String, String> map = new HashMap<>();
+    map.put(null, "test");
+
+    LogstashTcpLifeCycle logstashTcpLifeCycle = new LogstashTcpLifeCycle(map, new LogstashTcpProperties(), new ObjectMapper());
+
+    assertThatThrownBy(logstashTcpLifeCycle::serializedFields).isInstanceOf(IllegalStateException.class);
+  }
+}

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpPropertiesTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpPropertiesTest.java.mustache
@@ -1,0 +1,15 @@
+package {{packageName}}.technical.infrastructure.secondary.logstash;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import {{packageName}}.UnitTest;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class LogstashTcpPropertiesTest {
+
+  @Test
+  void shouldDisableByDefault() {
+    assertThat(new LogstashTcpProperties().isEnabled()).isFalse();
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashApplicationServiceIT.java
@@ -1,0 +1,89 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.logstash.tcp.application.LogstashAssert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class LogstashApplicationServiceIT {
+
+  @Autowired
+  LogstashApplicationService logstashApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "foo");
+
+    initApplicationService.init(project);
+
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    logstashApplicationService.init(project);
+
+    assertDependencies(project);
+
+    assertJavaFiles(project);
+
+    assertProperties(project);
+  }
+
+  @Test
+  void shouldAddDependencies() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    logstashApplicationService.addDependencies(project);
+
+    assertDependencies(project);
+  }
+
+  @Test
+  void shouldAddJavaFiles() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    logstashApplicationService.addJavaFiles(project);
+
+    assertJavaFiles(project);
+  }
+
+  @Test
+  void shouldAddProperties() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    logstashApplicationService.addProperties(project);
+
+    assertProperties(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/application/LogstashAssert.java
@@ -1,0 +1,75 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
+
+import java.util.List;
+import tech.jhipster.lite.generator.project.domain.DefaultConfig;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain.Logstash;
+
+public class LogstashAssert {
+
+  public static void assertDependencies(Project project) {
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of("<logstash-logback-encoder.version>" + Logstash.getLogstashLogbackEncoderVersion() + "</logstash-logback-encoder.version>")
+    );
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>net.logstash.logback</groupId>",
+        "<artifactId>logstash-logback-encoder</artifactId>",
+        "<version>${logstash-logback-encoder.version}</version>",
+        "</dependency>"
+      )
+    );
+  }
+
+  public static void assertJavaFiles(Project project) {
+    String basePackage = project.getPackageName().orElse("com.mycompany.myapp");
+    String logstashPackage = basePackage + ".technical.infrastructure.secondary.logstash";
+
+    String basePath = project.getPackageNamePath().orElse(getPath(DefaultConfig.PACKAGE_PATH));
+    String logstashPath = getPath(MAIN_JAVA, basePath, "technical/infrastructure/secondary/logstash");
+
+    assertFileExist(project, getPath(logstashPath, "LogstashTcpConfiguration.java"));
+    assertFileExist(project, getPath(logstashPath, "LogstashTcpLifeCycle.java"));
+    assertFileExist(project, getPath(logstashPath, "LogstashTcpProperties.java"));
+
+    assertFileContent(project, getPath(logstashPath, "LogstashTcpConfiguration.java"), "package " + logstashPackage);
+    assertFileContent(project, getPath(logstashPath, "LogstashTcpLifeCycle.java"), "package " + logstashPackage);
+    assertFileContent(project, getPath(logstashPath, "LogstashTcpProperties.java"), "package " + logstashPackage);
+
+    String logstashTestPath = getPath(TEST_JAVA, basePath, "technical/infrastructure/secondary/logstash");
+
+    assertFileExist(project, getPath(logstashTestPath, "LogstashTcpConfigurationIT.java"));
+    assertFileExist(project, getPath(logstashTestPath, "LogstashTcpConfigurationTest.java"));
+    assertFileExist(project, getPath(logstashTestPath, "LogstashTcpLifeCycleTest.java"));
+    assertFileExist(project, getPath(logstashTestPath, "LogstashTcpPropertiesTest.java"));
+
+    assertFileContent(project, getPath(logstashTestPath, "LogstashTcpConfigurationIT.java"), "package " + logstashPackage);
+    assertFileContent(project, getPath(logstashTestPath, "LogstashTcpConfigurationTest.java"), "package " + logstashPackage);
+    assertFileContent(project, getPath(logstashTestPath, "LogstashTcpLifeCycleTest.java"), "package " + logstashPackage);
+    assertFileContent(project, getPath(logstashTestPath, "LogstashTcpPropertiesTest.java"), "package " + logstashPackage);
+  }
+
+  public static void assertProperties(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config/application.properties"),
+      List.of(
+        "application.logging.logstash.tcp.enabled=true",
+        "application.logging.logstash.tcp.host=localhost",
+        "application.logging.logstash.tcp.port=5000",
+        "application.logging.logstash.tcp.ring-buffer-size=8192",
+        "application.logging.logstash.tcp.shutdown_grace_period=PT1M"
+      )
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/domain/LogstashTest.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+@UnitTest
+class LogstashTest {
+
+  @Test
+  void shouldLogstashLogbackEncoder() {
+    Dependency dependency = Logstash.logstashLogbackEncoderDependency();
+
+    assertThat(dependency.getGroupId()).isEqualTo("net.logstash.logback");
+    assertThat(dependency.getArtifactId()).isEqualTo("logstash-logback-encoder");
+    assertThat(dependency.getVersion()).hasValue("\\${logstash-logback-encoder.version}");
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/config/LogstashBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/config/LogstashBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.logstash.tcp.domain.LogstashDomainService;
+
+@IntegrationTest
+class LogstashBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("logstashService")).isNotNull().isInstanceOf(LogstashDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/primary/rest/LogstashResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logstash/tcp/infrastructure/primary/rest/LogstashResourceIT.java
@@ -1,0 +1,62 @@
+package tech.jhipster.lite.generator.server.springboot.logstash.tcp.infrastructure.primary.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.generator.server.springboot.logstash.tcp.application.LogstashAssert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class LogstashResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldInit() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/logging/logstash/tcp")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertDependencies(project);
+    assertJavaFiles(project);
+    assertProperties(project);
+  }
+}

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -33,6 +33,7 @@ if [[ $filename == 'tomcat-postgresql' ]]; then
   callApi "/api/servers/spring-boot/databases/postgresql"
   callApi "/api/servers/spring-boot/databases/migration/liquibase"
   callApi "/api/servers/spring-boot/aop/logging"
+  callApi "/api/servers/spring-boot/logging/logstash/tcp"
   callApi "/api/servers/spring-boot/async"
   callApi "/api/servers/sonar"
 
@@ -50,6 +51,7 @@ elif [[ $filename == 'undertow-mysql' ]]; then
   callApi "/api/servers/spring-boot/databases/mysql"
   callApi "/api/servers/spring-boot/databases/migration/liquibase"
   callApi "/api/servers/spring-boot/aop/logging"
+  callApi "/api/servers/spring-boot/logging/logstash/tcp"
   callApi "/api/servers/spring-boot/async"
   callApi "/api/servers/sonar"
 


### PR DESCRIPTION
Fix #276 

- [x] Logstash basic TCP configuration
- [x] Replace deprecated `queueSize` by `ringBufferSize` property.
- [x] Add the `shutdownGracePeriod` property and set it to 1 second in integration test (default of 1 minute made the test wait before quitting, as there is no logstash server).
- [x] If there is no `server.port`, do not add the custom `app_port` field
- [ ] LoggerContextListener: allowed hot reloading of logstash configuration.
In a classic (non-web) application it produces a ConcurrentModificationException on exit (LOGBACK-1299, https://github.com/spring-projects/spring-boot/issues/17439) unless DelayingShutdownHook is removed.
It only makes sense if properties are reloadable, and not sure it's useful.
- [x] Refactor for better testability and extensibility

Naming
- [x] Make it explicit that this is a TCP only configuration
      eg. rename route to include "tcp"
- [x] Rename config prefix from `logstash` to `application.logging.logstash.tcp`?

Later refactoring in another PR:
- [ ] Move logging (`SpringBootLogging*`) to logging.logger (shared kernel)
- [ ] Move logstash to logging.logstash
- [ ] Move aop.logging to logging.aop