### PR TITLE
Sonar: update rules from squid:S4502 to java:S4502

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -27,7 +27,7 @@ sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey=squid:UndocumentedApi
 
 # Rule https://rules.sonarsource.com/java/RSPEC-4502 is ignored, as for JWT tokens we are not subject to CSRF attack
 sonar.issue.ignore.multicriteria.S4502.resourceKey=src/main/java/**/*
-sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
+sonar.issue.ignore.multicriteria.S4502.ruleKey=java:S4502
 
 # Rule https://rules.sonarsource.com/java/RSPEC-4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=src/main/java/**/*

--- a/src/main/resources/generator/server/sonar/sonar-project.properties.mustache
+++ b/src/main/resources/generator/server/sonar/sonar-project.properties.mustache
@@ -24,7 +24,7 @@ sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey=squid:UndocumentedApi
 
 # Rule https://rules.sonarsource.com/java/RSPEC-4502 is ignored, as for JWT tokens we are not subject to CSRF attack
 sonar.issue.ignore.multicriteria.S4502.resourceKey=src/main/java/**/*
-sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
+sonar.issue.ignore.multicriteria.S4502.ruleKey=java:S4502
 
 # Rule https://rules.sonarsource.com/java/RSPEC-4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=src/main/java/**/*


### PR DESCRIPTION
It's for fixing:

![image](https://user-images.githubusercontent.com/9156882/150659130-2cbb8de6-cae4-4509-8d45-5479c9a3f68f.png)
