### PR TITLE
improve line separator handling

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -148,3 +148,6 @@ Procfile        text
 *.otf           binary
 *.woff          binary
 *.woff2         binary
+
+# git patch
+*.patch         text eol=lf

--- a/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/FileUtils.java
@@ -1,14 +1,13 @@
 package tech.jhipster.lite.common.domain;
 
-import java.io.File;
-import java.io.IOException;
-import java.io.InputStream;
+import java.io.*;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.FileSystems;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
+import java.util.Optional;
 import java.util.Scanner;
 import java.util.UUID;
 import java.util.regex.Pattern;
@@ -136,5 +135,24 @@ public class FileUtils {
 
   public static boolean isPosix() {
     return FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
+  }
+
+  public static Optional<String> detectEndOfLine(String filename) throws IOException {
+    try (BufferedReader reader = new BufferedReader(new InputStreamReader(new FileInputStream(filename), StandardCharsets.UTF_8))) {
+      char previousChar = 0;
+      char currentChar;
+      int read;
+      while ((read = reader.read()) != -1) {
+        currentChar = (char) read;
+        if (currentChar == '\n') {
+          if (previousChar == '\r') {
+            return Optional.of(WordUtils.CRLF);
+          }
+          return Optional.of(WordUtils.LF);
+        }
+        previousChar = currentChar;
+      }
+    }
+    return Optional.empty();
   }
 }

--- a/src/main/java/tech/jhipster/lite/common/domain/WordUtils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/WordUtils.java
@@ -5,6 +5,9 @@ import tech.jhipster.lite.error.domain.Assert;
 
 public class WordUtils {
 
+  public static final String LF = "\n";
+  public static final String CRLF = "\r\n";
+
   public static final int DEFAULT_INDENTATION = 2;
   public static final String DQ = "\"";
 

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
@@ -1,5 +1,6 @@
 package tech.jhipster.lite.generator.buildtool.maven.domain;
 
+import static tech.jhipster.lite.common.domain.WordUtils.LF;
 import static tech.jhipster.lite.common.domain.WordUtils.indent;
 
 import java.util.List;
@@ -67,17 +68,17 @@ public class Maven {
   public static String getParentHeader(Parent parent, int indentation) {
     StringBuilder result = new StringBuilder()
       .append(PARENT_BEGIN)
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(2, indentation))
       .append(GROUP_ID_BEGIN)
       .append(parent.getGroupId())
       .append(GROUP_ID_END)
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(2, indentation))
       .append(ARTIFACT_ID_BEGIN)
       .append(parent.getArtifactId())
       .append(ARTIFACT_ID_END)
-      .append(System.lineSeparator());
+      .append(LF);
     return result.toString();
   }
 
@@ -88,10 +89,10 @@ public class Maven {
       .append(VERSION_BEGIN)
       .append(parent.getVersion())
       .append(VERSION_END)
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(2, indentation))
       .append("<relativePath />")
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(1, indentation))
       .append(PARENT_END);
 
@@ -103,17 +104,17 @@ public class Maven {
   }
 
   public static String getDependencyHeader(Dependency dependency, int indentation) {
-    String begin = DEPENDENCY_BEGIN + "\n";
+    String begin = DEPENDENCY_BEGIN + LF;
 
     String content = new StringBuilder()
       .append(GROUP_ID_BEGIN)
       .append(dependency.getGroupId())
       .append(GROUP_ID_END)
-      .append("\n")
+      .append(LF)
       .append(ARTIFACT_ID_BEGIN)
       .append(dependency.getArtifactId())
       .append(ARTIFACT_ID_END)
-      .append("\n")
+      .append(LF)
       .toString()
       .indent(indentation);
 
@@ -126,19 +127,19 @@ public class Maven {
     StringBuilder additionalBodyBuilder = new StringBuilder();
 
     if (dependency.isOptional()) {
-      additionalBodyBuilder.append(OPTIONAL).append("\n");
+      additionalBodyBuilder.append(OPTIONAL).append(LF);
     }
 
     dependency
       .getVersion()
-      .ifPresent(version -> additionalBodyBuilder.append(VERSION_BEGIN).append(version).append(VERSION_END).append("\n"));
+      .ifPresent(version -> additionalBodyBuilder.append(VERSION_BEGIN).append(version).append(VERSION_END).append(LF));
 
-    dependency.getScope().ifPresent(scope -> additionalBodyBuilder.append(SCOPE_BEGIN).append(scope).append(SCOPE_END).append("\n"));
+    dependency.getScope().ifPresent(scope -> additionalBodyBuilder.append(SCOPE_BEGIN).append(scope).append(SCOPE_END).append(LF));
 
-    dependency.getType().ifPresent(type -> additionalBodyBuilder.append(TYPE_BEGIN).append(type).append(TYPE_END).append("\n"));
+    dependency.getType().ifPresent(type -> additionalBodyBuilder.append(TYPE_BEGIN).append(type).append(TYPE_END).append(LF));
 
     if (exclusions != null && !exclusions.isEmpty()) {
-      additionalBodyBuilder.append(getExclusions(exclusions, indentation)).append("\n");
+      additionalBodyBuilder.append(getExclusions(exclusions, indentation)).append(LF);
     }
 
     String additionalBody = additionalBodyBuilder.toString().indent(indentation);
@@ -147,17 +148,17 @@ public class Maven {
   }
 
   public static String getExclusion(Dependency exclusion, int indentation) {
-    String begin = EXCLUSION_BEGIN + "\n";
+    String begin = EXCLUSION_BEGIN + LF;
 
     String body = new StringBuilder()
       .append(GROUP_ID_BEGIN)
       .append(exclusion.getGroupId())
       .append(GROUP_ID_END)
-      .append("\n")
+      .append(LF)
       .append(ARTIFACT_ID_BEGIN)
       .append(exclusion.getArtifactId())
       .append(ARTIFACT_ID_END)
-      .append("\n")
+      .append(LF)
       .toString()
       .indent(indentation);
 
@@ -165,12 +166,12 @@ public class Maven {
   }
 
   public static String getExclusions(List<Dependency> exclusions, int indentation) {
-    String begin = EXCLUSIONS_BEGIN + "\n";
+    String begin = EXCLUSIONS_BEGIN + LF;
 
     String body = exclusions
       .stream()
       .map(exclusion -> getExclusion(exclusion, indentation))
-      .collect(Collectors.joining("\n"))
+      .collect(Collectors.joining(LF))
       .indent(indentation);
 
     return begin + body + EXCLUSIONS_END;
@@ -211,17 +212,17 @@ public class Maven {
   public static String getPluginHeader(Plugin plugin, int indentation, int initialIndentation) {
     StringBuilder result = new StringBuilder()
       .append(PLUGIN_BEGIN)
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(initialIndentation + 1, indentation))
       .append(GROUP_ID_BEGIN)
       .append(plugin.getGroupId())
       .append(GROUP_ID_END)
-      .append(System.lineSeparator())
+      .append(LF)
       .append(indent(initialIndentation + 1, indentation))
       .append(ARTIFACT_ID_BEGIN)
       .append(plugin.getArtifactId())
       .append(ARTIFACT_ID_END)
-      .append(System.lineSeparator());
+      .append(LF);
     return result.toString();
   }
 
@@ -231,22 +232,13 @@ public class Maven {
     plugin
       .getVersion()
       .ifPresent(version ->
-        result
-          .append(indent(initialIndentation + 1, indentation))
-          .append(VERSION_BEGIN)
-          .append(version)
-          .append(VERSION_END)
-          .append(System.lineSeparator())
+        result.append(indent(initialIndentation + 1, indentation)).append(VERSION_BEGIN).append(version).append(VERSION_END).append(LF)
       );
 
     //replace '\n' to make the multi-line additionalConfiguration platform specific
     plugin
       .getAdditionalElements()
-      .ifPresent(additionalElements ->
-        result.append(
-          plugin.getAdditionalElements().get().indent((initialIndentation + 1) * indentation).replace("\n", System.lineSeparator())
-        )
-      );
+      .ifPresent(additionalElements -> result.append(plugin.getAdditionalElements().get().indent((initialIndentation + 1) * indentation)));
 
     result.append(indent(initialIndentation, indentation)).append(PLUGIN_END);
 

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
@@ -1,8 +1,7 @@
 package tech.jhipster.lite.generator.buildtool.maven.domain;
 
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.common.domain.WordUtils.DEFAULT_INDENTATION;
-import static tech.jhipster.lite.common.domain.WordUtils.indent;
+import static tech.jhipster.lite.common.domain.WordUtils.*;
 import static tech.jhipster.lite.generator.buildtool.maven.domain.Maven.*;
 import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.*;
@@ -29,10 +28,11 @@ public class MavenDomainService implements MavenService {
   @Override
   public void addParent(Project project, Parent parent) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
-    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
 
-    String parentNode = Maven.getParent(parent, indent);
-    String parentHeaderNode = Maven.getParentHeader(parent, indent);
+    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
+
+    String parentNode = Maven.getParent(parent, indent).replace(LF, project.getEndOfLine());
+    String parentHeaderNode = Maven.getParentHeader(parent, indent).replace(LF, project.getEndOfLine());
     String parentHeaderRegexp = FileUtils.REGEXP_PREFIX_MULTILINE + parentHeaderNode;
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, parentHeaderRegexp)) {
@@ -61,17 +61,20 @@ public class MavenDomainService implements MavenService {
   }
 
   private void addDependency(Project project, Dependency dependency, List<Dependency> exclusions, String needle) {
+    project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
+
     int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
+
     int level = NEEDLE_DEPENDENCY_MANAGEMENT.equals(needle) ? 3 : 2;
 
     String dependencyNode = Maven.getDependencyHeader(dependency, indent).indent(2 * indent);
-    String dependencyRegexp = (FileUtils.REGEXP_PREFIX_MULTILINE + dependencyNode).replace("\n", System.lineSeparator());
+    String dependencyRegexp = (FileUtils.REGEXP_PREFIX_MULTILINE + dependencyNode).replace(LF, project.getEndOfLine());
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, dependencyRegexp)) {
       project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
 
       String newDependencyNode = Maven.getDependency(dependency, indent, exclusions).indent(level * indent);
-      String dependencyWithNeedle = (newDependencyNode + indent(level, indent) + needle).replace("\n", System.lineSeparator());
+      String dependencyWithNeedle = (newDependencyNode + indent(level, indent) + needle).replace(LF, project.getEndOfLine());
 
       projectRepository.replaceText(project, "", POM_XML, "[ \t]*" + needle, dependencyWithNeedle);
     }
@@ -80,12 +83,14 @@ public class MavenDomainService implements MavenService {
   @Override
   public void deleteDependency(Project project, Dependency dependency) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
+
     int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
+
     Dependency dependencyToDelete = Dependency.builder().groupId(dependency.getGroupId()).artifactId(dependency.getArtifactId()).build();
 
     String dependencyNode = Maven.getDependency(dependencyToDelete, indent).indent(2 * indent);
     String endNode = indent(2, indent) + "</dependency>";
-    String dependencyNodeRegExp = ("(?s)" + dependencyNode.replace(endNode, ".*" + endNode)).replace("\n", System.lineSeparator());
+    String dependencyNodeRegExp = ("(?s)" + dependencyNode.replace(endNode, ".*" + endNode)).replace(LF, project.getEndOfLine());
 
     projectRepository.replaceRegexp(project, "", POM_XML, dependencyNodeRegExp, "");
   }
@@ -93,7 +98,8 @@ public class MavenDomainService implements MavenService {
   @Override
   public void addPlugin(Project project, Plugin plugin) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
-    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
+
+    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
 
     String pluginNodeNode = Maven.getPluginHeader(plugin, indent);
 
@@ -102,7 +108,7 @@ public class MavenDomainService implements MavenService {
       FileUtils.REGEXP_PREFIX_DOTALL + PLUGIN_BEGIN + FileUtils.DOT_STAR_REGEX + pluginNodeNode + FileUtils.DOT_STAR_REGEX + NEEDLE_PLUGIN;
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, pluginRegexp)) {
-      String pluginWithNeedle = Maven.getPlugin(plugin, indent) + System.lineSeparator() + indent(3, indent) + NEEDLE_PLUGIN;
+      String pluginWithNeedle = Maven.getPlugin(plugin, indent) + project.getEndOfLine() + indent(3, indent) + NEEDLE_PLUGIN;
 
       projectRepository.replaceText(project, "", POM_XML, NEEDLE_PLUGIN, pluginWithNeedle);
     }
@@ -111,7 +117,8 @@ public class MavenDomainService implements MavenService {
   @Override
   public void addPluginManagement(Project project, Plugin plugin) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
-    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
+
+    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
 
     String pluginNodeNode = Maven.getPluginManagementHeader(plugin, indent);
     //Checking for plugin declaration in <pluginManagement> section
@@ -125,7 +132,7 @@ public class MavenDomainService implements MavenService {
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, pluginRegexp)) {
       String pluginWithNeedle =
-        Maven.getPluginManagement(plugin, indent) + System.lineSeparator() + indent(4, indent) + NEEDLE_PLUGIN_MANAGEMENT;
+        Maven.getPluginManagement(plugin, indent) + project.getEndOfLine() + indent(4, indent) + NEEDLE_PLUGIN_MANAGEMENT;
 
       projectRepository.replaceText(project, "", POM_XML, NEEDLE_PLUGIN_MANAGEMENT, pluginWithNeedle);
     }
@@ -134,12 +141,13 @@ public class MavenDomainService implements MavenService {
   @Override
   public void addProperty(Project project, String key, String version) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
-    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
+
+    int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
 
     String pluginRegexp = Maven.getProperty(key, ".*");
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, pluginRegexp)) {
-      String propertyWithNeedle = Maven.getProperty(key, version) + System.lineSeparator() + indent(2, indent) + NEEDLE_PROPERTIES;
+      String propertyWithNeedle = Maven.getProperty(key, version) + project.getEndOfLine() + indent(2, indent) + NEEDLE_PROPERTIES;
 
       projectRepository.replaceText(project, "", POM_XML, NEEDLE_PROPERTIES, propertyWithNeedle);
     }
@@ -149,7 +157,7 @@ public class MavenDomainService implements MavenService {
   public void deleteProperty(Project project, String key) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
 
-    String propertyNode = Maven.getProperty(key, ".*") + System.lineSeparator();
+    String propertyNode = Maven.getProperty(key, ".*") + project.getEndOfLine();
 
     projectRepository.replaceText(project, "", POM_XML, propertyNode, "");
   }

--- a/src/main/java/tech/jhipster/lite/generator/init/domain/InitDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/init/domain/InitDomainService.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.init.domain;
 
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.common.domain.WordUtils.CRLF;
 import static tech.jhipster.lite.generator.project.domain.Constants.PACKAGE_JSON;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.*;
 
@@ -57,7 +58,9 @@ public class InitDomainService implements InitService {
   public void addEditorConfiguration(Project project) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
 
+    project.addConfig("editorConfigEndOfLine", CRLF.equals(project.getEndOfLine()) ? "crlf" : "lf");
     projectRepository.template(project, SOURCE, ".editorconfig");
+
     projectRepository.add(project, SOURCE, ".eslintignore");
   }
 
@@ -67,6 +70,8 @@ public class InitDomainService implements InitService {
     projectRepository.add(project, SOURCE, ".prettierignore");
     projectRepository.add(project, getPath(SOURCE, HUSKY_FOLDER), "pre-commit", HUSKY_FOLDER);
     projectRepository.setExecutable(project, HUSKY_FOLDER, "pre-commit");
+
+    project.addConfig("prettierEndOfLine", CRLF.equals(project.getEndOfLine()) ? "crlf" : "lf");
     projectRepository.template(project, SOURCE, ".prettierrc");
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/project/domain/DefaultConfig.java
+++ b/src/main/java/tech/jhipster/lite/generator/project/domain/DefaultConfig.java
@@ -1,5 +1,7 @@
 package tech.jhipster.lite.generator.project.domain;
 
+import static tech.jhipster.lite.common.domain.WordUtils.DEFAULT_INDENTATION;
+
 import java.util.Map;
 import java.util.Optional;
 
@@ -15,7 +17,7 @@ public class DefaultConfig {
     BASE_NAME, "jhipster",
     PROJECT_NAME, "JHipster Project",
     PACKAGE_NAME, "com.mycompany.myapp",
-    PRETTIER_DEFAULT_INDENT, 2
+    PRETTIER_DEFAULT_INDENT, DEFAULT_INDENTATION
   );
 
   public static final String PACKAGE_PATH = "com/mycompany/myapp";

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
@@ -64,9 +64,10 @@ public class LiquibaseDomainService implements LiquibaseService {
   @Override
   public void addChangelogXml(Project project, String path, String fileName) {
     int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(2);
+
     String includeLine = new StringBuilder()
       .append(Liquibase.getIncludeLine(path, fileName))
-      .append(System.lineSeparator())
+      .append(project.getEndOfLine())
       .append(indent(1, indent))
       .append(NEEDLE_LIQUIBASE)
       .toString();

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/domain/SpringBootLoggingDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/domain/SpringBootLoggingDomainService.java
@@ -35,7 +35,7 @@ public class SpringBootLoggingDomainService implements SpringBootLoggingService 
     String needleLogger
   ) {
     String loggerWithNeedle =
-      String.format("<logger name=\"%s\" level=\"%s\" />", packageName, level.toString()) + System.lineSeparator() + "  " + needleLogger;
+      String.format("<logger name=\"%s\" level=\"%s\" />", packageName, level.toString()) + project.getEndOfLine() + "  " + needleLogger;
     projectRepository.replaceText(project, getPath(folderConfig), fileLoggingConfig, needleLogger, loggerWithNeedle);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/properties/domain/SpringBootPropertiesDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/properties/domain/SpringBootPropertiesDomainService.java
@@ -39,7 +39,7 @@ public class SpringBootPropertiesDomainService implements SpringBootPropertiesSe
     String fileProperties,
     String needleProperties
   ) {
-    String propertiesWithNeedle = key + "=" + value + System.lineSeparator() + needleProperties;
+    String propertiesWithNeedle = key + "=" + value + project.getEndOfLine() + needleProperties;
     projectRepository.replaceText(project, getPath(folderProperties, "config"), fileProperties, needleProperties, propertiesWithNeedle);
   }
 }

--- a/src/main/resources/generator/init/.editorconfig.mustache
+++ b/src/main/resources/generator/init/.editorconfig.mustache
@@ -7,7 +7,7 @@ root = true
 [*]
 
 # We recommend you to keep these unchanged
-end_of_line = lf
+end_of_line = {{editorConfigEndOfLine}}
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true

--- a/src/main/resources/generator/init/.prettierrc.mustache
+++ b/src/main/resources/generator/init/.prettierrc.mustache
@@ -4,6 +4,7 @@ printWidth: 140
 singleQuote: true
 tabWidth: {{prettierDefaultIndent}}{{^prettierDefaultIndent}}2{{/prettierDefaultIndent}}
 useTabs: false
+endOfLine: "{{prettierEndOfLine}}"
 
 # js and ts rules:
 arrowParens: avoid

--- a/src/main/resources/generator/init/gitattributes
+++ b/src/main/resources/generator/init/gitattributes
@@ -1,7 +1,6 @@
 # This file is inspired by https://github.com/alexkaratarakis/gitattributes
 #
 # Auto detect text files and perform LF normalization
-# http://davidlaing.com/2012/09/19/customise-your-gitattributes-to-become-a-git-ninja/
 * text=auto
 
 # The above will handle all files NOT found below

--- a/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
+++ b/src/test/java/tech/jhipster/lite/common/domain/FileUtilsTest.java
@@ -1,13 +1,10 @@
 package tech.jhipster.lite.common.domain;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
 import static tech.jhipster.lite.TestUtils.assertFileNotExist;
 import static tech.jhipster.lite.common.domain.FileUtils.*;
+import static tech.jhipster.lite.common.domain.WordUtils.LF;
 
 import java.io.File;
 import java.io.IOException;
@@ -144,6 +141,34 @@ class FileUtilsTest {
   }
 
   @Nested
+  class DetectEndOfLineTest {
+
+    @Test
+    void shouldDetectLf() throws Exception {
+      Path tempFile = Files.createTempFile("detect-lf", null);
+      Files.writeString(tempFile, "my little file \nwith lf");
+
+      assertThat(detectEndOfLine(tempFile.toString())).hasValue(LF);
+    }
+
+    @Test
+    void shouldDetectCrLf() throws Exception {
+      Path tempFile = Files.createTempFile("detect-crlf", null);
+      Files.writeString(tempFile, "my little file \r\nwith crlf");
+
+      assertThat(detectEndOfLine(tempFile.toString())).hasValue(WordUtils.CRLF);
+    }
+
+    @Test
+    void shouldNotDetectEndOfLine() throws Exception {
+      Path tempFile = Files.createTempFile("detect-none", null);
+      Files.writeString(tempFile, "my little file without new line");
+
+      assertThat(detectEndOfLine(tempFile.toString())).isEmpty();
+    }
+  }
+
+  @Nested
   class ReadTest {
 
     @Test
@@ -152,7 +177,7 @@ class FileUtilsTest {
 
       String result = FileUtils.read(filename);
 
-      String lineSeparator = System.lineSeparator();
+      String lineSeparator = detectEndOfLine(filename).orElse("\0");
       String expectedResult = new StringBuilder()
         .append("this is a short readme")
         .append(lineSeparator)
@@ -314,7 +339,7 @@ class FileUtilsTest {
 
       String result = FileUtils.replaceInFile(filename, "powered by JHipster \uD83E\uDD13", "Hello JHipster Lite");
 
-      String lineSeparator = System.lineSeparator();
+      String lineSeparator = detectEndOfLine(filename).orElse("\0");
       String expectedResult = new StringBuilder()
         .append("this is a short readme")
         .append(lineSeparator)
@@ -354,14 +379,13 @@ class FileUtilsTest {
 
     @Test
     void shouldContainMultiLineTextOneLineRegexp() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
 
       assertTrue(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_DOTALL + "short.*for unit"));
@@ -369,14 +393,13 @@ class FileUtilsTest {
 
     @Test
     void shouldNotContainMultiLineTextOneLineRegexp() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
 
       assertFalse(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_DOTALL + "JHipster.*for unit"));
@@ -384,73 +407,64 @@ class FileUtilsTest {
 
     @Test
     void shouldContainMultiLineTextMultiLineRegexp() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
-      String regexp = new StringBuilder().append("used for unit tests").append(lineSeparator).append("Hello J.* Lite").toString();
+      String regexp = new StringBuilder().append("used for unit tests").append(LF).append("Hello J.* Lite").toString();
 
       assertTrue(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_DOTALL + regexp));
     }
 
     @Test
     void shouldNotContainMultiLineTextMultiLineRegexp() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
-      String regexp = new StringBuilder().append("used for unit tests").append(lineSeparator).append("Hello W.* Lite").toString();
+      String regexp = new StringBuilder().append("used for unit tests").append(LF).append("Hello W.* Lite").toString();
 
       assertFalse(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_DOTALL + regexp));
     }
 
     @Test
     void shouldContainMultiLineTextMultiLineText() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
-      String searchText = new StringBuilder()
-        .append("used for unit tests")
-        .append(lineSeparator)
-        .append("Hello JHipster Lite")
-        .append(lineSeparator)
-        .toString();
+      String searchText = new StringBuilder().append("used for unit tests").append(LF).append("Hello JHipster Lite").append(LF).toString();
 
       assertTrue(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_MULTILINE + searchText));
     }
 
     @Test
     void shouldNotContainMultiLineTextMultiLineText() {
-      String lineSeparator = System.lineSeparator();
       String text = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("used for unit tests")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
       String searchText = new StringBuilder()
         .append("this is a short readme")
-        .append(lineSeparator)
+        .append(LF)
         .append("Hello JHipster Lite")
-        .append(lineSeparator)
+        .append(LF)
         .toString();
 
       assertFalse(FileUtils.containsRegexp(text, FileUtils.REGEXP_PREFIX_MULTILINE + searchText));
@@ -478,8 +492,8 @@ class FileUtilsTest {
     void shouldCountManyItemMultiLineRegexp() throws Exception {
       String filename = getPath("src/test/resources/generator/utils/example-readme.md");
 
-      String lineSeparator = System.lineSeparator();
-      String regexp = new StringBuilder().append("```").append(lineSeparator).append("./mv.?w clean").toString();
+      String lineSeparator = detectEndOfLine(filename).orElse("\0");
+      String regexp = new StringBuilder().append("```").append(LF).append("./mv.?w clean").toString();
 
       assertEquals(2, FileUtils.countsRegexp(filename, FileUtils.REGEXP_PREFIX_DOTALL + regexp));
     }
@@ -488,8 +502,8 @@ class FileUtilsTest {
     void shouldCountNoItemMultiLineRegexp() throws Exception {
       String filename = getPath("src/test/resources/generator/utils/example-readme.md");
 
-      String lineSeparator = System.lineSeparator();
-      String regexp = new StringBuilder().append("```").append(lineSeparator).append("np.? ci").toString();
+      String lineSeparator = detectEndOfLine(filename).orElse("\0");
+      String regexp = new StringBuilder().append("```").append(LF).append("np.? ci").toString();
 
       assertEquals(0, FileUtils.countsRegexp(filename, FileUtils.REGEXP_PREFIX_DOTALL + regexp));
     }

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
@@ -175,12 +175,7 @@ class MavenApplicationServiceIT {
     mavenApplicationService.addDependency(project, dependency);
     mavenApplicationService.addDependency(project, dependency);
 
-    assertFileContentManyTimes(
-      project,
-      POM_XML,
-      Maven.getDependencyHeader(dependency, 2).indent(4).replace("\n", System.lineSeparator()),
-      1
-    );
+    assertFileContentManyTimes(project, POM_XML, Maven.getDependencyHeader(dependency, 2).indent(4), 1);
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
@@ -17,12 +17,13 @@ class MavenTest {
   void shouldGetParent() {
     // @formatter:off
     String expected =
-      "<parent>" + System.lineSeparator() +
-      "    <groupId>org.springframework.boot</groupId>" + System.lineSeparator() +
-      "    <artifactId>spring-boot-starter-parent</artifactId>" + System.lineSeparator() +
-      "    <version>2.5.3</version>" + System.lineSeparator() +
-      "    <relativePath />" + System.lineSeparator() +
-      "  </parent>";
+      """
+        <parent>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-parent</artifactId>
+            <version>2.5.3</version>
+            <relativePath />
+          </parent>""";
     // @formatter:on
     Parent parent = Parent.builder().groupId("org.springframework.boot").artifactId("spring-boot-starter-parent").version("2.5.3").build();
 
@@ -33,12 +34,13 @@ class MavenTest {
   void shouldGetParentWith4Indentations() {
     // @formatter:off
     String expected =
-      "<parent>" + System.lineSeparator() +
-      "        <groupId>org.springframework.boot</groupId>" + System.lineSeparator() +
-      "        <artifactId>spring-boot-starter-parent</artifactId>" + System.lineSeparator() +
-      "        <version>2.5.3</version>" + System.lineSeparator() +
-      "        <relativePath />" + System.lineSeparator() +
-      "    </parent>";
+      """
+        <parent>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-parent</artifactId>
+                <version>2.5.3</version>
+                <relativePath />
+            </parent>""";
     // @formatter:on
     Parent parent = Parent.builder().groupId("org.springframework.boot").artifactId("spring-boot-starter-parent").version("2.5.3").build();
 
@@ -180,7 +182,7 @@ class MavenTest {
       <plugin>
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-maven-plugin</artifactId>
-            </plugin>""".replace("\n", System.lineSeparator());
+            </plugin>""";
     Plugin plugin = minimalPluginBuilder().build();
 
     assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
@@ -193,7 +195,7 @@ class MavenTest {
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-maven-plugin</artifactId>
               <version>2.6.0</version>
-            </plugin>""".replace("\n", System.lineSeparator());
+            </plugin>""";
     Plugin plugin = fullPluginBuilder().build();
 
     assertThat(Maven.getPlugin(plugin)).isEqualTo(expected);
@@ -205,7 +207,7 @@ class MavenTest {
       <plugin>
                       <groupId>org.springframework.boot</groupId>
                       <artifactId>spring-boot-maven-plugin</artifactId>
-                  </plugin>""".replace("\n", System.lineSeparator());
+                  </plugin>""";
     Plugin plugin = minimalPluginBuilder().build();
 
     assertThat(Maven.getPlugin(plugin, 4)).isEqualTo(expected);
@@ -241,7 +243,7 @@ class MavenTest {
                     </resource>
                   </webResources>
                 </configuration>
-              </plugin>""".replace("\n", System.lineSeparator());
+              </plugin>""";
     // @formatter:on
     Plugin plugin = fullPluginBuilder()
       .additionalElements(

--- a/src/test/java/tech/jhipster/lite/generator/init/application/InitApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/init/application/InitApplicationServiceIT.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.init.application;
 
 import static tech.jhipster.lite.TestUtils.*;
+import static tech.jhipster.lite.common.domain.WordUtils.CRLF;
 import static tech.jhipster.lite.generator.init.application.InitAssertFiles.*;
 import static tech.jhipster.lite.generator.project.domain.Constants.PACKAGE_JSON;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.*;
@@ -35,14 +36,15 @@ class InitApplicationServiceIT {
       )
     );
     // @formatter:on
-    Project project = tmpProjectBuilder().config(config).build();
+    Project project = tmpProjectBuilder().endOfLine(CRLF).config(config).build();
 
     initApplicationService.init(project);
 
     assertFilesInit(project);
     assertFileContent(project, "README.md", "JHipster Lite");
     assertFileContent(project, PACKAGE_JSON, "jhipster-lite");
-    assertFileContent(project, ".prettierrc", "tabWidth: 4");
+    assertFileContent(project, ".editorconfig", "end_of_line = crlf");
+    assertFileContent(project, ".prettierrc", "endOfLine: \"crlf\"");
     // @formatter:off
     assertFileContent(project, ".prettierrc",
       List.of(
@@ -64,7 +66,8 @@ class InitApplicationServiceIT {
     assertFilesInit(project);
     assertFileContent(project, "README.md", "JHipster Project");
     assertFileContent(project, PACKAGE_JSON, "jhipster");
-    assertFileContent(project, ".prettierrc", "tabWidth: 2");
+    assertFileContent(project, ".editorconfig", "end_of_line = lf");
+    assertFileContent(project, ".prettierrc", "endOfLine: \"lf\"");
     // @formatter:off
     assertFileContent(project, ".prettierrc",
       List.of(
@@ -101,7 +104,7 @@ class InitApplicationServiceIT {
 
     initApplicationService.addGitConfiguration(project);
 
-    assertFilesConfiguration(project);
+    assertFilesGitConfiguration(project);
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/init/application/InitAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/init/application/InitAssertFiles.java
@@ -21,7 +21,7 @@ public class InitAssertFiles {
     assertFileExist(project, "README.md");
   }
 
-  public static void assertFilesConfiguration(Project project) {
+  public static void assertFilesGitConfiguration(Project project) {
     assertFileExist(project, ".gitignore");
     assertFileExist(project, ".gitattributes");
   }
@@ -47,7 +47,7 @@ public class InitAssertFiles {
   public static void assertFilesInit(Project project) {
     assertFilesPackageJson(project);
     assertFilesReadme(project);
-    assertFilesConfiguration(project);
+    assertFilesGitConfiguration(project);
     assertFilesEditorConfiguration(project);
     assertFilesPrettier(project);
   }

--- a/src/test/java/tech/jhipster/lite/generator/project/domain/ProjectTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/project/domain/ProjectTest.java
@@ -4,8 +4,14 @@ import static org.assertj.core.api.Assertions.*;
 import static tech.jhipster.lite.TestUtils.*;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.common.domain.FileUtils.tmpDirForTest;
+import static tech.jhipster.lite.common.domain.WordUtils.CRLF;
+import static tech.jhipster.lite.common.domain.WordUtils.LF;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.*;
 
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -30,6 +36,7 @@ class ProjectTest {
       Project project = minimalBuilder(folder).build();
 
       assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
       assertThat(project.getConfig()).isEmpty();
 
       assertThat(project.getLanguage()).isEmpty();
@@ -49,6 +56,7 @@ class ProjectTest {
       Project project = minimalBuilder(folder).config(null).build();
 
       assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
       assertThat(project.getConfig()).isEmpty();
     }
 
@@ -58,6 +66,7 @@ class ProjectTest {
       Project project = fullBuilder(folder).config(Map.of(PROJECT_NAME, "JHipster Lite")).build();
 
       assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
       assertThat(project.getConfig()).isEqualTo(Map.of(PROJECT_NAME, "JHipster Lite"));
 
       assertThat(project.getLanguage()).contains(LanguageType.JAVA);
@@ -90,6 +99,59 @@ class ProjectTest {
       Project.ProjectBuilder builder = Project.builder().folder(" ");
 
       assertThatThrownBy(builder::build).isExactlyInstanceOf(MissingMandatoryValueException.class).hasMessageContaining("folder");
+    }
+  }
+
+  @Nested
+  class DetectEndOfLineTest {
+
+    @Test
+    void shouldBuildProjectCrlf() throws IOException {
+      String folder = tmpDirForTest();
+
+      Files.createDirectory(Path.of(folder));
+      Files.writeString(Path.of(folder, "file.txt"), "my file with \r\ncrlf", StandardOpenOption.CREATE);
+
+      Project project = minimalBuilder(folder).build();
+
+      assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(CRLF);
+    }
+
+    @Test
+    void shouldBuildProjectLf() throws IOException {
+      String folder = tmpDirForTest();
+
+      Files.createDirectory(Path.of(folder));
+      Files.writeString(Path.of(folder, "file.txt"), "my file with \nlf", StandardOpenOption.CREATE);
+
+      Project project = minimalBuilder(folder).build();
+
+      assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
+    }
+
+    @Test
+    void shouldBuildProjectNoNewline() throws IOException {
+      String folder = tmpDirForTest();
+
+      Files.createDirectory(Path.of(folder));
+      Files.writeString(Path.of(folder, "file.txt"), "my file with only 1 line", StandardOpenOption.CREATE);
+
+      Project project = minimalBuilder(folder).build();
+
+      assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
+    }
+
+    @Test
+    void shouldBuildProjectDefault() {
+      String folder = tmpDirForTest();
+
+      Project project = minimalBuilder(folder).build();
+
+      assertThat(project.getFolder()).isEqualTo(folder);
+      assertThat(project.getEndOfLine()).isEqualTo(LF);
     }
   }
 


### PR DESCRIPTION
fix #477 

- [x] .gitattributes
- [x] .editorconfig
- [x] .prettierrc
- [x] Add a lineSeparator project configuration and use it where applicable
- [x] Remove all uses of System.lineSeparator
- [ ] Add utility method that replaces LF with custom lineSeparator

Some use of indentation constants were also committed as part of this PR

@pascalgrimaud supporting custom line separators would also required that we ensure applying them when modifying Java files (eg. updateExceptionTranslatorIT).

As LF is widely used in git repos by both Unix and Windows worlds, I'm not sure it's worth the effort after all. Let's re-think about forcing LF for everyone as good-practice. I don't know any advantage of using CRLF in source code, and it should never be used in Git.

Note that .gitattributes still overrides bat, cmd, ps1 and sh but it's not the case in editorconfig and prettierrc.