### PR TITLE
maven resources filtering config to template (bis)

### DIFF
--- a/src/main/resources/generator/buildtool/maven/pom.xml.mustache
+++ b/src/main/resources/generator/buildtool/maven/pom.xml.mustache
@@ -66,6 +66,21 @@
   </dependencies>
 
   <build>
+    <resources>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+        <filtering>true</filtering>
+        <includes>
+          <include>config/*.properties</include>
+        </includes>
+      </resource>
+      <resource>
+        <directory>${basedir}/src/main/resources</directory>
+        <excludes>
+          <exclude>config/*.properties</exclude>
+        </excludes>
+      </resource>
+    </resources>
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
same as #436 but this time in the pom.xml **template** as it's needed on the generated side.

I didn't revert the addition on the generator side, as it also makes sense after all...