### PR TITLE
Add Spring Boot Cache Simple

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -63,7 +63,7 @@ jobs:
       matrix:
         app:
           - tomcat-postgresql
-          - undertow-mysql
+          - undertow-mysql-simplecache
     steps:
       - name: 'Setup: checkout project'
         uses: actions/checkout@v2

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheApplicationService.java
@@ -1,0 +1,23 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+
+@Service
+public class SpringBootCacheApplicationService {
+
+  private final SpringBootCacheService springBootCacheService;
+
+  public SpringBootCacheApplicationService(SpringBootCacheService springBootCacheService) {
+    this.springBootCacheService = springBootCacheService;
+  }
+
+  public void addDependencies(Project project) {
+    springBootCacheService.addDependencies(project);
+  }
+
+  public void addEnableCaching(Project project) {
+    springBootCacheService.addEnableCaching(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCache.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCache.java
@@ -1,0 +1,14 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class SpringBootCache {
+
+  public static final String SPRINGBOOT_PACKAGE = "org.springframework.boot";
+
+  private SpringBootCache() {}
+
+  public static Dependency springBootStarterCacheDependency() {
+    return Dependency.builder().groupId(SPRINGBOOT_PACKAGE).artifactId("spring-boot-starter-cache").build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCacheDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCacheDomainService.java
@@ -1,0 +1,42 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.domain;
+
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+
+public class SpringBootCacheDomainService implements SpringBootCacheService {
+
+  public static final String SOURCE = "server/springboot/cache/common";
+  public static final String DESTINATION = "technical/infrastructure/secondary/cache";
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+
+  public SpringBootCacheDomainService(BuildToolService buildToolService, ProjectRepository projectRepository) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+  }
+
+  @Override
+  public void addDependencies(Project project) {
+    buildToolService.addDependency(project, SpringBootCache.springBootStarterCacheDependency());
+  }
+
+  @Override
+  public void addEnableCaching(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    project.addDefaultConfig(BASE_NAME);
+    String packageNamePath = project.getPackageNamePath().orElse(getPath("com/mycompany/myapp"));
+
+    templateToCache(project, packageNamePath, "src", "CacheConfiguration.java", MAIN_JAVA);
+  }
+
+  private void templateToCache(Project project, String source, String type, String sourceFilename, String destination) {
+    projectRepository.template(project, getPath(SOURCE, type), sourceFilename, getPath(destination, source, DESTINATION));
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCacheService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/domain/SpringBootCacheService.java
@@ -1,0 +1,8 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface SpringBootCacheService {
+  void addDependencies(Project project);
+  void addEnableCaching(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/infrastructure/config/SpringBootCacheBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/infrastructure/config/SpringBootCacheBeanConfiguration.java
@@ -1,0 +1,25 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheDomainService;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+
+@Configuration
+public class SpringBootCacheBeanConfiguration {
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+
+  public SpringBootCacheBeanConfiguration(BuildToolService buildToolService, ProjectRepository projectRepository) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+  }
+
+  @Bean
+  public SpringBootCacheService springBootCacheService() {
+    return new SpringBootCacheDomainService(buildToolService, projectRepository);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/common/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.SharedKernel
+package tech.jhipster.lite.generator.server.springboot.cache.common;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleApplicationService.java
@@ -1,0 +1,19 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.simple.domain.SpringBootCacheSimpleService;
+
+@Service
+public class SpringBootCacheSimpleApplicationService {
+
+  private final SpringBootCacheSimpleService springBootCacheSimpleService;
+
+  public SpringBootCacheSimpleApplicationService(SpringBootCacheSimpleService springBootCacheSimpleService) {
+    this.springBootCacheSimpleService = springBootCacheSimpleService;
+  }
+
+  public void init(Project project) {
+    springBootCacheSimpleService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/domain/SpringBootCacheSimpleDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/domain/SpringBootCacheSimpleDomainService.java
@@ -1,0 +1,19 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+
+public class SpringBootCacheSimpleDomainService implements SpringBootCacheSimpleService {
+
+  private final SpringBootCacheService springBootCacheService;
+
+  public SpringBootCacheSimpleDomainService(SpringBootCacheService springBootCacheService) {
+    this.springBootCacheService = springBootCacheService;
+  }
+
+  @Override
+  public void init(Project project) {
+    springBootCacheService.addDependencies(project);
+    springBootCacheService.addEnableCaching(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/domain/SpringBootCacheSimpleService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/domain/SpringBootCacheSimpleService.java
@@ -1,0 +1,7 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface SpringBootCacheSimpleService {
+  void init(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/config/SpringBootCacheSimpleBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/config/SpringBootCacheSimpleBeanConfiguration.java
@@ -1,0 +1,22 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheService;
+import tech.jhipster.lite.generator.server.springboot.cache.simple.domain.SpringBootCacheSimpleDomainService;
+import tech.jhipster.lite.generator.server.springboot.cache.simple.domain.SpringBootCacheSimpleService;
+
+@Configuration
+public class SpringBootCacheSimpleBeanConfiguration {
+
+  private final SpringBootCacheService springBootCacheService;
+
+  public SpringBootCacheSimpleBeanConfiguration(SpringBootCacheService springBootCacheService) {
+    this.springBootCacheService = springBootCacheService;
+  }
+
+  @Bean
+  public SpringBootCacheSimpleService springBootCacheSimpleService() {
+    return new SpringBootCacheSimpleDomainService(springBootCacheService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/rest/SpringBootCacheSimpleResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/rest/SpringBootCacheSimpleResource.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.infrastructure.primary.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.cache.simple.application.SpringBootCacheSimpleApplicationService;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/cache/simple")
+@Tag(name = "Spring Boot - Cache")
+class SpringBootCacheSimpleResource {
+
+  private final SpringBootCacheSimpleApplicationService springBootCacheSimpleApplicationService;
+
+  public SpringBootCacheSimpleResource(SpringBootCacheSimpleApplicationService springBootCacheSimpleApplicationService) {
+    this.springBootCacheSimpleApplicationService = springBootCacheSimpleApplicationService;
+  }
+
+  @Operation(summary = "Add simple cache")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding simple cache")
+  @PostMapping
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    springBootCacheSimpleApplicationService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.cache.simple;

--- a/src/main/resources/generator/server/springboot/cache/common/src/CacheConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/common/src/CacheConfiguration.java.mustache
@@ -1,0 +1,8 @@
+package {{packageName}}.technical.infrastructure.secondary.cache;
+
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableCaching
+public class CacheConfiguration {}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheApplicationServiceIT.java
@@ -1,0 +1,57 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.cache.common.application.SpringBootCacheAssert.*;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class SpringBootCacheApplicationServiceIT {
+
+  @Autowired
+  SpringBootCacheApplicationService springBootCacheApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldAddDependencies() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    springBootCacheApplicationService.addDependencies(project);
+
+    assertDependencies(project);
+  }
+
+  @Test
+  void shouldEnableCaching() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.baz");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    springBootCacheApplicationService.addEnableCaching(project);
+
+    assertEnableCaching(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/application/SpringBootCacheAssert.java
@@ -1,0 +1,39 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+
+import java.util.List;
+import tech.jhipster.lite.generator.project.domain.DefaultConfig;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheDomainService;
+
+public class SpringBootCacheAssert {
+
+  public static void assertDependencies(Project project) {
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.boot</groupId>",
+        "<artifactId>spring-boot-starter-cache</artifactId>",
+        "</dependency>"
+      )
+    );
+  }
+
+  public static void assertEnableCaching(Project project) {
+    String basePackage = project.getPackageName().orElse("com.mycompany.myapp");
+    String cachePackage = basePackage + ".technical.infrastructure.secondary.cache";
+
+    String basePath = project.getPackageNamePath().orElse(getPath(DefaultConfig.PACKAGE_PATH));
+    String cachePath = getPath(MAIN_JAVA, basePath, SpringBootCacheDomainService.DESTINATION);
+
+    assertFileExist(project, getPath(cachePath, "CacheConfiguration.java"));
+
+    assertFileContent(project, getPath(cachePath, "CacheConfiguration.java"), "package " + cachePackage);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/infrastructure/config/SpringBootCacheBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/common/infrastructure/config/SpringBootCacheBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.cache.common.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.cache.common.domain.SpringBootCacheDomainService;
+
+@IntegrationTest
+class SpringBootCacheBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("springBootCacheService")).isNotNull().isInstanceOf(SpringBootCacheDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleApplicationServiceIT.java
@@ -1,0 +1,44 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.cache.simple.application.SpringBootCacheSimpleAssert.assertInit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class SpringBootCacheSimpleApplicationServiceIT {
+
+  @Autowired
+  SpringBootCacheSimpleApplicationService springBootCacheSimpleApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "foo");
+
+    initApplicationService.init(project);
+
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    springBootCacheSimpleApplicationService.init(project);
+
+    assertInit(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/application/SpringBootCacheSimpleAssert.java
@@ -1,0 +1,12 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.application;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.cache.common.application.SpringBootCacheAssert;
+
+public class SpringBootCacheSimpleAssert {
+
+  public static void assertInit(Project project) {
+    SpringBootCacheAssert.assertDependencies(project);
+    SpringBootCacheAssert.assertEnableCaching(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/config/SpringBootCacheSimpleConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/config/SpringBootCacheSimpleConfigurationIT.java
@@ -1,0 +1,23 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.cache.simple.domain.SpringBootCacheSimpleDomainService;
+
+@IntegrationTest
+class SpringBootCacheSimpleConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("springBootCacheSimpleService"))
+      .isNotNull()
+      .isInstanceOf(SpringBootCacheSimpleDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/rest/SpringBootCacheSimpleResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/rest/SpringBootCacheSimpleResourceIT.java
@@ -1,0 +1,60 @@
+package tech.jhipster.lite.generator.server.springboot.cache.simple.infrastructure.primary.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.generator.server.springboot.cache.simple.application.SpringBootCacheSimpleAssert.assertInit;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class SpringBootCacheSimpleResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldInit() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/cache/simple")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertInit(project);
+  }
+}

--- a/tests-ci/config/undertow-mysql-simplecache.json
+++ b/tests-ci/config/undertow-mysql-simplecache.json
@@ -1,5 +1,5 @@
 {
-  "folder": "/tmp/jhlite/undertow-mysql",
+  "folder": "/tmp/jhlite/undertow-mysql-simplecache",
   "generator-jhipster": {
     "projectName": "Beer Project",
     "baseName": "beer",

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -36,7 +36,7 @@ if [[ $filename == 'tomcat-postgresql' ]]; then
   callApi "/api/servers/spring-boot/async"
   callApi "/api/servers/sonar"
 
-elif [[ $filename == 'undertow-mysql' ]]; then
+elif [[ $filename == 'undertow-mysql-simplecache' ]]; then
   callApi "/api/projects/init"
   callApi "/api/build-tools/maven"
   callApi "/api/servers/java/base"
@@ -51,6 +51,7 @@ elif [[ $filename == 'undertow-mysql' ]]; then
   callApi "/api/servers/spring-boot/databases/migration/liquibase"
   callApi "/api/servers/spring-boot/aop/logging"
   callApi "/api/servers/spring-boot/async"
+  callApi "/api/servers/spring-boot/cache/simple"
   callApi "/api/servers/sonar"
 
 else


### PR DESCRIPTION
Allows the user to select the simple ConcurrentHashMap cache with no provider, just in case!
https://docs.spring.io/spring-boot/docs/current/reference/html/io.html#io.caching.provider.simple

- [x] Simple
- [x] add to CI

This PR could be merged first, to simplify #431 and #432. It's based on the same commons.