### PR TITLE
Spring Boot: Spring Cloud Consul

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -65,6 +65,7 @@ jobs:
           - tomcat-postgresql-ehcachejava
           - tomcat-postgresql-ehcachexml
           - undertow-mysql-simplecache
+          - undertow-consul
     steps:
       - name: 'Setup: checkout project'
         uses: actions/checkout@v2

--- a/src/main/java/tech/jhipster/lite/generator/project/domain/Constants.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/domain/Constants.java
@@ -10,6 +10,8 @@ public class Constants {
   public static final String MAIN_RESOURCES = String.join(File.separator, "src", "main", "resources");
   public static final String TEMPLATE_FOLDER = "generator";
 
+  public static final String CONFIG_FOLDER = "config";
+
   public static final String TEST_JAVA = String.join(File.separator, "src", "test", "java");
   public static final String TEST_RESOURCES = String.join(File.separator, "src", "test", "resources");
   public static final String TEST_TEMPLATE_RESOURCES = String.join(File.separator, TEST_RESOURCES, TEMPLATE_FOLDER);

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationService.java
@@ -1,0 +1,27 @@
+package tech.jhipster.lite.generator.server.springboot.consul.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.consul.domain.ConsulService;
+
+@Service
+public class ConsulApplicationService {
+
+  private final ConsulService consulService;
+
+  public ConsulApplicationService(ConsulService consulService) {
+    this.consulService = consulService;
+  }
+
+  public void init(Project project) {
+    consulService.init(project);
+  }
+
+  public void addDependencies(Project project) {
+    consulService.addDependencies(project);
+  }
+
+  public void addProperties(Project project) {
+    consulService.addProperties(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationService.java
@@ -24,4 +24,8 @@ public class ConsulApplicationService {
   public void addProperties(Project project) {
     consulService.addProperties(project);
   }
+
+  public void addDockerConsul(Project project) {
+    consulService.addDockerConsul(project);
+  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
@@ -13,12 +13,24 @@ public class Consul {
 
   private static final String SPRING_CLOUD = "org.springframework.cloud";
 
-  // TODO
-  // currently hard-coded in pom template - move to commons cloud?
-  // private static final String SPRING_CLOUD_VERSION = "2021.0.0";
-  // public static String getSpringCloudVersion() {
-  //  return SPRING_CLOUD_VERSION;
-  //}
+  private static final String SPRING_CLOUD_VERSION = "2021.0.0";
+
+  private Consul() {}
+
+  public static String getSpringCloudVersion() {
+    return SPRING_CLOUD_VERSION;
+  }
+
+  public static Dependency springCloudDependencyManagement() {
+    return Dependency
+      .builder()
+      .groupId(SPRING_CLOUD)
+      .artifactId("spring-cloud-dependencies")
+      .version("\\${spring-cloud.version}")
+      .type("pom")
+      .scope("import")
+      .build();
+  }
 
   public static Dependency springCloudBootstrapDependency() {
     return Dependency.builder().groupId(SPRING_CLOUD).artifactId("spring-cloud-starter-bootstrap").build();

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
@@ -7,10 +7,6 @@ public class Consul {
   public static final String BOOTSTRAP_PROPERTIES = "bootstrap.properties";
   public static final String BOOTSTRAP_FAST_PROPERTIES = "bootstrap-fast.properties";
 
-  public static final String NEEDLE_BOOTSTRAP_PROPERTIES = "# jhipster-needle-bootstrap-properties";
-  public static final String NEEDLE_BOOTSTRAP_FAST_PROPERTIES = "# jhipster-needle-bootstrap-fast-properties";
-  public static final String NEEDLE_BOOTSTRAP_TEST_PROPERTIES = "# jhipster-needle-bootstrap-test-properties";
-
   private static final String SPRING_CLOUD = "org.springframework.cloud";
 
   private static final String SPRING_CLOUD_VERSION = "2021.0.0";

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
@@ -1,0 +1,34 @@
+package tech.jhipster.lite.generator.server.springboot.consul.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class Consul {
+
+  public static final String BOOTSTRAP_PROPERTIES = "bootstrap.properties";
+  public static final String BOOTSTRAP_FAST_PROPERTIES = "bootstrap-fast.properties";
+
+  public static final String NEEDLE_BOOTSTRAP_PROPERTIES = "# jhipster-needle-bootstrap-properties";
+  public static final String NEEDLE_BOOTSTRAP_FAST_PROPERTIES = "# jhipster-needle-bootstrap-fast-properties";
+  public static final String NEEDLE_BOOTSTRAP_TEST_PROPERTIES = "# jhipster-needle-bootstrap-test-properties";
+
+  private static final String SPRING_CLOUD = "org.springframework.cloud";
+
+  // TODO
+  // currently hard-coded in pom template - move to commons cloud?
+  // private static final String SPRING_CLOUD_VERSION = "2021.0.0";
+  // public static String getSpringCloudVersion() {
+  //  return SPRING_CLOUD_VERSION;
+  //}
+
+  public static Dependency springCloudBootstrapDependency() {
+    return Dependency.builder().groupId(SPRING_CLOUD).artifactId("spring-cloud-starter-bootstrap").build();
+  }
+
+  public static Dependency springCloudConsulDiscoveryDependency() {
+    return Dependency.builder().groupId(SPRING_CLOUD).artifactId("spring-cloud-starter-consul-discovery").build();
+  }
+
+  public static Dependency springCloudConsulConfigDependency() {
+    return Dependency.builder().groupId(SPRING_CLOUD).artifactId("spring-cloud-starter-consul-config").build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/Consul.java
@@ -7,11 +7,15 @@ public class Consul {
   public static final String BOOTSTRAP_PROPERTIES = "bootstrap.properties";
   public static final String BOOTSTRAP_FAST_PROPERTIES = "bootstrap-fast.properties";
 
+  private static final String DOCKER_CONSUL_IMAGE = "consul:1.11.1";
   private static final String SPRING_CLOUD = "org.springframework.cloud";
-
   private static final String SPRING_CLOUD_VERSION = "2021.0.0";
 
   private Consul() {}
+
+  public static String getDockerConsulImage() {
+    return DOCKER_CONSUL_IMAGE;
+  }
 
   public static String getSpringCloudVersion() {
     return SPRING_CLOUD_VERSION;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -55,7 +55,7 @@ public class ConsulDomainService implements ConsulService {
   private Map<String, Object> properties() {
     TreeMap<String, Object> result = new TreeMap<>();
 
-    result.put("spring.cloud.consul.config.enabled", "true");
+    result.put("spring.cloud.consul.discovery.health-check-path", "/management/health");
     result.put("spring.cloud.consul.host", "localhost");
     result.put("spring.cloud.consul.port", 8500);
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -25,6 +25,7 @@ public class ConsulDomainService implements ConsulService {
   public void init(Project project) {
     addDependencies(project);
     addProperties(project);
+    addDockerConsul(project);
   }
 
   @Override
@@ -43,5 +44,11 @@ public class ConsulDomainService implements ConsulService {
     projectRepository.template(project, getPath(SOURCE, "src"), BOOTSTRAP_PROPERTIES, getPath(MAIN_RESOURCES, CONFIG_FOLDER));
     projectRepository.template(project, getPath(SOURCE, "src"), BOOTSTRAP_FAST_PROPERTIES, getPath(MAIN_RESOURCES, CONFIG_FOLDER));
     projectRepository.template(project, getPath(SOURCE, "test"), BOOTSTRAP_PROPERTIES, getPath(TEST_RESOURCES, CONFIG_FOLDER));
+  }
+
+  @Override
+  public void addDockerConsul(Project project) {
+    project.addConfig("dockerConsulImage", getDockerConsulImage());
+    projectRepository.template(project, getPath(SOURCE, "src"), "consul.yml", "src/main/docker", "consul.yml");
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -1,11 +1,9 @@
 package tech.jhipster.lite.generator.server.springboot.consul.domain;
 
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
 import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.*;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBootDomainService.CONFIG_FOLDER;
 
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -33,9 +33,11 @@ public class ConsulDomainService implements ConsulService {
 
   @Override
   public void addDependencies(Project project) {
-    buildToolService.addDependency(project, Consul.springCloudBootstrapDependency());
-    buildToolService.addDependency(project, Consul.springCloudConsulConfigDependency());
-    buildToolService.addDependency(project, Consul.springCloudConsulDiscoveryDependency());
+    buildToolService.addProperty(project, "spring-cloud", getSpringCloudVersion());
+    buildToolService.addDependencyManagement(project, springCloudDependencyManagement());
+    buildToolService.addDependency(project, springCloudBootstrapDependency());
+    buildToolService.addDependency(project, springCloudConsulConfigDependency());
+    buildToolService.addDependency(project, springCloudConsulDiscoveryDependency());
   }
 
   @Override

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -7,8 +7,8 @@ import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAM
 import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.*;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBootDomainService.CONFIG_FOLDER;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
-import java.util.TreeMap;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
@@ -49,39 +49,26 @@ public class ConsulDomainService implements ConsulService {
     projectRepository.template(project, getPath(SOURCE, "test"), "bootstrap.properties", getPath(TEST_RESOURCES, CONFIG_FOLDER));
 
     properties().forEach((k, v) -> addProperty(project, k, v, MAIN_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_PROPERTIES));
-    fastProperties()
-      .forEach((k, v) -> addProperty(project, k, v, MAIN_RESOURCES, BOOTSTRAP_FAST_PROPERTIES, NEEDLE_BOOTSTRAP_FAST_PROPERTIES));
-    testProperties().forEach((k, v) -> addProperty(project, k, v, TEST_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_TEST_PROPERTIES));
+
+    addProperty(
+      project,
+      "spring.cloud.consul.enabled",
+      "false",
+      MAIN_RESOURCES,
+      BOOTSTRAP_FAST_PROPERTIES,
+      NEEDLE_BOOTSTRAP_FAST_PROPERTIES
+    );
+    addProperty(project, "spring.cloud.consul.enabled", "false", TEST_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_TEST_PROPERTIES);
   }
 
   private Map<String, Object> properties() {
-    TreeMap<String, Object> result = new TreeMap<>();
+    Map<String, Object> result = new LinkedHashMap<>();
 
     result.put("spring.cloud.consul.discovery.health-check-path", "/management/health");
+    result.put("spring.cloud.consul.discovery.tags[0]", "version=@project.version@");
+    result.put("spring.cloud.consul.discovery.tags[1]", "context-path=\\$\\{server.servlet.context-path:\\}");
     result.put("spring.cloud.consul.host", "localhost");
     result.put("spring.cloud.consul.port", 8500);
-
-    // TODO other properties
-
-    return result;
-  }
-
-  private Map<String, Object> fastProperties() {
-    TreeMap<String, Object> result = new TreeMap<>();
-
-    result.put("spring.cloud.consul.config.enabled", "false");
-    result.put("spring.cloud.consul.discovery.enabled", "false");
-    result.put("spring.cloud.consul.enabled", "false");
-
-    return result;
-  }
-
-  private Map<String, Object> testProperties() {
-    TreeMap<String, Object> result = new TreeMap<>();
-
-    result.put("spring.cloud.consul.config.enabled", "false");
-    result.put("spring.cloud.consul.discovery.enabled", "false");
-    result.put("spring.cloud.consul.enabled", "false");
 
     return result;
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -1,0 +1,98 @@
+package tech.jhipster.lite.generator.server.springboot.consul.domain;
+
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.*;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBootDomainService.CONFIG_FOLDER;
+
+import java.util.Map;
+import java.util.TreeMap;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+
+public class ConsulDomainService implements ConsulService {
+
+  public static final String SOURCE = "server/springboot/consul";
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+
+  public ConsulDomainService(BuildToolService buildToolService, ProjectRepository projectRepository) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+  }
+
+  @Override
+  public void init(Project project) {
+    addDependencies(project);
+    addProperties(project);
+  }
+
+  @Override
+  public void addDependencies(Project project) {
+    buildToolService.addDependency(project, Consul.springCloudBootstrapDependency());
+    buildToolService.addDependency(project, Consul.springCloudConsulConfigDependency());
+    buildToolService.addDependency(project, Consul.springCloudConsulDiscoveryDependency());
+  }
+
+  @Override
+  public void addProperties(Project project) {
+    project.addDefaultConfig(BASE_NAME);
+
+    projectRepository.template(project, getPath(SOURCE, "src"), "bootstrap.properties", getPath(MAIN_RESOURCES, CONFIG_FOLDER));
+    projectRepository.template(project, getPath(SOURCE, "src"), "bootstrap-fast.properties", getPath(MAIN_RESOURCES, CONFIG_FOLDER));
+    projectRepository.template(project, getPath(SOURCE, "test"), "bootstrap.properties", getPath(TEST_RESOURCES, CONFIG_FOLDER));
+
+    properties().forEach((k, v) -> addProperty(project, k, v, MAIN_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_PROPERTIES));
+    fastProperties()
+      .forEach((k, v) -> addProperty(project, k, v, MAIN_RESOURCES, BOOTSTRAP_FAST_PROPERTIES, NEEDLE_BOOTSTRAP_FAST_PROPERTIES));
+    testProperties().forEach((k, v) -> addProperty(project, k, v, TEST_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_TEST_PROPERTIES));
+  }
+
+  private Map<String, Object> properties() {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("spring.cloud.consul.config.enabled", "true");
+    result.put("spring.cloud.consul.host", "localhost");
+    result.put("spring.cloud.consul.port", 8500);
+
+    // TODO other properties
+
+    return result;
+  }
+
+  private Map<String, Object> fastProperties() {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("spring.cloud.consul.config.enabled", "false");
+    result.put("spring.cloud.consul.discovery.enabled", "false");
+    result.put("spring.cloud.consul.enabled", "false");
+
+    return result;
+  }
+
+  private Map<String, Object> testProperties() {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("spring.cloud.consul.config.enabled", "false");
+    result.put("spring.cloud.consul.discovery.enabled", "false");
+    result.put("spring.cloud.consul.enabled", "false");
+
+    return result;
+  }
+
+  private void addProperty(
+    Project project,
+    String key,
+    Object value,
+    String folderProperties,
+    String fileProperties,
+    String needleProperties
+  ) {
+    String propertiesWithNeedle = key + "=" + value + System.lineSeparator() + needleProperties;
+    projectRepository.replaceText(project, getPath(folderProperties, "config"), fileProperties, needleProperties, propertiesWithNeedle);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulDomainService.java
@@ -7,8 +7,6 @@ import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAM
 import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.*;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBootDomainService.CONFIG_FOLDER;
 
-import java.util.LinkedHashMap;
-import java.util.Map;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
@@ -44,44 +42,8 @@ public class ConsulDomainService implements ConsulService {
   public void addProperties(Project project) {
     project.addDefaultConfig(BASE_NAME);
 
-    projectRepository.template(project, getPath(SOURCE, "src"), "bootstrap.properties", getPath(MAIN_RESOURCES, CONFIG_FOLDER));
-    projectRepository.template(project, getPath(SOURCE, "src"), "bootstrap-fast.properties", getPath(MAIN_RESOURCES, CONFIG_FOLDER));
-    projectRepository.template(project, getPath(SOURCE, "test"), "bootstrap.properties", getPath(TEST_RESOURCES, CONFIG_FOLDER));
-
-    properties().forEach((k, v) -> addProperty(project, k, v, MAIN_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_PROPERTIES));
-
-    addProperty(
-      project,
-      "spring.cloud.consul.enabled",
-      "false",
-      MAIN_RESOURCES,
-      BOOTSTRAP_FAST_PROPERTIES,
-      NEEDLE_BOOTSTRAP_FAST_PROPERTIES
-    );
-    addProperty(project, "spring.cloud.consul.enabled", "false", TEST_RESOURCES, BOOTSTRAP_PROPERTIES, NEEDLE_BOOTSTRAP_TEST_PROPERTIES);
-  }
-
-  private Map<String, Object> properties() {
-    Map<String, Object> result = new LinkedHashMap<>();
-
-    result.put("spring.cloud.consul.discovery.health-check-path", "/management/health");
-    result.put("spring.cloud.consul.discovery.tags[0]", "version=@project.version@");
-    result.put("spring.cloud.consul.discovery.tags[1]", "context-path=\\$\\{server.servlet.context-path:\\}");
-    result.put("spring.cloud.consul.host", "localhost");
-    result.put("spring.cloud.consul.port", 8500);
-
-    return result;
-  }
-
-  private void addProperty(
-    Project project,
-    String key,
-    Object value,
-    String folderProperties,
-    String fileProperties,
-    String needleProperties
-  ) {
-    String propertiesWithNeedle = key + "=" + value + System.lineSeparator() + needleProperties;
-    projectRepository.replaceText(project, getPath(folderProperties, "config"), fileProperties, needleProperties, propertiesWithNeedle);
+    projectRepository.template(project, getPath(SOURCE, "src"), BOOTSTRAP_PROPERTIES, getPath(MAIN_RESOURCES, CONFIG_FOLDER));
+    projectRepository.template(project, getPath(SOURCE, "src"), BOOTSTRAP_FAST_PROPERTIES, getPath(MAIN_RESOURCES, CONFIG_FOLDER));
+    projectRepository.template(project, getPath(SOURCE, "test"), BOOTSTRAP_PROPERTIES, getPath(TEST_RESOURCES, CONFIG_FOLDER));
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulService.java
@@ -7,4 +7,5 @@ public interface ConsulService {
 
   void addDependencies(Project project);
   void addProperties(Project project);
+  void addDockerConsul(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/domain/ConsulService.java
@@ -1,0 +1,10 @@
+package tech.jhipster.lite.generator.server.springboot.consul.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface ConsulService {
+  void init(Project project);
+
+  void addDependencies(Project project);
+  void addProperties(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/config/ConsulBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/config/ConsulBeanConfiguration.java
@@ -1,0 +1,25 @@
+package tech.jhipster.lite.generator.server.springboot.consul.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.consul.domain.ConsulDomainService;
+import tech.jhipster.lite.generator.server.springboot.consul.domain.ConsulService;
+
+@Configuration
+public class ConsulBeanConfiguration {
+
+  private final BuildToolService buildToolService;
+  private final ProjectRepository projectRepository;
+
+  public ConsulBeanConfiguration(BuildToolService buildToolService, ProjectRepository projectRepository) {
+    this.buildToolService = buildToolService;
+    this.projectRepository = projectRepository;
+  }
+
+  @Bean
+  public ConsulService consulService() {
+    return new ConsulDomainService(buildToolService, projectRepository);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResource.java
@@ -12,7 +12,7 @@ import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDT
 import tech.jhipster.lite.generator.server.springboot.consul.application.ConsulApplicationService;
 
 @RestController
-@RequestMapping("/api/servers/spring-boot/cloud/consul")
+@RequestMapping("/api/servers/spring-boot/spring-cloud/consul")
 @Tag(name = "Spring Boot - Cloud")
 class ConsulResource {
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResource.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.consul.infrastructure.primary.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.consul.application.ConsulApplicationService;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/cloud/consul")
+@Tag(name = "Spring Boot - Cloud")
+class ConsulResource {
+
+  private final ConsulApplicationService consulApplicationService;
+
+  public ConsulResource(ConsulApplicationService consulApplicationService) {
+    this.consulApplicationService = consulApplicationService;
+  }
+
+  @Operation(summary = "Add Spring Cloud Consul config and discovery")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding Spring Cloud Consul config and discovery")
+  @PostMapping
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    consulApplicationService.init(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/consul/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.consul;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootDomainService.java
@@ -19,7 +19,6 @@ public class SpringBootDomainService implements SpringBootService {
 
   public static final String SOURCE = "server/springboot/core";
   public static final String SPRINGBOOT_PACKAGE = "org.springframework.boot";
-  public static final String CONFIG_FOLDER = "config";
 
   private final ProjectRepository projectRepository;
   private final BuildToolService buildToolService;

--- a/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
@@ -1,6 +1,5 @@
 #====================================================================
-# Spring Cloud Consul Config bootstrap configuration
+# Spring Cloud Consul Config bootstrap configuration for fast profile
 #====================================================================
 
-spring.application.name={{baseName}}
-# jhipster-needle-bootstrap-fast-properties
+spring.cloud.consul.enabled=false

--- a/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
@@ -2,4 +2,4 @@
 # Spring Cloud Consul Config bootstrap configuration for fast profile
 #====================================================================
 
-spring.cloud.consul.enabled=false
+spring.cloud.consul.config.fail-fast=false

--- a/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/bootstrap-fast.properties.mustache
@@ -1,0 +1,6 @@
+#====================================================================
+# Spring Cloud Consul Config bootstrap configuration
+#====================================================================
+
+spring.application.name={{baseName}}
+# jhipster-needle-bootstrap-fast-properties

--- a/src/main/resources/generator/server/springboot/consul/src/bootstrap.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/bootstrap.properties.mustache
@@ -1,0 +1,6 @@
+#====================================================================
+# Spring Cloud Consul Config bootstrap configuration
+#====================================================================
+
+spring.application.name={{baseName}}
+# jhipster-needle-bootstrap-properties

--- a/src/main/resources/generator/server/springboot/consul/src/bootstrap.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/bootstrap.properties.mustache
@@ -3,4 +3,8 @@
 #====================================================================
 
 spring.application.name={{baseName}}
-# jhipster-needle-bootstrap-properties
+spring.cloud.consul.discovery.health-check-path=/management/health
+spring.cloud.consul.discovery.tags[0]=version=@project.version@
+spring.cloud.consul.discovery.tags[1]=context-path=${server.servlet.context-path:}
+spring.cloud.consul.host=localhost
+spring.cloud.consul.port=8500

--- a/src/main/resources/generator/server/springboot/consul/src/consul.yml.mustache
+++ b/src/main/resources/generator/server/springboot/consul/src/consul.yml.mustache
@@ -1,0 +1,12 @@
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
+version: '3.8'
+services:
+  consul:
+    image: {{dockerConsulImage}}
+    # If you want to expose these ports outside your dev PC,
+    # remove the "127.0.0.1:" prefix
+    ports:
+      - 127.0.0.1:8300:8300
+      - 127.0.0.1:8500:8500
+      - 127.0.0.1:8600:8600
+    command: consul agent -dev -ui -client 0.0.0.0 -log-level=INFO

--- a/src/main/resources/generator/server/springboot/consul/test/bootstrap.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/test/bootstrap.properties.mustache
@@ -1,0 +1,6 @@
+#====================================================================
+# Spring Cloud Consul Config bootstrap configuration
+#====================================================================
+
+spring.application.name={{baseName}}
+# jhipster-needle-bootstrap-test-properties

--- a/src/main/resources/generator/server/springboot/consul/test/bootstrap.properties.mustache
+++ b/src/main/resources/generator/server/springboot/consul/test/bootstrap.properties.mustache
@@ -1,6 +1,5 @@
 #====================================================================
-# Spring Cloud Consul Config bootstrap configuration
+# Spring Cloud Consul Config bootstrap test configuration
 #====================================================================
 
-spring.application.name={{baseName}}
-# jhipster-needle-bootstrap-test-properties
+spring.cloud.consul.enabled=false

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
@@ -1,0 +1,69 @@
+package tech.jhipster.lite.generator.server.springboot.consul.application;
+
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertDependencies;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertProperties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class ConsulApplicationServiceIT {
+
+  @Autowired
+  ConsulApplicationService consulApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "foo");
+
+    initApplicationService.init(project);
+
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    consulApplicationService.init(project);
+
+    assertProperties(project);
+  }
+
+  @Test
+  void shouldAddDependencies() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    consulApplicationService.addDependencies(project);
+
+    assertDependencies(project);
+  }
+
+  @Test
+  void shouldAddProperties() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    consulApplicationService.addProperties(project);
+
+    assertProperties(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
@@ -40,6 +40,7 @@ class ConsulApplicationServiceIT {
 
     consulApplicationService.init(project);
 
+    assertDependencies(project);
     assertProperties(project);
   }
 

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulApplicationServiceIT.java
@@ -2,8 +2,7 @@ package tech.jhipster.lite.generator.server.springboot.consul.application;
 
 import static tech.jhipster.lite.TestUtils.tmpProject;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
-import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertDependencies;
-import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertProperties;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -42,6 +41,7 @@ class ConsulApplicationServiceIT {
 
     assertDependencies(project);
     assertProperties(project);
+    assertDockerConsul(project);
   }
 
   @Test
@@ -66,5 +66,18 @@ class ConsulApplicationServiceIT {
     consulApplicationService.addProperties(project);
 
     assertProperties(project);
+  }
+
+  @Test
+  void shouldAddDockerConsul() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    consulApplicationService.addDockerConsul(project);
+
+    assertDockerConsul(project);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -1,0 +1,85 @@
+package tech.jhipster.lite.generator.server.springboot.consul.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+
+import java.util.List;
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public class ConsulAssert {
+
+  public static void assertDependencies(Project project) {
+    // TODO test dependency management for spring-cloud
+
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.cloud</groupId>",
+        "<artifactId>spring-cloud-starter-bootstrap</artifactId>",
+        "</dependency>"
+      )
+    );
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.cloud</groupId>",
+        "<artifactId>spring-cloud-starter-consul-discovery</artifactId>",
+        "</dependency>"
+      )
+    );
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.cloud</groupId>",
+        "<artifactId>spring-cloud-starter-consul-config</artifactId>",
+        "</dependency>"
+      )
+    );
+  }
+
+  public static void assertProperties(Project project) {
+    assertFileExist(project, MAIN_RESOURCES, "config/bootstrap.properties");
+    assertFileExist(project, MAIN_RESOURCES, "config/bootstrap-fast.properties");
+    assertFileExist(project, TEST_RESOURCES, "config/bootstrap.properties");
+
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config/bootstrap.properties"),
+      List.of(
+        "spring.cloud.consul.config.enabled=true",
+        "spring.cloud.consul.host=localhost",
+        "spring.cloud.consul.port=8500"
+        // TODO other properties
+      )
+    );
+
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"),
+      List.of(
+        "spring.cloud.consul.config.enabled=false",
+        "spring.cloud.consul.discovery.enabled=false",
+        "spring.cloud.consul.enabled=false"
+      )
+    );
+
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, "config/bootstrap.properties"),
+      List.of(
+        "spring.cloud.consul.config.enabled=false",
+        "spring.cloud.consul.discovery.enabled=false",
+        "spring.cloud.consul.enabled=false"
+      )
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -5,6 +5,7 @@ import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
 import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.getSpringCloudVersion;
 
 import java.util.List;
 import tech.jhipster.lite.generator.project.domain.Project;
@@ -12,8 +13,21 @@ import tech.jhipster.lite.generator.project.domain.Project;
 public class ConsulAssert {
 
   public static void assertDependencies(Project project) {
-    // TODO test dependency management for spring-cloud
+    assertFileContent(project, "pom.xml", "<spring-cloud.version>" + getSpringCloudVersion() + "</spring-cloud.version>");
 
+    assertFileContent(
+      project,
+      "pom.xml",
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.cloud</groupId>",
+        "<artifactId>spring-cloud-dependencies</artifactId>",
+        "<version>${spring-cloud.version}</version>",
+        "<scope>import</scope>",
+        "<type>pom</type>",
+        "</dependency>"
+      )
+    );
     assertFileContent(
       project,
       "pom.xml",

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -70,30 +70,15 @@ public class ConsulAssert {
       getPath(MAIN_RESOURCES, "config/bootstrap.properties"),
       List.of(
         "spring.cloud.consul.discovery.health-check-path=/management/health",
+        "spring.cloud.consul.discovery.tags[0]=version=@project.version@",
+        "spring.cloud.consul.discovery.tags[1]=context-path=${server.servlet.context-path:}",
         "spring.cloud.consul.host=localhost",
         "spring.cloud.consul.port=8500"
-        // TODO other properties
       )
     );
 
-    assertFileContent(
-      project,
-      getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"),
-      List.of(
-        "spring.cloud.consul.config.enabled=false",
-        "spring.cloud.consul.discovery.enabled=false",
-        "spring.cloud.consul.enabled=false"
-      )
-    );
+    assertFileContent(project, getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"), "spring.cloud.consul.enabled=false");
 
-    assertFileContent(
-      project,
-      getPath(TEST_RESOURCES, "config/bootstrap.properties"),
-      List.of(
-        "spring.cloud.consul.config.enabled=false",
-        "spring.cloud.consul.discovery.enabled=false",
-        "spring.cloud.consul.enabled=false"
-      )
-    );
+    assertFileContent(project, getPath(TEST_RESOURCES, "config/bootstrap.properties"), "spring.cloud.consul.enabled=false");
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -77,7 +77,7 @@ public class ConsulAssert {
       )
     );
 
-    assertFileContent(project, getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"), "spring.cloud.consul.enabled=false");
+    assertFileContent(project, getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"), "spring.cloud.consul.config.fail-fast=false");
 
     assertFileContent(project, getPath(TEST_RESOURCES, "config/bootstrap.properties"), "spring.cloud.consul.enabled=false");
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -55,7 +55,7 @@ public class ConsulAssert {
       project,
       getPath(MAIN_RESOURCES, "config/bootstrap.properties"),
       List.of(
-        "spring.cloud.consul.config.enabled=true",
+        "spring.cloud.consul.discovery.health-check-path=/management/health",
         "spring.cloud.consul.host=localhost",
         "spring.cloud.consul.port=8500"
         // TODO other properties

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/application/ConsulAssert.java
@@ -5,6 +5,7 @@ import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
 import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.getDockerConsulImage;
 import static tech.jhipster.lite.generator.server.springboot.consul.domain.Consul.getSpringCloudVersion;
 
 import java.util.List;
@@ -80,5 +81,11 @@ public class ConsulAssert {
     assertFileContent(project, getPath(MAIN_RESOURCES, "config/bootstrap-fast.properties"), "spring.cloud.consul.config.fail-fast=false");
 
     assertFileContent(project, getPath(TEST_RESOURCES, "config/bootstrap.properties"), "spring.cloud.consul.enabled=false");
+  }
+
+  public static void assertDockerConsul(Project project) {
+    assertFileExist(project, "src/main/docker/consul.yml");
+
+    assertFileContent(project, "src/main/docker/consul.yml", getDockerConsulImage());
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/config/ConsulBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/config/ConsulBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.consul.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.consul.domain.ConsulDomainService;
+
+@IntegrationTest
+class ConsulBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("consulService")).isNotNull().isInstanceOf(ConsulDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
@@ -1,0 +1,62 @@
+package tech.jhipster.lite.generator.server.springboot.consul.infrastructure.primary.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertDependencies;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertProperties;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class ConsulResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldInit() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/cloud/consul")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    assertDependencies(project);
+    assertProperties(project);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
@@ -2,8 +2,7 @@ package tech.jhipster.lite.generator.server.springboot.consul.infrastructure.pri
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertDependencies;
-import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.assertProperties;
+import static tech.jhipster.lite.generator.server.springboot.consul.application.ConsulAssert.*;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,5 +57,6 @@ class ConsulResourceIT {
 
     assertDependencies(project);
     assertProperties(project);
+    assertDockerConsul(project);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/consul/infrastructure/primary/rest/ConsulResourceIT.java
@@ -50,7 +50,7 @@ class ConsulResourceIT {
 
     mockMvc
       .perform(
-        post("/api/servers/spring-boot/cloud/consul")
+        post("/api/servers/spring-boot/spring-cloud/consul")
           .contentType(MediaType.APPLICATION_JSON)
           .content(TestUtils.convertObjectToJsonBytes(projectDTO))
       )

--- a/tests-ci/config/undertow-consul.json
+++ b/tests-ci/config/undertow-consul.json
@@ -1,0 +1,9 @@
+{
+  "folder": "/tmp/jhlite/undertow-consul",
+  "generator-jhipster": {
+    "projectName": "Beer Project",
+    "baseName": "beer",
+    "prettierDefaultIndent": 2,
+    "packageName": "tech.jhipster.beer"
+  }
+}

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -91,7 +91,7 @@ elif [[ $filename == 'undertow-consul' ]]; then
   callApi "/api/servers/spring-boot/mvc/web/actuator"
   callApi "/api/servers/spring-boot/mvc/security/jwt"
   callApi "/api/servers/spring-boot/mvc/security/jwt/basic-auth"
-  callApi "/api/servers/spring-boot/cloud/consul"
+  callApi "/api/servers/spring-boot/spring-cloud/consul"
   callApi "/api/servers/sonar"
 
 else

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -79,6 +79,21 @@ elif [[ $filename == 'undertow-mysql-simplecache' ]]; then
   callApi "/api/servers/spring-boot/cache/simple"
   callApi "/api/servers/sonar"
 
+elif [[ $filename == 'undertow-consul' ]]; then
+  callApi "/api/projects/init"
+  callApi "/api/build-tools/maven"
+  callApi "/api/servers/java/base"
+  callApi "/api/servers/java/jacoco-minimum-coverage"
+  callApi "/api/servers/spring-boot"
+  callApi "/api/servers/spring-boot/devtools"
+  callApi "/api/servers/spring-boot/banner/jhipster-v3"
+  callApi "/api/servers/spring-boot/mvc/web/undertow"
+  callApi "/api/servers/spring-boot/mvc/web/actuator"
+  callApi "/api/servers/spring-boot/mvc/security/jwt"
+  callApi "/api/servers/spring-boot/mvc/security/jwt/basic-auth"
+  callApi "/api/servers/spring-boot/cloud/consul"
+  callApi "/api/servers/sonar"
+
 else
   echo "*** Unknown configuration..."
   exit 1


### PR DESCRIPTION
fixes #281 

- [x] Consul bootstrap, config and discovery base
- [x] Add Spring Cloud to dependency management
- [x] Add more Consul properties
- [x] Use the same group as #279 - "spring-cloud"
- [x] Add Docker Consul (without jhipster/consul-config-loader)