### PR TITLE
Springdoc-openapi: use get version, managed by dependabot

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDoc.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDoc.java
@@ -4,8 +4,6 @@ import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 
 public class SpringDoc {
 
-  private static final String SPRING_DOC_VERSION = "1.6.4";
-
   private SpringDoc() {}
 
   public static Dependency springDocDependency() {
@@ -15,9 +13,5 @@ public class SpringDoc {
       .artifactId("springdoc-openapi-ui")
       .version("\\${springdoc-openapi-ui.version}")
       .build();
-  }
-
-  public static String springDocVersion() {
-    return SPRING_DOC_VERSION;
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainService.java
@@ -9,6 +9,7 @@ import static tech.jhipster.lite.generator.server.springboot.mvc.springdoc.domai
 import java.util.HashMap;
 import java.util.Map;
 import java.util.TreeMap;
+import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
@@ -49,8 +50,16 @@ public class SpringDocDomainService implements SpringDocService {
 
   @Override
   public void addSpringDocDependency(Project project) {
-    buildToolService.addProperty(project, "springdoc-openapi-ui.version", SpringDoc.springDocVersion());
-    buildToolService.addDependency(project, SpringDoc.springDocDependency());
+    this.buildToolService.getVersion(project, "springdoc-openapi")
+      .ifPresentOrElse(
+        version -> {
+          buildToolService.addProperty(project, "springdoc-openapi-ui.version", version);
+          buildToolService.addDependency(project, SpringDoc.springDocDependency());
+        },
+        () -> {
+          throw new GeneratorException("Springdoc Openapi version not found");
+        }
+      );
   }
 
   @Override

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -18,7 +18,7 @@
     <problem-spring.version>0.27.0</problem-spring.version>
     <spring-boot.version>2.6.3</spring-boot.version>
     <spring-cloud.version>2021.0.0</spring-cloud.version>
-    <springdoc-openapi.version.version>1.6.4</springdoc-openapi.version.version>
+    <springdoc-openapi.version>1.6.5</springdoc-openapi.version>
     <testcontainers.version>1.16.2</testcontainers.version>
   </properties>
 

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/application/SpringDocAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/application/SpringDocAssert.java
@@ -8,18 +8,13 @@ import java.util.List;
 import tech.jhipster.lite.TestUtils;
 import tech.jhipster.lite.generator.project.domain.DefaultConfig;
 import tech.jhipster.lite.generator.project.domain.Project;
-import tech.jhipster.lite.generator.server.springboot.mvc.springdoc.domain.SpringDoc;
 
 public class SpringDocAssert {
 
   public static final String SPRING_DOC_CONFIG_JAVA_FILE_NAME = "SpringDocConfiguration.java";
 
   public static void assertDependencies(Project project) {
-    TestUtils.assertFileContent(
-      project,
-      POM_XML,
-      List.of("<springdoc-openapi-ui.version>" + SpringDoc.springDocVersion() + "</springdoc-openapi-ui.version>")
-    );
+    TestUtils.assertFileContent(project, POM_XML, List.of("<springdoc-openapi-ui.version>"));
     TestUtils.assertFileContent(
       project,
       POM_XML,

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/springdoc/domain/SpringDocDomainServiceTest.java
@@ -1,14 +1,15 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.springdoc.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.*;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.*;
 import static tech.jhipster.lite.TestUtils.tmpProject;
 import static tech.jhipster.lite.generator.server.springboot.mvc.springdoc.domain.SpringDocConstants.*;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -16,6 +17,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 import tech.jhipster.lite.generator.project.domain.Project;
@@ -44,10 +46,11 @@ class SpringDocDomainServiceTest {
     Project project = tmpProject();
 
     // When
+    when(buildToolService.getVersion(project, "springdoc-openapi")).thenReturn(Optional.of("0.0.0"));
     springDocDomainService.init(project);
 
     // Then
-    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "1.6.4");
+    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "0.0.0");
     ArgumentCaptor<Dependency> dependencyArgCaptor = ArgumentCaptor.forClass(Dependency.class);
     verify(buildToolService).addDependency(eq(project), dependencyArgCaptor.capture());
     assertThat(dependencyArgCaptor.getValue()).usingRecursiveComparison().isEqualTo(getExpectedDependency());
@@ -89,10 +92,11 @@ class SpringDocDomainServiceTest {
     project.getConfig().putAll(projectConfig);
 
     // When
+    when(buildToolService.getVersion(project, "springdoc-openapi")).thenReturn(Optional.of("0.0.0"));
     springDocDomainService.init(project);
 
     // Then
-    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "1.6.4");
+    verify(buildToolService).addProperty(project, "springdoc-openapi-ui.version", "0.0.0");
     ArgumentCaptor<Dependency> dependencyArgCaptor = ArgumentCaptor.forClass(Dependency.class);
     verify(buildToolService).addDependency(eq(project), dependencyArgCaptor.capture());
     assertThat(dependencyArgCaptor.getValue()).usingRecursiveComparison().isEqualTo(getExpectedDependency());
@@ -111,6 +115,13 @@ class SpringDocDomainServiceTest {
     verify(springBootCommonService).addProperties(project, "springdoc.swagger-ui.tryItOutEnabled", DEFAULT_TRY_OUT_ENABLED);
 
     assertThat(project.getConfig()).containsAllEntriesOf(projectConfig);
+  }
+
+  @Test
+  void shouldNotAddSpringDocDependency() {
+    Project project = tmpProject();
+
+    assertThatThrownBy(() -> springDocDomainService.addSpringDocDependency(project)).isExactlyInstanceOf(GeneratorException.class);
   }
 
   private static Dependency getExpectedDependency() {


### PR DESCRIPTION
- related to https://github.com/jhipster/jhipster-lite/issues/615