### PR TITLE
Fix integrations tests

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
@@ -156,6 +156,7 @@ public class MySQLDomainService implements MySQLService {
     result.put("spring.datasource.url", "jdbc:tc:" + MySQL.getDockerImageName() + ":///" + baseName);
     result.put("spring.datasource.username", baseName);
     result.put("spring.datasource.password", "");
+    result.put("spring.datasource.hikari.maximum-pool-size", 2);
     return result;
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
@@ -190,6 +190,7 @@ public class PostgresqlDomainService implements PostgresqlService {
     );
     result.put("spring.datasource.username", baseName);
     result.put("spring.datasource.password", "");
+    result.put("spring.datasource.hikari.maximum-pool-size", 2);
     return result;
   }
 

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/test/LiquibaseConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/test/LiquibaseConfigurationIT.java.mustache
@@ -9,15 +9,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class LiquibaseConfigurationIT {
-
-  @Autowired
-  ApplicationContext applicationContext;
 
   @Nested
   @IntegrationTest(properties = { "application.liquibase.async=true" })
   class Async {
+
+    @Autowired
+    ApplicationContext applicationContext;
 
     @Test
     void shouldGetLiquibaseAsync() {
@@ -30,6 +29,9 @@ class LiquibaseConfigurationIT {
   @Nested
   @IntegrationTest(properties = { "application.liquibase.async=false" })
   class Sync {
+
+    @Autowired
+    ApplicationContext applicationContext;
 
     @Test
     void shouldGetLiquibaseSync() {

--- a/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/tcp/test/LogstashTcpConfigurationIT.java.mustache
@@ -19,7 +19,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationContext;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class LogstashTcpConfigurationIT {
 
   @Nested

--- a/src/main/resources/generator/server/springboot/mvc/security/jwt/test/CorsFilterConfigurationIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/jwt/test/CorsFilterConfigurationIT.java.mustache
@@ -9,7 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.filter.CorsFilter;
 import {{packageName}}.IntegrationTest;
 
-@IntegrationTest
 class CorsFilterConfigurationIT {
 
   @Nested


### PR DESCRIPTION
- fix duplicate `@IntegrationTest` on both enclosing class and inner class (probably not the cause of the problem, but...)
- limit hikari max pool size during tests (testcontainer-postgresql was complaining about too much connections during testing)