### PR TITLE
Spring-cloud: use get version, managed by dependabot

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfig.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfig.java
@@ -4,15 +4,10 @@ import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 
 public class SpringCloudConfig {
 
-  private static final String SPRING_CLOUD_VERSION = "2021.0.0";
   private static final String JHIPSTER_REGISTRY_DOCKER_IMAGE = "jhipster/jhipster-registry:v7.1.0";
   private static final String SPRING_CLOUD_GROUP_ID = "org.springframework.cloud";
 
   private SpringCloudConfig() {}
-
-  public static String getSpringCloudVersion() {
-    return SPRING_CLOUD_VERSION;
-  }
 
   public static Dependency springCloudDependencies() {
     return Dependency

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainService.java
@@ -6,6 +6,7 @@ import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAM
 import static tech.jhipster.lite.generator.server.springboot.springcloud.configclient.domain.SpringCloudConfig.*;
 
 import tech.jhipster.lite.common.domain.Base64Utils;
+import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
@@ -56,9 +57,17 @@ public class SpringCloudConfigClientDomainService implements SpringCloudConfigCl
 
   @Override
   public void addCloudConfigDependencies(Project project) {
-    this.buildToolService.addProperty(project, "spring-cloud.version", getSpringCloudVersion());
-    this.buildToolService.addDependencyManagement(project, springCloudDependencies());
-    this.buildToolService.addDependency(project, springCloudBootstrap());
-    this.buildToolService.addDependency(project, springCloudConfigClient());
+    this.buildToolService.getVersion(project, "spring-cloud")
+      .ifPresentOrElse(
+        version -> {
+          this.buildToolService.addProperty(project, "spring-cloud.version", version);
+          this.buildToolService.addDependencyManagement(project, springCloudDependencies());
+          this.buildToolService.addDependency(project, springCloudBootstrap());
+          this.buildToolService.addDependency(project, springCloudConfigClient());
+        },
+        () -> {
+          throw new GeneratorException("Spring Cloud version not found");
+        }
+      );
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigClientDomainServiceTest.java
@@ -1,0 +1,57 @@
+package tech.jhipster.lite.generator.server.springboot.springcloud.configclient.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static tech.jhipster.lite.TestUtils.tmpProjectWithPomXml;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class SpringCloudConfigClientDomainServiceTest {
+
+  @Mock
+  ProjectRepository projectRepository;
+
+  @Mock
+  BuildToolService buildToolService;
+
+  @InjectMocks
+  SpringCloudConfigClientDomainService springCloudConfigClientDomainService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProjectWithPomXml();
+    when(buildToolService.getVersion(project, "spring-cloud")).thenReturn(Optional.of("0.0.0"));
+
+    springCloudConfigClientDomainService.init(project);
+
+    verify(buildToolService).addProperty(any(Project.class), anyString(), anyString());
+    verify(buildToolService).addDependencyManagement(any(Project.class), any(Dependency.class));
+    verify(buildToolService, times(2)).addDependency(any(Project.class), any(Dependency.class));
+
+    verify(projectRepository, times(3)).template(any(Project.class), anyString(), anyString(), anyString());
+    verify(projectRepository, times(2)).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotAddCloudConfigDependencies() {
+    Project project = tmpProjectWithPomXml();
+
+    assertThatThrownBy(() -> springCloudConfigClientDomainService.addCloudConfigDependencies(project))
+      .isExactlyInstanceOf(GeneratorException.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/domain/SpringCloudConfigTest.java
@@ -10,11 +10,6 @@ import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 class SpringCloudConfigTest {
 
   @Test
-  void shouldGetSpringCloudVersion() {
-    assertThat(SpringCloudConfig.getSpringCloudVersion()).isEqualTo(SpringCloudConfig.getSpringCloudVersion());
-  }
-
-  @Test
   void shouldGetJhipsterRegistryDockerImageName() {
     assertThat(SpringCloudConfig.getJhipsterRegistryDockerImage()).isEqualTo("jhipster/jhipster-registry:v7.1.0");
   }


### PR DESCRIPTION
- related to https://github.com/jhipster/jhipster-lite/issues/615