### PR TITLE
add Spring Boot Ehcache (XML configuration)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,6 +63,7 @@ jobs:
       matrix:
         app:
           - tomcat-postgresql-ehcachejava
+          - tomcat-postgresql-ehcachexml
           - undertow-mysql-simplecache
     steps:
       - name: 'Setup: checkout project'

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
@@ -13,12 +13,20 @@ public class EhcacheApplicationService {
     this.ehcacheService = ehcacheService;
   }
 
+  public void initXmlConfiguration(Project project) {
+    ehcacheService.initXmlConfiguration(project);
+  }
+
   public void initJavaConfiguration(Project project) {
     ehcacheService.initJavaConfiguration(project);
   }
 
   public void addDependencies(Project project) {
     ehcacheService.addDependencies(project);
+  }
+
+  public void addXmlDependencies(Project project) {
+    ehcacheService.addXmlDependencies(project);
   }
 
   public void addEnableCaching(Project project) {
@@ -31,5 +39,13 @@ public class EhcacheApplicationService {
 
   public void addJavaProperties(Project project) {
     ehcacheService.addJavaProperties(project);
+  }
+
+  public void addEhcacheXml(Project project) {
+    ehcacheService.addEhcacheXml(project);
+  }
+
+  public void addXmlProperty(Project project) {
+    ehcacheService.addXmlProperty(project);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/Ehcache.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/Ehcache.java
@@ -6,6 +6,14 @@ public class Ehcache {
 
   private Ehcache() {}
 
+  public static Dependency jakartaXmlBindApi() {
+    return Dependency.builder().groupId("jakarta.xml.bind").artifactId("jakarta.xml.bind-api").build();
+  }
+
+  public static Dependency glassfishJaxbRuntime() {
+    return Dependency.builder().groupId("org.glassfish.jaxb").artifactId("jaxb-runtime").scope("runtime").build();
+  }
+
   public static Dependency ehcacheDependency() {
     return Dependency.builder().groupId("org.ehcache").artifactId("ehcache").build();
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
@@ -1,8 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain;
 
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
 
@@ -43,14 +42,39 @@ public class EhcacheDomainService implements EhcacheService {
   }
 
   @Override
+  public void initXmlConfiguration(Project project) {
+    addDependencies(project);
+    addXmlDependencies(project);
+    addEnableCaching(project);
+    addEhcacheXml(project);
+    addXmlProperty(project);
+  }
+
+  @Override
   public void addDependencies(Project project) {
     springBootJCacheService.addDependencies(project);
     buildToolService.addDependency(project, Ehcache.ehcacheDependency());
   }
 
   @Override
+  public void addXmlDependencies(Project project) {
+    buildToolService.addDependency(project, Ehcache.jakartaXmlBindApi());
+    buildToolService.addDependency(project, Ehcache.glassfishJaxbRuntime());
+  }
+
+  @Override
   public void addEnableCaching(Project project) {
     springBootJCacheService.addEnableCaching(project);
+  }
+
+  @Override
+  public void addEhcacheXml(Project project) {
+    projectRepository.add(project, getPath(SOURCE, "resources"), "ehcache.xml", getPath(MAIN_RESOURCES, "config/ehcache"));
+  }
+
+  @Override
+  public void addXmlProperty(Project project) {
+    springBootPropertiesService.addProperties(project, "spring.cache.jcache.config", "classpath:config/ehcache/ehcache.xml");
   }
 
   @Override

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
@@ -4,12 +4,12 @@ import tech.jhipster.lite.generator.project.domain.Project;
 
 public interface EhcacheService {
   void initJavaConfiguration(Project project);
-
+  void initXmlConfiguration(Project project);
   void addDependencies(Project project);
-
+  void addXmlDependencies(Project project);
   void addEnableCaching(Project project);
-
   void addJavaConfig(Project project);
-
   void addJavaProperties(Project project);
+  void addEhcacheXml(Project project);
+  void addXmlProperty(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
@@ -22,11 +22,19 @@ class EhcacheResource {
     this.ehcacheApplicationService = ehcacheApplicationService;
   }
 
-  @Operation(summary = "Add Ehcache")
-  @ApiResponse(responseCode = "500", description = "An error occurred while adding Ehcache")
+  @Operation(summary = "Add Ehcache with Java configuration")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Ehcache with Java configuration")
   @PostMapping("java-configuration")
   public void initJavaConfiguration(@RequestBody ProjectDTO projectDTO) {
     Project project = ProjectDTO.toProject(projectDTO);
     ehcacheApplicationService.initJavaConfiguration(project);
+  }
+
+  @Operation(summary = "Add Ehcache with XML configuration")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Ehcache with XML configuration")
+  @PostMapping("xml-configuration")
+  public void initXmlConfiguration(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    ehcacheApplicationService.initXmlConfiguration(project);
   }
 }

--- a/src/main/resources/generator/server/springboot/cache/ehcache/resources/ehcache.xml
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/resources/ehcache.xml
@@ -1,0 +1,25 @@
+<config
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://www.ehcache.org/v3"
+  xmlns:jsr107="http://www.ehcache.org/v3/jsr107"
+  xsi:schemaLocation="
+            http://www.ehcache.org/v3 http://www.ehcache.org/schema/ehcache-core-3.0.xsd
+            http://www.ehcache.org/v3/jsr107 http://www.ehcache.org/schema/ehcache-107-ext-3.0.xsd"
+>
+  <service>
+    <jsr107:defaults default-template="tinyCache">
+      <!-- jhipster-needle-ehcache-add-entity -->
+    </jsr107:defaults>
+  </service>
+
+  <cache-template name="tinyCache">
+    <heap unit="entries">20</heap>
+  </cache-template>
+
+  <cache-template name="entityCache">
+    <expiry>
+      <ttl unit="hours">1</ttl>
+    </expiry>
+    <heap unit="entries">100</heap>
+  </cache-template>
+</config>

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
@@ -29,7 +29,7 @@ class EhcacheApplicationServiceIT {
   SpringBootApplicationService springBootApplicationService;
 
   @Test
-  void shouldInit() {
+  void shouldInitJavaConfiguration() {
     Project project = tmpProject();
     project.addConfig(BASE_NAME, "foo");
 
@@ -44,6 +44,21 @@ class EhcacheApplicationServiceIT {
   }
 
   @Test
+  void shouldInitXmlConfiguration() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "foo");
+
+    initApplicationService.init(project);
+
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.initXmlConfiguration(project);
+
+    assertInitXmlConfiguration(project);
+  }
+
+  @Test
   void shouldAddDependencies() {
     Project project = tmpProject();
     project.addConfig(BASE_NAME, "bar");
@@ -54,6 +69,19 @@ class EhcacheApplicationServiceIT {
     ehcacheApplicationService.addDependencies(project);
 
     assertDependencies(project);
+  }
+
+  @Test
+  void shouldAddXmlDependencies() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    ehcacheApplicationService.addXmlDependencies(project);
+
+    assertXmlDependencies(project);
   }
 
   @Test
@@ -95,5 +123,30 @@ class EhcacheApplicationServiceIT {
     ehcacheApplicationService.addJavaProperties(project);
 
     assertProperties(project);
+  }
+
+  @Test
+  void shouldAddEhcacheXml() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+
+    ehcacheApplicationService.addEhcacheXml(project);
+
+    assertEhcacheXml(project);
+  }
+
+  @Test
+  void shouldAddXmlProperty() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.addXmlProperty(project);
+
+    assertXmlProperty(project);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
@@ -20,6 +20,14 @@ public class EhcacheAssert {
     assertProperties(project);
   }
 
+  public static void assertInitXmlConfiguration(Project project) {
+    assertDependencies(project);
+    assertXmlDependencies(project);
+    assertEnableCaching(project);
+    assertEhcacheXml(project);
+    assertXmlProperty(project);
+  }
+
   public static void assertDependencies(Project project) {
     SpringBootJCacheAssert.assertDependencies(project);
 
@@ -27,6 +35,25 @@ public class EhcacheAssert {
       project,
       "pom.xml",
       List.of("<dependency>", "<groupId>org.ehcache</groupId>", "<artifactId>ehcache</artifactId>", "</dependency>")
+    );
+  }
+
+  public static void assertXmlDependencies(Project project) {
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of("<dependency>", "<groupId>jakarta.xml.bind</groupId>", "<artifactId>jakarta.xml.bind-api</artifactId>", "</dependency>")
+    );
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.glassfish.jaxb</groupId>",
+        "<artifactId>jaxb-runtime</artifactId>",
+        "<scope>runtime</scope>",
+        "</dependency>"
+      )
     );
   }
 
@@ -63,6 +90,18 @@ public class EhcacheAssert {
       project,
       getPath(MAIN_RESOURCES, "config/application.properties"),
       List.of("application.cache.ehcache.max-entries=100", "application.cache.ehcache.time-to-live-seconds=3600")
+    );
+  }
+
+  public static void assertEhcacheXml(Project project) {
+    assertFileExist(project, getPath(MAIN_RESOURCES, "config/ehcache/ehcache.xml"));
+  }
+
+  public static void assertXmlProperty(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config/application.properties"),
+      List.of("spring.cache.jcache.config=classpath:config/ehcache/ehcache.xml")
     );
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastruct
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.assertInitJavaConfiguration;
+import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.assertInitXmlConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -36,7 +37,7 @@ class EhcacheResourceIT {
   MockMvc mockMvc;
 
   @Test
-  void shouldAddEhcache() throws Exception {
+  void shouldAddEhcacheJava() throws Exception {
     ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
     if (projectDTO == null) {
       throw new GeneratorException("Error when reading file");
@@ -56,5 +57,28 @@ class EhcacheResourceIT {
       .andExpect(status().isOk());
 
     assertInitJavaConfiguration(project);
+  }
+
+  @Test
+  void shouldAddEhcacheXml() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/cache/ehcache/xml-configuration")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertInitXmlConfiguration(project);
   }
 }

--- a/tests-ci/config/tomcat-postgresql-ehcachexml.json
+++ b/tests-ci/config/tomcat-postgresql-ehcachexml.json
@@ -1,0 +1,9 @@
+{
+  "folder": "/tmp/jhlite/tomcat-postgresql-ehcachexml",
+  "generator-jhipster": {
+    "projectName": "Beer Project",
+    "baseName": "beer",
+    "prettierDefaultIndent": 2,
+    "packageName": "tech.jhipster.beer"
+  }
+}

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -38,6 +38,25 @@ if [[ $filename == 'tomcat-postgresql-ehcachejava' ]]; then
   callApi "/api/servers/spring-boot/cache/ehcache/java-configuration"
   callApi "/api/servers/sonar"
 
+elif [[ $filename == 'tomcat-postgresql-ehcachexml' ]]; then
+  callApi "/api/projects/init"
+  callApi "/api/build-tools/maven"
+  callApi "/api/servers/java/base"
+  callApi "/api/servers/java/jacoco-minimum-coverage"
+  callApi "/api/servers/spring-boot"
+  callApi "/api/servers/spring-boot/devtools"
+  callApi "/api/servers/spring-boot/banner/jhipster-v7"
+  callApi "/api/servers/spring-boot/mvc/web/tomcat"
+  callApi "/api/servers/spring-boot/mvc/security/jwt"
+  callApi "/api/servers/spring-boot/mvc/security/jwt/basic-auth"
+  callApi "/api/servers/spring-boot/databases/postgresql"
+  callApi "/api/servers/spring-boot/databases/migration/liquibase"
+  callApi "/api/servers/spring-boot/aop/logging"
+  callApi "/api/servers/spring-boot/logging/logstash/tcp"
+  callApi "/api/servers/spring-boot/async"
+  callApi "/api/servers/spring-boot/cache/ehcache/xml-configuration"
+  callApi "/api/servers/sonar"
+
 elif [[ $filename == 'undertow-mysql-simplecache' ]]; then
   callApi "/api/projects/init"
   callApi "/api/build-tools/maven"


### PR DESCRIPTION
#121 (alternative to #432 )

Here is a version with JSR-107 Ehcache XML configuration.

[Getting JSR-107 caches configured through Ehcache XML](https://www.ehcache.org/documentation/3.0/107.html#getting-jsr-107-caches-configured-through-ehcache-xml)


[Spring Boot Caching with JCache](https://docs.spring.io/spring-boot/docs/current/reference/html/io.html#io.caching.provider.jcache)

There are many pros with XML configuration on both the generator and generated sides, but there are probably cons.

Generator:
- [x] Ehcache
- [x] Rename to xml-configuration

Generated:
- [x] ehcache.xml with template for entities
- [x] jhipster-needle-ehcache-add-entity
note the explicit "entity" needle because it uses a template to have a shared ttl and max-entries
- [ ] ~~integration test of the configuration? see [Supplement JSR-107’s configurations](https://www.ehcache.org/documentation/3.0/107.html#supplement-jsr-107-configurations)~~

---

This is based on a common branch: https://github.com/pblanchardie/jhipster-lite/tree/add-spring-boot-jcache

- [x] Spring Boot Cache Commons (spring-boot-starter-cache + CacheConfiguration)
- [x] Spring Boot JCache Commons (jcache)