### PR TITLE
Fix Arch tests on windows

### DIFF
--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -47,6 +47,7 @@ class HexagonalArchTest {
         .walk(Paths.get("src/main/java/tech/jhipster/lite"))
         .filter(path -> path.toString().endsWith("package-info.java"))
         .map(toPackageName())
+        .map(path -> path.replaceAll("[\\\\]", "."))
         .map(path -> path.replaceAll("[\\/]", "."))
         .map(path -> path.replace("src.main.java.", ""))
         .map(toPackage())


### PR DESCRIPTION
To partialy fix #302 

Fix HexagonalArch test on Windows