### PR TITLE
add Spring Boot Ehcache (Java Configuration)

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         app:
-          - tomcat-postgresql
+          - tomcat-postgresql-ehcache
           - undertow-mysql-simplecache
     steps:
       - name: 'Setup: checkout project'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -62,7 +62,7 @@ jobs:
     strategy:
       matrix:
         app:
-          - tomcat-postgresql-ehcache
+          - tomcat-postgresql-ehcachejava
           - undertow-mysql-simplecache
     steps:
       - name: 'Setup: checkout project'

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
@@ -13,19 +13,23 @@ public class EhcacheApplicationService {
     this.ehcacheService = ehcacheService;
   }
 
-  public void init(Project project) {
-    ehcacheService.init(project);
+  public void initJavaConfiguration(Project project) {
+    ehcacheService.initJavaConfiguration(project);
   }
 
   public void addDependencies(Project project) {
     ehcacheService.addDependencies(project);
   }
 
-  public void addJavaFiles(Project project) {
-    ehcacheService.addJavaFiles(project);
+  public void addEnableCaching(Project project) {
+    ehcacheService.addEnableCaching(project);
   }
 
-  public void addProperties(Project project) {
-    ehcacheService.addProperties(project);
+  public void addJavaConfig(Project project) {
+    ehcacheService.addJavaConfig(project);
+  }
+
+  public void addJavaProperties(Project project) {
+    ehcacheService.addJavaProperties(project);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationService.java
@@ -1,0 +1,31 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain.EhcacheService;
+
+@Service
+public class EhcacheApplicationService {
+
+  private final EhcacheService ehcacheService;
+
+  public EhcacheApplicationService(EhcacheService ehcacheService) {
+    this.ehcacheService = ehcacheService;
+  }
+
+  public void init(Project project) {
+    ehcacheService.init(project);
+  }
+
+  public void addDependencies(Project project) {
+    ehcacheService.addDependencies(project);
+  }
+
+  public void addJavaFiles(Project project) {
+    ehcacheService.addJavaFiles(project);
+  }
+
+  public void addProperties(Project project) {
+    ehcacheService.addProperties(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/Ehcache.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/Ehcache.java
@@ -1,0 +1,12 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class Ehcache {
+
+  private Ehcache() {}
+
+  public static Dependency ehcacheDependency() {
+    return Dependency.builder().groupId("org.ehcache").artifactId("ehcache").build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
@@ -35,10 +35,11 @@ public class EhcacheDomainService implements EhcacheService {
   }
 
   @Override
-  public void init(Project project) {
+  public void initJavaConfiguration(Project project) {
     addDependencies(project);
-    addJavaFiles(project);
-    addProperties(project);
+    addEnableCaching(project);
+    addJavaConfig(project);
+    addJavaProperties(project);
   }
 
   @Override
@@ -48,8 +49,12 @@ public class EhcacheDomainService implements EhcacheService {
   }
 
   @Override
-  public void addJavaFiles(Project project) {
+  public void addEnableCaching(Project project) {
     springBootJCacheService.addEnableCaching(project);
+  }
+
+  @Override
+  public void addJavaConfig(Project project) {
     springBootJCacheService.addJavaConfig(project);
 
     project.addDefaultConfig(PACKAGE_NAME);
@@ -64,7 +69,7 @@ public class EhcacheDomainService implements EhcacheService {
   }
 
   @Override
-  public void addProperties(Project project) {
+  public void addJavaProperties(Project project) {
     springBootPropertiesService.addProperties(project, "application.cache.ehcache.max-entries", 100);
     springBootPropertiesService.addProperties(project, "application.cache.ehcache.time-to-live-seconds", 3600);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheDomainService.java
@@ -1,0 +1,75 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain;
+
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheService;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+public class EhcacheDomainService implements EhcacheService {
+
+  public static final String SOURCE = "server/springboot/cache/ehcache";
+  public static final String DESTINATION = "technical/infrastructure/secondary/cache/ehcache";
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+  private final SpringBootJCacheService springBootJCacheService;
+  private final SpringBootPropertiesService springBootPropertiesService;
+
+  public EhcacheDomainService(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootJCacheService springBootJCacheService,
+    SpringBootPropertiesService springBootPropertiesService
+  ) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+    this.springBootJCacheService = springBootJCacheService;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Override
+  public void init(Project project) {
+    addDependencies(project);
+    addJavaFiles(project);
+    addProperties(project);
+  }
+
+  @Override
+  public void addDependencies(Project project) {
+    springBootJCacheService.addDependencies(project);
+    buildToolService.addDependency(project, Ehcache.ehcacheDependency());
+  }
+
+  @Override
+  public void addJavaFiles(Project project) {
+    springBootJCacheService.addEnableCaching(project);
+    springBootJCacheService.addJavaConfig(project);
+
+    project.addDefaultConfig(PACKAGE_NAME);
+    project.addDefaultConfig(BASE_NAME);
+    String packageNamePath = project.getPackageNamePath().orElse(getPath("com/mycompany/myapp"));
+
+    templateToEhcache(project, packageNamePath, "src", "EhcacheConfiguration.java", MAIN_JAVA);
+    templateToEhcache(project, packageNamePath, "src", "EhcacheConfigurer.java", MAIN_JAVA);
+    templateToEhcache(project, packageNamePath, "src", "EhcacheProperties.java", MAIN_JAVA);
+
+    templateToEhcache(project, packageNamePath, "test", "EhcacheConfigurationIT.java", TEST_JAVA);
+  }
+
+  @Override
+  public void addProperties(Project project) {
+    springBootPropertiesService.addProperties(project, "application.cache.ehcache.max-entries", 100);
+    springBootPropertiesService.addProperties(project, "application.cache.ehcache.time-to-live-seconds", 3600);
+  }
+
+  private void templateToEhcache(Project project, String source, String type, String sourceFilename, String destination) {
+    projectRepository.template(project, getPath(SOURCE, type), sourceFilename, getPath(destination, source, DESTINATION));
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
@@ -1,0 +1,13 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface EhcacheService {
+  void init(Project project);
+
+  void addDependencies(Project project);
+
+  void addJavaFiles(Project project);
+
+  void addProperties(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/domain/EhcacheService.java
@@ -3,11 +3,13 @@ package tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain;
 import tech.jhipster.lite.generator.project.domain.Project;
 
 public interface EhcacheService {
-  void init(Project project);
+  void initJavaConfiguration(Project project);
 
   void addDependencies(Project project);
 
-  void addJavaFiles(Project project);
+  void addEnableCaching(Project project);
 
-  void addProperties(Project project);
+  void addJavaConfig(Project project);
+
+  void addJavaProperties(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/config/EhcacheBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/config/EhcacheBeanConfiguration.java
@@ -1,0 +1,36 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain.EhcacheDomainService;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain.EhcacheService;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheService;
+import tech.jhipster.lite.generator.server.springboot.properties.domain.SpringBootPropertiesService;
+
+@Configuration
+public class EhcacheBeanConfiguration {
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+  private final SpringBootJCacheService springBootJCacheService;
+  private final SpringBootPropertiesService springBootPropertiesService;
+
+  public EhcacheBeanConfiguration(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootJCacheService springBootJCacheService,
+    SpringBootPropertiesService springBootPropertiesService
+  ) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+    this.springBootJCacheService = springBootJCacheService;
+    this.springBootPropertiesService = springBootPropertiesService;
+  }
+
+  @Bean
+  public EhcacheService ehcacheService() {
+    return new EhcacheDomainService(buildToolService, projectRepository, springBootJCacheService, springBootPropertiesService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.primary.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheApplicationService;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/cache/ehcache")
+@Tag(name = "Spring Boot - Cache")
+class EhcacheResource {
+
+  private final EhcacheApplicationService ehcacheApplicationService;
+
+  public EhcacheResource(EhcacheApplicationService ehcacheApplicationService) {
+    this.ehcacheApplicationService = ehcacheApplicationService;
+  }
+
+  @Operation(summary = "Add Ehcache")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Ehcache")
+  @PostMapping
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    ehcacheApplicationService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResource.java
@@ -24,9 +24,9 @@ class EhcacheResource {
 
   @Operation(summary = "Add Ehcache")
   @ApiResponse(responseCode = "500", description = "An error occurred while adding Ehcache")
-  @PostMapping
-  public void init(@RequestBody ProjectDTO projectDTO) {
+  @PostMapping("java-configuration")
+  public void initJavaConfiguration(@RequestBody ProjectDTO projectDTO) {
     Project project = ProjectDTO.toProject(projectDTO);
-    ehcacheApplicationService.init(project);
+    ehcacheApplicationService.initJavaConfiguration(project);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationService.java
@@ -20,4 +20,8 @@ public class SpringBootJCacheApplicationService {
   public void addEnableCaching(Project project) {
     springBootJCacheService.addEnableCaching(project);
   }
+
+  public void addJavaConfig(Project project) {
+    springBootJCacheService.addJavaConfig(project);
+  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationService.java
@@ -1,0 +1,23 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheService;
+
+@Service
+public class SpringBootJCacheApplicationService {
+
+  private final SpringBootJCacheService springBootJCacheService;
+
+  public SpringBootJCacheApplicationService(SpringBootJCacheService springBootJCacheService) {
+    this.springBootJCacheService = springBootJCacheService;
+  }
+
+  public void addDependencies(Project project) {
+    springBootJCacheService.addDependencies(project);
+  }
+
+  public void addEnableCaching(Project project) {
+    springBootJCacheService.addEnableCaching(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCache.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCache.java
@@ -1,0 +1,12 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class SpringBootJCache {
+
+  private SpringBootJCache() {}
+
+  public static Dependency cacheApiDependency() {
+    return Dependency.builder().groupId("javax.cache").artifactId("cache-api").build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheDomainService.java
@@ -1,0 +1,29 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+
+public class SpringBootJCacheDomainService implements SpringBootJCacheService {
+
+  public static final String SOURCE = "server/springboot/cache/jcache";
+
+  private final BuildToolService buildToolService;
+  private final SpringBootCacheService springBootCacheService;
+
+  public SpringBootJCacheDomainService(BuildToolService buildToolService, SpringBootCacheService springBootCacheService) {
+    this.buildToolService = buildToolService;
+    this.springBootCacheService = springBootCacheService;
+  }
+
+  @Override
+  public void addDependencies(Project project) {
+    springBootCacheService.addDependencies(project);
+    buildToolService.addDependency(project, SpringBootJCache.cacheApiDependency());
+  }
+
+  @Override
+  public void addEnableCaching(Project project) {
+    springBootCacheService.addEnableCaching(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheDomainService.java
@@ -1,18 +1,32 @@
 package tech.jhipster.lite.generator.server.springboot.cache.jcache.domain;
 
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
 import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
 
 public class SpringBootJCacheDomainService implements SpringBootJCacheService {
 
   public static final String SOURCE = "server/springboot/cache/jcache";
+  public static final String DESTINATION = "technical/infrastructure/secondary/cache";
 
   private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
   private final SpringBootCacheService springBootCacheService;
 
-  public SpringBootJCacheDomainService(BuildToolService buildToolService, SpringBootCacheService springBootCacheService) {
+  public SpringBootJCacheDomainService(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootCacheService springBootCacheService
+  ) {
     this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
     this.springBootCacheService = springBootCacheService;
   }
 
@@ -25,5 +39,22 @@ public class SpringBootJCacheDomainService implements SpringBootJCacheService {
   @Override
   public void addEnableCaching(Project project) {
     springBootCacheService.addEnableCaching(project);
+  }
+
+  @Override
+  public void addJavaConfig(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    project.addDefaultConfig(BASE_NAME);
+    String packageNamePath = project.getPackageNamePath().orElse(getPath("com/mycompany/myapp"));
+
+    templateToCache(project, packageNamePath, "src", "JCacheConfiguration.java", MAIN_JAVA);
+    templateToCache(project, packageNamePath, "src", "JCacheConfigurer.java", MAIN_JAVA);
+    templateToCache(project, packageNamePath, "src", "JCacheCreator.java", MAIN_JAVA);
+
+    templateToCache(project, packageNamePath, "test", "JCacheCreatorTest.java", TEST_JAVA);
+  }
+
+  private void templateToCache(Project project, String source, String type, String sourceFilename, String destination) {
+    projectRepository.template(project, getPath(SOURCE, type), sourceFilename, getPath(destination, source, DESTINATION));
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheService.java
@@ -1,0 +1,8 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface SpringBootJCacheService {
+  void addDependencies(Project project);
+  void addEnableCaching(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/domain/SpringBootJCacheService.java
@@ -5,4 +5,5 @@ import tech.jhipster.lite.generator.project.domain.Project;
 public interface SpringBootJCacheService {
   void addDependencies(Project project);
   void addEnableCaching(Project project);
+  void addJavaConfig(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfiguration.java
@@ -27,6 +27,6 @@ public class SpringBootJCacheBeanConfiguration {
 
   @Bean
   public SpringBootJCacheService springBootJCacheService() {
-    return new SpringBootJCacheDomainService(buildToolService, springBootCacheService);
+    return new SpringBootJCacheDomainService(buildToolService, projectRepository, springBootCacheService);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfiguration.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheDomainService;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheService;
+
+@Configuration
+public class SpringBootJCacheBeanConfiguration {
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+  private final SpringBootCacheService springBootCacheService;
+
+  public SpringBootJCacheBeanConfiguration(
+    BuildToolService buildToolService,
+    ProjectRepository projectRepository,
+    SpringBootCacheService springBootCacheService
+  ) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+    this.springBootCacheService = springBootCacheService;
+  }
+
+  @Bean
+  public SpringBootJCacheService springBootJCacheService() {
+    return new SpringBootJCacheDomainService(buildToolService, springBootCacheService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.SharedKernel
+package tech.jhipster.lite.generator.server.springboot.cache.jcache;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
@@ -156,6 +156,7 @@ public class MySQLDomainService implements MySQLService {
     result.put("spring.datasource.url", "jdbc:tc:" + MySQL.getDockerImageName() + ":///" + baseName);
     result.put("spring.datasource.username", baseName);
     result.put("spring.datasource.password", "");
+    result.put("spring.datasource.hikari.maximum-pool-size", 2);
     return result;
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
@@ -190,6 +190,7 @@ public class PostgresqlDomainService implements PostgresqlService {
     );
     result.put("spring.datasource.username", baseName);
     result.put("spring.datasource.password", "");
+    result.put("spring.datasource.hikari.maximum-pool-size", 2);
     return result;
   }
 

--- a/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheConfiguration.java.mustache
@@ -1,0 +1,19 @@
+package {{packageName}}.technical.infrastructure.secondary.cache.ehcache;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class EhcacheConfiguration {
+
+  private final EhcacheProperties properties;
+
+  public EhcacheConfiguration(EhcacheProperties properties) {
+    this.properties = properties;
+  }
+
+  @Bean
+  public EhcacheConfigurer ehcacheConfigurer() {
+    return new EhcacheConfigurer(properties);
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheConfigurer.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheConfigurer.java.mustache
@@ -1,0 +1,28 @@
+package {{packageName}}.technical.infrastructure.secondary.cache.ehcache;
+
+import {{packageName}}.technical.infrastructure.secondary.cache.JCacheConfigurer;
+import java.time.Duration;
+import javax.cache.configuration.Configuration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ExpiryPolicyBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.jsr107.Eh107Configuration;
+
+public class EhcacheConfigurer implements JCacheConfigurer {
+
+  private final EhcacheProperties properties;
+
+  public EhcacheConfigurer(EhcacheProperties properties) {
+    this.properties = properties;
+  }
+
+  @Override
+  public Configuration<Object, Object> configure() {
+    return Eh107Configuration.fromEhcacheCacheConfiguration(
+      CacheConfigurationBuilder
+        .newCacheConfigurationBuilder(Object.class, Object.class, ResourcePoolsBuilder.heap(properties.getMaxEntries()))
+        .withExpiry(ExpiryPolicyBuilder.timeToLiveExpiration(Duration.ofSeconds(properties.getTimeToLiveSeconds())))
+        .build()
+    );
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheProperties.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/src/EhcacheProperties.java.mustache
@@ -1,0 +1,38 @@
+package {{packageName}}.technical.infrastructure.secondary.cache.ehcache;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "application.cache.ehcache")
+public class EhcacheProperties {
+
+  public static final int DEFAULT_MAX_ENTRIES = 100;
+  public static final int DEFAULT_TTL_SECONDS = 3600;
+
+  /**
+   * Default maximum number of entries
+   */
+  private long maxEntries = DEFAULT_MAX_ENTRIES;
+
+  /**
+   * Default cache time to live in seconds
+   */
+  private int timeToLiveSeconds = DEFAULT_TTL_SECONDS;
+
+  public long getMaxEntries() {
+    return maxEntries;
+  }
+
+  public void setMaxEntries(long maxEntries) {
+    this.maxEntries = maxEntries;
+  }
+
+  public int getTimeToLiveSeconds() {
+    return timeToLiveSeconds;
+  }
+
+  public void setTimeToLiveSeconds(int timeToLiveSeconds) {
+    this.timeToLiveSeconds = timeToLiveSeconds;
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/ehcache/test/EhcacheConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/test/EhcacheConfigurationIT.java.mustache
@@ -1,0 +1,51 @@
+package {{packageName}}.technical.infrastructure.secondary.cache.ehcache;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import {{packageName}}.IntegrationTest;
+import {{packageName}}.technical.infrastructure.secondary.cache.JCacheConfigurer;
+import {{packageName}}.technical.infrastructure.secondary.cache.JCacheCreator;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import org.ehcache.config.CacheRuntimeConfiguration;
+import org.ehcache.config.ResourceType;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationContext;
+
+@IntegrationTest
+@SpringBootTest(properties = { "application.cache.ehcache.max-entries=1000", "application.cache.ehcache.time-to-live-seconds=86400" })
+class EhcacheConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Autowired
+  CacheManager cm;
+
+  @Autowired
+  JCacheCreator jCacheCreator;
+
+  @Test
+  void shouldEhcacheConfigurer() {
+    assertThat(applicationContext.getBean(JCacheConfigurer.class)).isInstanceOf(EhcacheConfigurer.class);
+  }
+
+  @Test
+  void shouldApplyProperties() {
+    jCacheCreator.createEntityCache(cm, "shouldApplyProperties");
+
+    Cache<Object, Object> cache = cm.getCache("shouldApplyProperties");
+
+    @SuppressWarnings("unchecked")
+    CacheRuntimeConfiguration<Object, Object> config = (CacheRuntimeConfiguration<Object, Object>) cache
+      .getConfiguration(Eh107Configuration.class)
+      .unwrap(CacheRuntimeConfiguration.class);
+
+    assertThat(config.getResourcePools().getPoolForResource(ResourceType.Core.HEAP).getSize()).isEqualTo(1000);
+
+    assertThat(config.getExpiryPolicy().getExpiryForCreation(42L, "entry").getSeconds()).isEqualTo(86400);
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfiguration.java.mustache
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 public class JCacheConfiguration {
 
+  @SuppressWarnings("java:S1068") // Not used without entity
   private final JCacheCreator jCacheCreator;
 
   public JCacheConfiguration(JCacheCreator jCacheCreator) {

--- a/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfiguration.java.mustache
@@ -1,0 +1,22 @@
+package {{packageName}}.technical.infrastructure.secondary.cache;
+
+import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class JCacheConfiguration {
+
+  private final JCacheCreator jCacheCreator;
+
+  public JCacheConfiguration(JCacheCreator jCacheCreator) {
+    this.jCacheCreator = jCacheCreator;
+  }
+
+  @Bean
+  public JCacheManagerCustomizer cacheManagerCustomizer() {
+    return cm -> {
+      // jhipster-needle-jcache-add-entity
+    };
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfigurer.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheConfigurer.java.mustache
@@ -1,0 +1,8 @@
+package {{packageName}}.technical.infrastructure.secondary.cache;
+
+import javax.cache.configuration.Configuration;
+
+@FunctionalInterface
+public interface JCacheConfigurer {
+  Configuration<Object, Object> configure();
+}

--- a/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheCreator.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/jcache/src/JCacheCreator.java.mustache
@@ -1,0 +1,41 @@
+package {{packageName}}.technical.infrastructure.secondary.cache;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JCacheCreator {
+
+  private final Configuration<Object, Object> entityCacheConfiguration;
+
+  public JCacheCreator(JCacheConfigurer jCacheConfigurer) {
+    entityCacheConfiguration = jCacheConfigurer.configure();
+  }
+
+  /**
+   * Create or replace a cache with the default entity cache configuration
+   *
+   * @param cm        cache manager
+   * @param cacheName cache name
+   */
+  public void createEntityCache(CacheManager cm, String cacheName) {
+    createCache(cm, cacheName, entityCacheConfiguration);
+  }
+
+  /**
+   * Create or replace a cache
+   *
+   * @param cm            cache manager
+   * @param cacheName     cache name
+   * @param configuration cache configuration
+   */
+  public void createCache(CacheManager cm, String cacheName, Configuration<Object, Object> configuration) {
+    Cache<Object, Object> cache = cm.getCache(cacheName);
+    if (cache != null) {
+      cm.destroyCache(cacheName);
+    }
+    cm.createCache(cacheName, configuration);
+  }
+}

--- a/src/main/resources/generator/server/springboot/cache/jcache/test/JCacheCreatorTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/jcache/test/JCacheCreatorTest.java.mustache
@@ -1,0 +1,72 @@
+package {{packageName}}.technical.infrastructure.secondary.cache;
+
+import static org.mockito.Mockito.*;
+
+import {{packageName}}.UnitTest;
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class JCacheCreatorTest {
+
+  private static final Configuration<Object, Object> defaultConfig = new Configuration<>() {
+    @Override
+    public Class<Object> getKeyType() {
+      return null;
+    }
+
+    @Override
+    public Class<Object> getValueType() {
+      return null;
+    }
+
+    @Override
+    public boolean isStoreByValue() {
+      return false;
+    }
+  };
+
+  private static final JCacheConfigurer jCacheConfigurer = () -> defaultConfig;
+
+  private static final JCacheCreator jCacheCreator = new JCacheCreator(jCacheConfigurer);
+
+  @Mock
+  CacheManager cm;
+
+  @Mock
+  Cache<Object, Object> cache;
+
+  @Mock
+  Configuration<Object, Object> customConfig;
+
+  @Test
+  void shouldCreateEntityCache() {
+    jCacheCreator.createEntityCache(cm, "test");
+    verify(cm).createCache("test", defaultConfig);
+  }
+
+  @Test
+  void shouldCreateCustomCache() {
+    jCacheCreator.createCache(cm, "test", customConfig);
+    verify(cm).createCache("test", customConfig);
+  }
+
+  @Test
+  void shouldReplaceExistingCache() {
+    // given an existing cache "test"
+    doReturn(cache).when(cm).getCache("test");
+
+    // when attempting to create a new cache "test"
+    jCacheCreator.createCache(cm, "test", customConfig);
+
+    // then destroy and create cache "test"
+    verify(cm).destroyCache("test");
+    verify(cm).createCache("test", customConfig);
+  }
+}

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/test/LiquibaseConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/test/LiquibaseConfigurationIT.java.mustache
@@ -9,15 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class LiquibaseConfigurationIT {
-
-  @Autowired
-  ApplicationContext applicationContext;
 
   @Nested
   @IntegrationTest(properties = { "application.liquibase.async=true" })
   class Async {
+
+    @Autowired
+    ApplicationContext applicationContext;
 
     @Test
     void shouldGetLiquibaseAsync() {
@@ -30,6 +29,9 @@ class LiquibaseConfigurationIT {
   @Nested
   @IntegrationTest(properties = { "application.liquibase.async=false" })
   class Sync {
+
+    @Autowired
+    ApplicationContext applicationContext;
 
     @Test
     void shouldGetLiquibaseSync() {

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class LogstashTcpConfigurationIT {
 
   @Nested

--- a/src/main/resources/generator/server/springboot/mvc/security/jwt/test/CorsFilterConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/jwt/test/CorsFilterConfigurationIT.java.mustache
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.filter.CorsFilter;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class CorsFilterConfigurationIT {
 
   @Nested

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
@@ -1,0 +1,85 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class EhcacheApplicationServiceIT {
+
+  @Autowired
+  EhcacheApplicationService ehcacheApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "foo");
+
+    initApplicationService.init(project);
+
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.init(project);
+
+    assertInit(project);
+  }
+
+  @Test
+  void shouldAddDependencies() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    ehcacheApplicationService.addDependencies(project);
+
+    assertDependencies(project);
+  }
+
+  @Test
+  void shouldAddJavaFiles() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.addJavaFiles(project);
+
+    assertJavaFiles(project);
+  }
+
+  @Test
+  void shouldAddProperties() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.addProperties(project);
+
+    assertProperties(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheApplicationServiceIT.java
@@ -38,9 +38,9 @@ class EhcacheApplicationServiceIT {
     mavenApplicationService.addPomXml(project);
     springBootApplicationService.init(project);
 
-    ehcacheApplicationService.init(project);
+    ehcacheApplicationService.initJavaConfiguration(project);
 
-    assertInit(project);
+    assertInitJavaConfiguration(project);
   }
 
   @Test
@@ -57,7 +57,7 @@ class EhcacheApplicationServiceIT {
   }
 
   @Test
-  void shouldAddJavaFiles() {
+  void shouldEnableCaching() {
     Project project = tmpProject();
     project.addConfig(BASE_NAME, "bar");
     project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
@@ -65,20 +65,34 @@ class EhcacheApplicationServiceIT {
     mavenApplicationService.addPomXml(project);
     springBootApplicationService.init(project);
 
-    ehcacheApplicationService.addJavaFiles(project);
+    ehcacheApplicationService.addEnableCaching(project);
+
+    assertEnableCaching(project);
+  }
+
+  @Test
+  void shouldAddJavaConfig() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    ehcacheApplicationService.addJavaConfig(project);
 
     assertJavaFiles(project);
   }
 
   @Test
-  void shouldAddProperties() {
+  void shouldAddJavaProperties() {
     Project project = tmpProject();
     project.addConfig(BASE_NAME, "bar");
     initApplicationService.init(project);
     mavenApplicationService.addPomXml(project);
     springBootApplicationService.init(project);
 
-    ehcacheApplicationService.addProperties(project);
+    ehcacheApplicationService.addJavaProperties(project);
 
     assertProperties(project);
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
@@ -13,8 +13,9 @@ import tech.jhipster.lite.generator.server.springboot.cache.jcache.application.S
 
 public class EhcacheAssert {
 
-  public static void assertInit(Project project) {
+  public static void assertInitJavaConfiguration(Project project) {
     assertDependencies(project);
+    assertEnableCaching(project);
     assertJavaFiles(project);
     assertProperties(project);
   }
@@ -29,8 +30,11 @@ public class EhcacheAssert {
     );
   }
 
-  public static void assertJavaFiles(Project project) {
+  public static void assertEnableCaching(Project project) {
     SpringBootJCacheAssert.assertEnableCaching(project);
+  }
+
+  public static void assertJavaFiles(Project project) {
     SpringBootJCacheAssert.assertJavaConfig(project);
 
     String basePackage = project.getPackageName().orElse("com.mycompany.myapp");

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/application/EhcacheAssert.java
@@ -1,0 +1,64 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
+
+import java.util.List;
+import tech.jhipster.lite.generator.project.domain.DefaultConfig;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain.EhcacheDomainService;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.application.SpringBootJCacheAssert;
+
+public class EhcacheAssert {
+
+  public static void assertInit(Project project) {
+    assertDependencies(project);
+    assertJavaFiles(project);
+    assertProperties(project);
+  }
+
+  public static void assertDependencies(Project project) {
+    SpringBootJCacheAssert.assertDependencies(project);
+
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of("<dependency>", "<groupId>org.ehcache</groupId>", "<artifactId>ehcache</artifactId>", "</dependency>")
+    );
+  }
+
+  public static void assertJavaFiles(Project project) {
+    SpringBootJCacheAssert.assertEnableCaching(project);
+    SpringBootJCacheAssert.assertJavaConfig(project);
+
+    String basePackage = project.getPackageName().orElse("com.mycompany.myapp");
+    String cachePackage = basePackage + ".technical.infrastructure.secondary.cache";
+
+    String basePath = project.getPackageNamePath().orElse(getPath(DefaultConfig.PACKAGE_PATH));
+    String ehcachePath = getPath(MAIN_JAVA, basePath, EhcacheDomainService.DESTINATION);
+
+    assertFileExist(project, getPath(ehcachePath, "EhcacheConfiguration.java"));
+    assertFileExist(project, getPath(ehcachePath, "EhcacheConfigurer.java"));
+    assertFileExist(project, getPath(ehcachePath, "EhcacheProperties.java"));
+
+    assertFileContent(project, getPath(ehcachePath, "EhcacheConfiguration.java"), "package " + cachePackage);
+    assertFileContent(project, getPath(ehcachePath, "EhcacheConfigurer.java"), "package " + cachePackage);
+    assertFileContent(project, getPath(ehcachePath, "EhcacheProperties.java"), "package " + cachePackage);
+
+    String ehcacheTestPath = getPath(TEST_JAVA, basePath, EhcacheDomainService.DESTINATION);
+
+    assertFileExist(project, getPath(ehcacheTestPath, "EhcacheConfigurationIT.java"));
+
+    assertFileContent(project, getPath(ehcacheTestPath, "EhcacheConfigurationIT.java"), "package " + cachePackage);
+  }
+
+  public static void assertProperties(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config/application.properties"),
+      List.of("application.cache.ehcache.max-entries=100", "application.cache.ehcache.time-to-live-seconds=3600")
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/config/EhcacheBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/config/EhcacheBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.cache.ehcache.domain.EhcacheDomainService;
+
+@IntegrationTest
+class EhcacheBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("ehcacheService")).isNotNull().isInstanceOf(EhcacheDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
@@ -2,7 +2,7 @@ package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastruct
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.assertInit;
+import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.assertInitJavaConfiguration;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -49,12 +49,12 @@ class EhcacheResourceIT {
 
     mockMvc
       .perform(
-        post("/api/servers/spring-boot/cache/ehcache")
+        post("/api/servers/spring-boot/cache/ehcache/java-configuration")
           .contentType(MediaType.APPLICATION_JSON)
           .content(TestUtils.convertObjectToJsonBytes(projectDTO))
       )
       .andExpect(status().isOk());
 
-    assertInit(project);
+    assertInitJavaConfiguration(project);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/rest/EhcacheResourceIT.java
@@ -1,0 +1,60 @@
+package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.primary.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.generator.server.springboot.cache.ehcache.application.EhcacheAssert.assertInit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class EhcacheResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldAddEhcache() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/cache/ehcache")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertInit(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationServiceIT.java
@@ -1,0 +1,57 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.cache.jcache.application.SpringBootJCacheAssert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class SpringBootJCacheApplicationServiceIT {
+
+  @Autowired
+  SpringBootJCacheApplicationService springBootJCacheApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldAddDependencies() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    springBootJCacheApplicationService.addDependencies(project);
+
+    assertDependencies(project);
+  }
+
+  @Test
+  void shouldEnableCaching() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    springBootJCacheApplicationService.addEnableCaching(project);
+
+    assertEnableCaching(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheApplicationServiceIT.java
@@ -54,4 +54,18 @@ class SpringBootJCacheApplicationServiceIT {
 
     assertEnableCaching(project);
   }
+
+  @Test
+  void shouldAddJavaConfig() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    springBootJCacheApplicationService.addJavaConfig(project);
+
+    assertJavaConfig(project);
+  }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheAssert.java
@@ -1,10 +1,16 @@
 package tech.jhipster.lite.generator.server.springboot.cache.jcache.application;
 
 import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
 
 import java.util.List;
+import tech.jhipster.lite.generator.project.domain.DefaultConfig;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.server.springboot.cache.common.application.SpringBootCacheAssert;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheDomainService;
 
 public class SpringBootJCacheAssert {
 
@@ -20,5 +26,27 @@ public class SpringBootJCacheAssert {
 
   public static void assertEnableCaching(Project project) {
     SpringBootCacheAssert.assertEnableCaching(project);
+  }
+
+  public static void assertJavaConfig(Project project) {
+    String basePackage = project.getPackageName().orElse("com.mycompany.myapp");
+    String cachePackage = basePackage + ".technical.infrastructure.secondary.cache";
+
+    String basePath = project.getPackageNamePath().orElse(getPath(DefaultConfig.PACKAGE_PATH));
+    String cachePath = getPath(MAIN_JAVA, basePath, SpringBootCacheDomainService.DESTINATION);
+
+    assertFileExist(project, getPath(cachePath, "JCacheConfiguration.java"));
+    assertFileExist(project, getPath(cachePath, "JCacheConfigurer.java"));
+    assertFileExist(project, getPath(cachePath, "JCacheCreator.java"));
+
+    assertFileContent(project, getPath(cachePath, "JCacheConfiguration.java"), "package " + cachePackage);
+    assertFileContent(project, getPath(cachePath, "JCacheConfigurer.java"), "package " + cachePackage);
+    assertFileContent(project, getPath(cachePath, "JCacheCreator.java"), "package " + cachePackage);
+
+    String cacheTestPath = getPath(TEST_JAVA, basePath, SpringBootCacheDomainService.DESTINATION);
+
+    assertFileExist(project, getPath(cacheTestPath, "JCacheCreatorTest.java"));
+
+    assertFileContent(project, getPath(cacheTestPath, "JCacheCreatorTest.java"), "package " + cachePackage);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/application/SpringBootJCacheAssert.java
@@ -1,0 +1,24 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+
+import java.util.List;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.application.SpringBootCacheAssert;
+
+public class SpringBootJCacheAssert {
+
+  public static void assertDependencies(Project project) {
+    SpringBootCacheAssert.assertDependencies(project);
+
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of("<dependency>", "<groupId>javax.cache</groupId>", "<artifactId>cache-api</artifactId>", "</dependency>")
+    );
+  }
+
+  public static void assertEnableCaching(Project project) {
+    SpringBootCacheAssert.assertEnableCaching(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/jcache/infrastructure/config/SpringBootJCacheBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.cache.jcache.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.cache.jcache.domain.SpringBootJCacheDomainService;
+
+@IntegrationTest
+class SpringBootJCacheBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("springBootJCacheService")).isNotNull().isInstanceOf(SpringBootJCacheDomainService.class);
+  }
+}

--- a/tests-ci/config/tomcat-postgresql-ehcache.json
+++ b/tests-ci/config/tomcat-postgresql-ehcache.json
@@ -1,5 +1,5 @@
 {
-  "folder": "/tmp/jhlite/tomcat-postgresql",
+  "folder": "/tmp/jhlite/tomcat-postgresql-ehcache",
   "generator-jhipster": {
     "projectName": "Beer Project",
     "baseName": "beer",

--- a/tests-ci/config/tomcat-postgresql-ehcachejava.json
+++ b/tests-ci/config/tomcat-postgresql-ehcachejava.json
@@ -1,5 +1,5 @@
 {
-  "folder": "/tmp/jhlite/tomcat-postgresql-ehcache",
+  "folder": "/tmp/jhlite/tomcat-postgresql-ehcachejava",
   "generator-jhipster": {
     "projectName": "Beer Project",
     "baseName": "beer",

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -19,7 +19,7 @@ callApi() {
     "http://localhost:7471"$api
 }
 
-if [[ $filename == 'tomcat-postgresql-ehcache' ]]; then
+if [[ $filename == 'tomcat-postgresql-ehcachejava' ]]; then
   callApi "/api/projects/init"
   callApi "/api/build-tools/maven"
   callApi "/api/servers/java/base"
@@ -35,7 +35,7 @@ if [[ $filename == 'tomcat-postgresql-ehcache' ]]; then
   callApi "/api/servers/spring-boot/aop/logging"
   callApi "/api/servers/spring-boot/logging/logstash/tcp"
   callApi "/api/servers/spring-boot/async"
-  callApi "/api/servers/spring-boot/cache/ehcache"
+  callApi "/api/servers/spring-boot/cache/ehcache/java-configuration"
   callApi "/api/servers/sonar"
 
 elif [[ $filename == 'undertow-mysql-simplecache' ]]; then

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -19,7 +19,7 @@ callApi() {
     "http://localhost:7471"$api
 }
 
-if [[ $filename == 'tomcat-postgresql' ]]; then
+if [[ $filename == 'tomcat-postgresql-ehcache' ]]; then
   callApi "/api/projects/init"
   callApi "/api/build-tools/maven"
   callApi "/api/servers/java/base"
@@ -35,6 +35,7 @@ if [[ $filename == 'tomcat-postgresql' ]]; then
   callApi "/api/servers/spring-boot/aop/logging"
   callApi "/api/servers/spring-boot/logging/logstash/tcp"
   callApi "/api/servers/spring-boot/async"
+  callApi "/api/servers/spring-boot/cache/ehcache"
   callApi "/api/servers/sonar"
 
 elif [[ $filename == 'undertow-mysql-simplecache' ]]; then


### PR DESCRIPTION
#121 (alternative to #431)

This is the version with Java configuration.

Quite verbose, will less flexibility than the XML configuration but a common needle for all JCache implementations.

Generator:

- [x] Ehcache
- [x] rename to java-configuration

Generated:

- [x] EhcacheConfiguration
- [x] jhipster-needle-**jcache**-add-**entity**
note 1: "jcache" needle because we can add entities at a single place for all JCache providers
note 2: explicit "entity" needle because it uses a template to have a shared ttl and max-entries
- [x] integration test of the configuration (2 properties...)

---

This is based on a common branch: https://github.com/pblanchardie/jhipster-lite/tree/add-spring-boot-jcache

- [x] Spring Boot Cache Commons (spring-boot-starter-cache + CacheConfiguration)
- [x] Spring Boot JCache Commons (jcache)
- [x] Spring Boot JCache Java Config (Java configuration)