### PR TITLE
Maven: Add version suffix manually

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolDomainService.java
@@ -72,9 +72,9 @@ public class BuildToolDomainService implements BuildToolService {
   }
 
   @Override
-  public void addProperty(Project project, String key, String version) {
+  public void addProperty(Project project, String key, String value) {
     if (project.isMavenProject()) {
-      mavenService.addProperty(project, key, version);
+      mavenService.addProperty(project, key, value);
     } else {
       throw new GeneratorException(EXCEPTION_NO_BUILD_TOOL);
     }

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolService.java
@@ -11,7 +11,7 @@ public interface BuildToolService {
   void addDependencyManagement(Project project, Dependency dependency);
   void addPlugin(Project project, Plugin plugin);
   void addPluginManagement(Project project, Plugin plugin);
-  void addProperty(Project project, String key, String version);
+  void addProperty(Project project, String key, String value);
   void addRepository(Project project, Repository repository);
   void addPluginRepository(Project project, Repository repository);
   void init(Project project, BuildToolType buildTool);

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/Maven.java
@@ -224,16 +224,8 @@ public class Maven {
     return header + additionalBody + PLUGIN_END;
   }
 
-  public static String getProperty(String key, String version) {
-    return new StringBuilder()
-      .append("<")
-      .append(key)
-      .append(".version>")
-      .append(version)
-      .append("</")
-      .append(key)
-      .append(".version>")
-      .toString();
+  public static String getProperty(String key, String value) {
+    return new StringBuilder().append("<").append(key).append(">").append(value).append("</").append(key).append(">").toString();
   }
 
   public static String getRepositoryHeader(Repository repository, int indentation) {

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenDomainService.java
@@ -140,7 +140,7 @@ public class MavenDomainService implements MavenService {
   }
 
   @Override
-  public void addProperty(Project project, String key, String version) {
+  public void addProperty(Project project, String key, String value) {
     project.addDefaultConfig(PRETTIER_DEFAULT_INDENT);
 
     int indent = (Integer) project.getConfig(PRETTIER_DEFAULT_INDENT).orElse(DEFAULT_INDENTATION);
@@ -148,7 +148,7 @@ public class MavenDomainService implements MavenService {
     String pluginRegexp = Maven.getProperty(key, ".*");
 
     if (!projectRepository.containsRegexp(project, "", POM_XML, pluginRegexp)) {
-      String propertyWithNeedle = Maven.getProperty(key, version) + LF + indent(2, indent) + NEEDLE_PROPERTIES;
+      String propertyWithNeedle = Maven.getProperty(key, value) + LF + indent(2, indent) + NEEDLE_PROPERTIES;
 
       projectRepository.replaceText(project, "", POM_XML, NEEDLE_PROPERTIES, propertyWithNeedle);
     }

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenService.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenService.java
@@ -15,7 +15,7 @@ public interface MavenService {
   void deleteDependency(Project project, Dependency dependency);
   void addPlugin(Project project, Plugin plugin);
   void addPluginManagement(Project project, Plugin plugin);
-  void addProperty(Project project, String key, String version);
+  void addProperty(Project project, String key, String value);
   void deleteProperty(Project project, String key);
   void addRepository(Project project, Repository repository);
   void addPluginRepository(Project project, Repository repository);

--- a/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainService.java
@@ -53,7 +53,7 @@ public class SonarDomainService implements SonarService {
         </executions>"""
       )
       .build();
-    buildToolService.addProperty(project, "properties-maven-plugin", "1.0.0");
+    buildToolService.addProperty(project, "properties-maven-plugin.version", "1.0.0");
     buildToolService.addPlugin(project, plugin);
   }
 
@@ -65,7 +65,7 @@ public class SonarDomainService implements SonarService {
       .artifactId("sonar-maven-plugin")
       .version("\\${sonar-maven-plugin.version}")
       .build();
-    buildToolService.addProperty(project, "sonar-maven-plugin", getMavenPluginVersion());
+    buildToolService.addProperty(project, "sonar-maven-plugin.version", getMavenPluginVersion());
     buildToolService.addPluginManagement(project, plugin);
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootDomainService.java
@@ -88,7 +88,7 @@ public class SpringBootDomainService implements SpringBootService {
       .artifactId("spring-boot-maven-plugin")
       .version("\\${spring-boot.version}")
       .build();
-    buildToolService.addProperty(project, "spring-boot", SpringBoot.getVersion());
+    buildToolService.addProperty(project, "spring-boot.version", SpringBoot.getVersion());
     buildToolService.addPlugin(project, plugin);
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/domain/MySQLDomainService.java
@@ -113,7 +113,7 @@ public class MySQLDomainService implements MySQLService {
       .version("\\${testcontainers.version}")
       .scope("test")
       .build();
-    buildToolService.addProperty(project, "testcontainers", MySQL.getTestcontainersVersion());
+    buildToolService.addProperty(project, "testcontainers.version", MySQL.getTestcontainersVersion());
     buildToolService.addDependency(project, dependency);
 
     springPropertiesForTest(baseName).forEach((k, v) -> springBootCommonService.addPropertiesTest(project, k, v));

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/domain/PostgresqlDomainService.java
@@ -110,7 +110,7 @@ public class PostgresqlDomainService implements PostgresqlService {
       .version("\\${testcontainers.version}")
       .scope("test")
       .build();
-    buildToolService.addProperty(project, "testcontainers", Postgresql.getTestcontainersVersion());
+    buildToolService.addProperty(project, "testcontainers.version", Postgresql.getTestcontainersVersion());
     buildToolService.addDependency(project, dependency);
 
     springPropertiesForTest(baseName).forEach((k, v) -> springBootCommonService.addPropertiesTest(project, k, v));

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
@@ -41,7 +41,7 @@ public class LogstashDomainService implements LogstashService {
 
   @Override
   public void addDependencies(Project project) {
-    buildToolService.addProperty(project, "logstash-logback-encoder", Logstash.getLogstashLogbackEncoderVersion());
+    buildToolService.addProperty(project, "logstash-logback-encoder.version", Logstash.getLogstashLogbackEncoderVersion());
     buildToolService.addDependency(project, Logstash.logstashLogbackEncoderDependency());
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainService.java
@@ -69,7 +69,7 @@ public class JwtSecurityDomainService implements JwtSecurityService {
   }
 
   private void addPropertyAndDependency(Project project) {
-    buildToolService.addProperty(project, "jjwt", jjwtVersion());
+    buildToolService.addProperty(project, "jjwt.version", jjwtVersion());
 
     buildToolService.addDependency(project, springBootStarterSecurityDependency());
     buildToolService.addDependency(project, jjwtApiDependency());

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainService.java
@@ -42,7 +42,7 @@ public class SpringDocDomainService implements SpringDocService {
 
   @Override
   public void addSpringDocDependency(Project project) {
-    buildToolService.addProperty(project, "springdoc-openapi-ui", SpringDoc.springDocVersion());
+    buildToolService.addProperty(project, "springdoc-openapi-ui.version", SpringDoc.springDocVersion());
     buildToolService.addDependency(project, SpringDoc.springDocDependency());
   }
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/web/domain/SpringBootMvcDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/web/domain/SpringBootMvcDomainService.java
@@ -80,8 +80,8 @@ public class SpringBootMvcDomainService implements SpringBootMvcService {
   public void addExceptionHandler(Project project) {
     project.addDefaultConfig(PACKAGE_NAME);
 
-    buildToolService.addProperty(project, "problem-spring", SpringBootMvc.problemSpringVersion());
-    buildToolService.addProperty(project, "problem-spring-web", "\\${problem-spring.version}");
+    buildToolService.addProperty(project, "problem-spring.version", SpringBootMvc.problemSpringVersion());
+    buildToolService.addProperty(project, "problem-spring-web.version", "\\${problem-spring.version}");
 
     buildToolService.addDependency(project, problemSpringDependency());
     buildToolService.addDependency(project, springBootStarterValidation());

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainService.java
@@ -56,7 +56,7 @@ public class SpringCloudConfigClientDomainService implements SpringCloudConfigCl
 
   @Override
   public void addCloudConfigDependencies(Project project) {
-    this.buildToolService.addProperty(project, "spring-cloud", getSpringCloudVersion());
+    this.buildToolService.addProperty(project, "spring-cloud.version", getSpringCloudVersion());
     this.buildToolService.addDependencyManagement(project, springCloudDependencies());
     this.buildToolService.addDependency(project, springCloudBootstrap());
     this.buildToolService.addDependency(project, springCloudConfigClient());

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/consul/domain/ConsulDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/consul/domain/ConsulDomainService.java
@@ -31,7 +31,7 @@ public class ConsulDomainService implements ConsulService {
 
   @Override
   public void addDependencies(Project project) {
-    buildToolService.addProperty(project, "spring-cloud", getSpringCloudVersion());
+    buildToolService.addProperty(project, "spring-cloud.version", getSpringCloudVersion());
     buildToolService.addDependencyManagement(project, springCloudDependencyManagement());
     buildToolService.addDependency(project, springCloudBootstrapDependency());
     buildToolService.addDependency(project, springCloudConsulConfigDependency());

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/generic/domain/BuildToolDomainServiceTest.java
@@ -95,9 +95,9 @@ class BuildToolDomainServiceTest {
     void shouldAddProperty() {
       Project project = tmpProjectWithPomXml();
 
-      buildToolDomainService.addProperty(project, "testcontainers", "1.16.0");
+      buildToolDomainService.addProperty(project, "testcontainers.version", "1.16.0");
 
-      verify(mavenService).addProperty(project, "testcontainers", "1.16.0");
+      verify(mavenService).addProperty(project, "testcontainers.version", "1.16.0");
     }
 
     @Test

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/application/MavenApplicationServiceIT.java
@@ -420,7 +420,7 @@ class MavenApplicationServiceIT {
 
     mavenApplicationService.addProperty(project, "testcontainers", "1.16.0");
 
-    assertFileContent(project, POM_XML, "    <testcontainers.version>1.16.0</testcontainers.version>");
+    assertFileContent(project, POM_XML, "    <testcontainers>1.16.0</testcontainers>");
   }
 
   @Test
@@ -448,11 +448,11 @@ class MavenApplicationServiceIT {
   void shouldDeleteProperty() {
     Project project = tmpProjectWithPomXml();
 
-    mavenApplicationService.addProperty(project, "my-key", "1.0");
+    mavenApplicationService.addProperty(project, "my-key.version", "1.0");
 
     assertFileContent(project, POM_XML, "    <my-key.version>1.0</my-key.version>");
 
-    mavenApplicationService.deleteProperty(project, "my-key");
+    mavenApplicationService.deleteProperty(project, "my-key.version");
 
     assertFileNoContent(project, POM_XML, "    <my-key.version>1.0</my-key.version>");
   }

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/maven/MavenTest.java
@@ -282,7 +282,7 @@ class MavenTest {
     String key = "testcontainers";
     String version = "1.16.0";
 
-    assertThat(Maven.getProperty(key, version)).isEqualTo("<testcontainers.version>1.16.0</testcontainers.version>");
+    assertThat(Maven.getProperty(key, version)).isEqualTo("<testcontainers>1.16.0</testcontainers>");
   }
 
   private Plugin.PluginBuilder minimalPluginBuilder() {

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainServiceTest.java
@@ -47,7 +47,7 @@ class SpringDocDomainServiceTest {
     springDocDomainService.init(project);
 
     // Then
-    verify(buildToolService).addProperty(project, "springdoc-openapi-ui", "1.6.4");
+    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "1.6.4");
     ArgumentCaptor<Dependency> dependencyArgCaptor = ArgumentCaptor.forClass(Dependency.class);
     verify(buildToolService).addDependency(eq(project), dependencyArgCaptor.capture());
     assertThat(dependencyArgCaptor.getValue()).usingRecursiveComparison().isEqualTo(getExpectedDependency());
@@ -92,7 +92,7 @@ class SpringDocDomainServiceTest {
     springDocDomainService.init(project);
 
     // Then
-    verify(buildToolService).addProperty(project, "springdoc-openapi-ui", "1.6.4");
+    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "1.6.4");
     ArgumentCaptor<Dependency> dependencyArgCaptor = ArgumentCaptor.forClass(Dependency.class);
     verify(buildToolService).addDependency(eq(project), dependencyArgCaptor.capture());
     assertThat(dependencyArgCaptor.getValue()).usingRecursiveComparison().isEqualTo(getExpectedDependency());


### PR DESCRIPTION
- Remove .version suffix in all properties added by addProperty() method (Reflects the work done by method and allows adding properties more flexibly)
- There are other properties that needs to be added in pom without (".version suffix) (https://github.com/jhipster/jhipster-sample-app/blob/main/pom.xml)

Found specifically while adding `jib` properties `jib-maven-plugin.image` and `jib-maven-plugin.architecture` (#424)