### PR TITLE
feat: Add MongoDB Support

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -92,6 +92,7 @@ jobs:
           - undertow-simplecache
           - tomcat-configserver
           - undertow-consul
+          - tomcat-mongodb
     steps:
       - name: 'Setup: checkout project'
         uses: actions/checkout@v2

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationService.java
@@ -16,36 +16,4 @@ public class MongodbApplicationService {
   public void init(Project project) {
     mongodbService.init(project);
   }
-
-  public void addSpringDataMongodb(Project project) {
-    mongodbService.addSpringDataMongodb(project);
-  }
-
-  public void addMongodbDriver(Project project) {
-    mongodbService.addMongodbDriver(project);
-  }
-
-  public void addDockerCompose(Project project) {
-    mongodbService.addDockerCompose(project);
-  }
-
-  public void addJavaFiles(Project project) {
-    mongodbService.addJavaFiles(project);
-  }
-
-  public void addConfigurationFiles(Project project) {
-    mongodbService.addConfigurationFiles(project);
-  }
-
-  public void addProperties(Project project) {
-    mongodbService.addProperties(project);
-  }
-
-  public void addLogger(Project project) {
-    mongodbService.addLoggerInConfiguration(project);
-  }
-
-  public void addTestContainers(Project project) {
-    mongodbService.addTestcontainers(project);
-  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationService.java
@@ -1,0 +1,51 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.MongodbService;
+
+@Service
+public class MongodbApplicationService {
+
+  private final MongodbService mongodbService;
+
+  public MongodbApplicationService(MongodbService mongodbService) {
+    this.mongodbService = mongodbService;
+  }
+
+  public void init(Project project) {
+    mongodbService.init(project);
+  }
+
+  public void addSpringDataMongodb(Project project) {
+    mongodbService.addSpringDataMongodb(project);
+  }
+
+  public void addMongodbDriver(Project project) {
+    mongodbService.addMongodbDriver(project);
+  }
+
+  public void addDockerCompose(Project project) {
+    mongodbService.addDockerCompose(project);
+  }
+
+  public void addJavaFiles(Project project) {
+    mongodbService.addJavaFiles(project);
+  }
+
+  public void addConfigurationFiles(Project project) {
+    mongodbService.addConfigurationFiles(project);
+  }
+
+  public void addProperties(Project project) {
+    mongodbService.addProperties(project);
+  }
+
+  public void addLogger(Project project) {
+    mongodbService.addLoggerInConfiguration(project);
+  }
+
+  public void addTestContainers(Project project) {
+    mongodbService.addTestcontainers(project);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/Mongodb.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/Mongodb.java
@@ -1,0 +1,24 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.domain;
+
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+public class Mongodb {
+
+  public static final String MONGODB_DOCKER_VERSION = "4.4.11";
+
+  public static final String MONGODB_DOCKER_IMAGE = "mongo:" + MONGODB_DOCKER_VERSION;
+
+  private Mongodb() {}
+
+  public static String getMongodbDockerVersion() {
+    return MONGODB_DOCKER_VERSION;
+  }
+
+  public static String getMongodbDockerImage() {
+    return MONGODB_DOCKER_IMAGE;
+  }
+
+  public static Dependency mongodbDriver() {
+    return Dependency.builder().groupId("org.mongodb").artifactId("mongodb-driver-sync").build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbDomainService.java
@@ -1,0 +1,166 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.domain;
+
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_PATH;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.Mongodb.mongodbDriver;
+
+import java.util.Map;
+import java.util.TreeMap;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
+import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
+
+public class MongodbDomainService implements MongodbService {
+
+  public static final String SOURCE = "server/springboot/database/mongodb";
+
+  private final ProjectRepository projectRepository;
+  private final BuildToolService buildToolService;
+  private final SpringBootCommonService springBootCommonService;
+
+  public MongodbDomainService(
+    ProjectRepository projectRepository,
+    BuildToolService buildToolService,
+    SpringBootCommonService springBootCommonService
+  ) {
+    this.projectRepository = projectRepository;
+    this.buildToolService = buildToolService;
+    this.springBootCommonService = springBootCommonService;
+  }
+
+  @Override
+  public void init(Project project) {
+    addSpringDataMongodb(project);
+    addMongodbDriver(project);
+    addDockerCompose(project);
+    addJavaFiles(project);
+    addConfigurationFiles(project);
+    addProperties(project);
+    addTestcontainers(project);
+    addLoggerInConfiguration(project);
+
+    updateIntegrationTestAnnotation(project);
+  }
+
+  @Override
+  public void addSpringDataMongodb(Project project) {
+    Dependency dependency = Dependency.builder().groupId("org.springframework.boot").artifactId("spring-boot-starter-data-mongodb").build();
+
+    buildToolService.addDependency(project, dependency);
+  }
+
+  @Override
+  public void addMongodbDriver(Project project) {
+    buildToolService.addDependency(project, mongodbDriver());
+  }
+
+  @Override
+  public void addDockerCompose(Project project) {
+    project.addDefaultConfig(BASE_NAME);
+    project.addConfig("mongodbDockerImage", Mongodb.getMongodbDockerImage());
+    projectRepository.template(project, SOURCE, "mongodb.yml", "src/main/docker", "mongodb.yml");
+  }
+
+  @Override
+  public void addJavaFiles(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    project.addDefaultConfig(BASE_NAME);
+    String packageNamePath = project.getPackageNamePath().orElse(getPath("com/mycompany/myapp"));
+    String mongodbPath = "technical/infrastructure/secondary/mongodb";
+
+    projectRepository.template(project, SOURCE, "MongodbDatabaseConfiguration.java", getPath(MAIN_JAVA, packageNamePath, mongodbPath));
+    projectRepository.template(project, SOURCE, "JSR310DateConverters.java", getPath(MAIN_JAVA, packageNamePath, mongodbPath));
+
+    projectRepository.template(project, SOURCE, "JSR310DateConvertersTest.java", getPath(TEST_JAVA, packageNamePath, mongodbPath));
+    projectRepository.template(project, SOURCE, "MongodbTestContainerExtension.java", getPath(TEST_JAVA, packageNamePath));
+    projectRepository.template(project, SOURCE, "TestContainersSpringContextCustomizerFactory.java", getPath(TEST_JAVA, packageNamePath));
+  }
+
+  @Override
+  public void addConfigurationFiles(Project project) {
+    project.addDefaultConfig(BASE_NAME);
+
+    projectRepository.template(project, SOURCE, "spring.factories", getPath(TEST_RESOURCES, "META-INF"));
+  }
+
+  @Override
+  public void addProperties(Project project) {
+    String baseName = project.getBaseName().orElse("jhipster");
+
+    springBootCommonService.addPropertiesComment(project, "Database Configuration");
+
+    springPropertiesMongodb(baseName).forEach((k, v) -> springBootCommonService.addProperties(project, k, v));
+    springBootCommonService.addPropertiesNewLine(project);
+  }
+
+  private Map<String, Object> springPropertiesMongodb(String baseName) {
+    TreeMap<String, Object> result = new TreeMap<>();
+
+    result.put("spring.data.mongodb.database", baseName);
+    result.put("spring.data.mongodb.uri", "mongodb://localhost:27017");
+
+    return result;
+  }
+
+  @Override
+  public void addTestcontainers(Project project) {
+    this.buildToolService.getVersion(project, "testcontainers")
+      .ifPresentOrElse(
+        version -> {
+          Dependency dependency = Dependency
+            .builder()
+            .groupId("org.testcontainers")
+            .artifactId("mongodb")
+            .version("\\${testcontainers.version}")
+            .scope("test")
+            .build();
+          buildToolService.addProperty(project, "testcontainers.version", version);
+          buildToolService.addDependency(project, dependency);
+        },
+        () -> {
+          throw new GeneratorException("Testcontainers version not found");
+        }
+      );
+  }
+
+  @Override
+  public void addLoggerInConfiguration(Project project) {
+    addLogger(project, "org.reflections", Level.WARN);
+    addLogger(project, "org.mongodb.driver", Level.WARN);
+
+    springBootCommonService.addLoggerTest(project, "com.github.dockerjava", Level.WARN);
+    springBootCommonService.addLoggerTest(project, "org.testcontainers", Level.WARN);
+  }
+
+  public void addLogger(Project project, String packageName, Level level) {
+    springBootCommonService.addLogger(project, packageName, level);
+    springBootCommonService.addLoggerTest(project, packageName, level);
+  }
+
+  private void updateIntegrationTestAnnotation(Project project) {
+    String packageNamePath = project.getPackageNamePath().orElse(getPath(PACKAGE_PATH));
+    String integrationTestPath = getPath(TEST_JAVA, packageNamePath);
+
+    String oldImport = "import org.springframework.boot.test.context.SpringBootTest;";
+    String newImport =
+      """
+        import org.junit.jupiter.api.extension.ExtendWith;
+        import org.springframework.boot.test.context.SpringBootTest;""";
+    projectRepository.replaceText(project, integrationTestPath, "IntegrationTest.java", oldImport, newImport);
+
+    String oldAnnotation = "public @interface";
+    String newAnnotation = """
+      @ExtendWith(MongodbTestContainerExtension.class)
+      public @interface""";
+    projectRepository.replaceText(project, integrationTestPath, "IntegrationTest.java", oldAnnotation, newAnnotation);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbService.java
@@ -1,0 +1,16 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.domain;
+
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public interface MongodbService {
+  void init(Project project);
+
+  void addSpringDataMongodb(Project project);
+  void addMongodbDriver(Project project);
+  void addDockerCompose(Project project);
+  void addJavaFiles(Project project);
+  void addConfigurationFiles(Project project);
+  void addProperties(Project project);
+  void addTestcontainers(Project project);
+  void addLoggerInConfiguration(Project project);
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfiguration.java
@@ -1,0 +1,32 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastructure.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
+import tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.MongodbDomainService;
+import tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.MongodbService;
+
+@Configuration
+public class MongodbBeanConfiguration {
+
+  public final ProjectRepository projectRepository;
+  public final BuildToolService buildToolService;
+  public final SpringBootCommonService springBootCommonService;
+
+  public MongodbBeanConfiguration(
+    ProjectRepository projectRepository,
+    BuildToolService buildToolService,
+    SpringBootCommonService springBootCommonService
+  ) {
+    this.projectRepository = projectRepository;
+    this.buildToolService = buildToolService;
+    this.springBootCommonService = springBootCommonService;
+  }
+
+  @Bean
+  public MongodbService mongodbService() {
+    return new MongodbDomainService(projectRepository, buildToolService, springBootCommonService);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfiguration.java
@@ -11,9 +11,9 @@ import tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.Mo
 @Configuration
 public class MongodbBeanConfiguration {
 
-  public final ProjectRepository projectRepository;
-  public final BuildToolService buildToolService;
-  public final SpringBootCommonService springBootCommonService;
+  private final ProjectRepository projectRepository;
+  private final BuildToolService buildToolService;
+  private final SpringBootCommonService springBootCommonService;
 
   public MongodbBeanConfiguration(
     ProjectRepository projectRepository,

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResource.java
@@ -1,0 +1,34 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastructure.primary.rest;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.database.mongodb.application.MongodbApplicationService;
+import tech.jhipster.lite.technical.infrastructure.primary.annotation.GeneratorStep;
+
+@RestController
+@RequestMapping("/api/servers/spring-boot/databases/mongodb")
+@Tag(name = "Spring Boot - Database")
+class MongodbResource {
+
+  private final MongodbApplicationService mongodbApplicationService;
+
+  public MongodbResource(MongodbApplicationService mongodbApplicationService) {
+    this.mongodbApplicationService = mongodbApplicationService;
+  }
+
+  @Operation(summary = "Add MongoDB drivers and dependencies, with testcontainers")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding MongoDB")
+  @PostMapping
+  @GeneratorStep(id = "mongodb")
+  public void init(@RequestBody ProjectDTO projectDTO) {
+    Project project = ProjectDTO.toProject(projectDTO);
+    mongodbApplicationService.init(project);
+  }
+}

--- a/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConverters.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConverters.java.mustache
@@ -1,0 +1,110 @@
+package {{packageName}}.technical.infrastructure.secondary.mongodb;
+
+import java.time.*;
+import java.util.Date;
+import org.springframework.core.convert.converter.Converter;
+
+/**
+ * <p>JSR310DateConverters class.</p>
+ */
+public final class JSR310DateConverters {
+
+  private JSR310DateConverters() {}
+
+  public static class LocalDateToDateConverter implements Converter<LocalDate, Date> {
+
+    public static final LocalDateToDateConverter INSTANCE = new LocalDateToDateConverter();
+
+    private LocalDateToDateConverter() {}
+
+    @Override
+    public Date convert(LocalDate source) {
+      return source == null ? null : Date.from(source.atStartOfDay(ZoneId.systemDefault()).toInstant());
+    }
+  }
+
+  public static class DateToLocalDateConverter implements Converter<Date, LocalDate> {
+
+    public static final DateToLocalDateConverter INSTANCE = new DateToLocalDateConverter();
+
+    private DateToLocalDateConverter() {}
+
+    @Override
+    public LocalDate convert(Date source) {
+      return source == null ? null : ZonedDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault()).toLocalDate();
+    }
+  }
+
+  public static class ZonedDateTimeToDateConverter implements Converter<ZonedDateTime, Date> {
+
+    public static final ZonedDateTimeToDateConverter INSTANCE = new ZonedDateTimeToDateConverter();
+
+    private ZonedDateTimeToDateConverter() {}
+
+    @Override
+    public Date convert(ZonedDateTime source) {
+      return source == null ? null : Date.from(source.toInstant());
+    }
+  }
+
+  public static class DateToZonedDateTimeConverter implements Converter<Date, ZonedDateTime> {
+
+    public static final DateToZonedDateTimeConverter INSTANCE = new DateToZonedDateTimeConverter();
+
+    private DateToZonedDateTimeConverter() {}
+
+    @Override
+    public ZonedDateTime convert(Date source) {
+      return source == null ? null : ZonedDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
+    }
+  }
+
+  public static class LocalDateTimeToDateConverter implements Converter<LocalDateTime, Date> {
+
+    public static final LocalDateTimeToDateConverter INSTANCE = new LocalDateTimeToDateConverter();
+
+    private LocalDateTimeToDateConverter() {}
+
+    @Override
+    public Date convert(LocalDateTime source) {
+      return source == null ? null : Date.from(source.atZone(ZoneId.systemDefault()).toInstant());
+    }
+  }
+
+  public static class DateToLocalDateTimeConverter implements Converter<Date, LocalDateTime> {
+
+    public static final DateToLocalDateTimeConverter INSTANCE = new DateToLocalDateTimeConverter();
+
+    private DateToLocalDateTimeConverter() {}
+
+    @Override
+    public LocalDateTime convert(Date source) {
+      return source == null ? null : LocalDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
+    }
+  }
+
+  public static class DurationToLongConverter implements Converter<Duration, Long> {
+
+    public static final DurationToLongConverter INSTANCE = new DurationToLongConverter();
+
+    private DurationToLongConverter() {}
+
+    @Override
+    public Long convert(Duration source) {
+      return source == null ? null : source.toNanos();
+    }
+  }
+
+  public static class LongToDurationConverter implements Converter<Long, Duration> {
+
+    public static final LongToDurationConverter INSTANCE = new LongToDurationConverter();
+
+    private LongToDurationConverter() {}
+
+    @Override
+    public Duration convert(Long source) {
+      return source == null ? null : Duration.ofNanos(source);
+    }
+  }
+}
+

--- a/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConverters.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConverters.java.mustache
@@ -1,6 +1,7 @@
 package {{packageName}}.technical.infrastructure.secondary.mongodb;
 
-import java.time.*;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
 import java.util.Date;
 import org.springframework.core.convert.converter.Converter;
 
@@ -11,30 +12,6 @@ public final class JSR310DateConverters {
 
   private JSR310DateConverters() {}
 
-  public static class LocalDateToDateConverter implements Converter<LocalDate, Date> {
-
-    public static final LocalDateToDateConverter INSTANCE = new LocalDateToDateConverter();
-
-    private LocalDateToDateConverter() {}
-
-    @Override
-    public Date convert(LocalDate source) {
-      return source == null ? null : Date.from(source.atStartOfDay(ZoneId.systemDefault()).toInstant());
-    }
-  }
-
-  public static class DateToLocalDateConverter implements Converter<Date, LocalDate> {
-
-    public static final DateToLocalDateConverter INSTANCE = new DateToLocalDateConverter();
-
-    private DateToLocalDateConverter() {}
-
-    @Override
-    public LocalDate convert(Date source) {
-      return source == null ? null : ZonedDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault()).toLocalDate();
-    }
-  }
-
   public static class ZonedDateTimeToDateConverter implements Converter<ZonedDateTime, Date> {
 
     public static final ZonedDateTimeToDateConverter INSTANCE = new ZonedDateTimeToDateConverter();
@@ -43,7 +20,7 @@ public final class JSR310DateConverters {
 
     @Override
     public Date convert(ZonedDateTime source) {
-      return source == null ? null : Date.from(source.toInstant());
+      return Date.from(source.toInstant());
     }
   }
 
@@ -55,56 +32,7 @@ public final class JSR310DateConverters {
 
     @Override
     public ZonedDateTime convert(Date source) {
-      return source == null ? null : ZonedDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
-    }
-  }
-
-  public static class LocalDateTimeToDateConverter implements Converter<LocalDateTime, Date> {
-
-    public static final LocalDateTimeToDateConverter INSTANCE = new LocalDateTimeToDateConverter();
-
-    private LocalDateTimeToDateConverter() {}
-
-    @Override
-    public Date convert(LocalDateTime source) {
-      return source == null ? null : Date.from(source.atZone(ZoneId.systemDefault()).toInstant());
-    }
-  }
-
-  public static class DateToLocalDateTimeConverter implements Converter<Date, LocalDateTime> {
-
-    public static final DateToLocalDateTimeConverter INSTANCE = new DateToLocalDateTimeConverter();
-
-    private DateToLocalDateTimeConverter() {}
-
-    @Override
-    public LocalDateTime convert(Date source) {
-      return source == null ? null : LocalDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
-    }
-  }
-
-  public static class DurationToLongConverter implements Converter<Duration, Long> {
-
-    public static final DurationToLongConverter INSTANCE = new DurationToLongConverter();
-
-    private DurationToLongConverter() {}
-
-    @Override
-    public Long convert(Duration source) {
-      return source == null ? null : source.toNanos();
-    }
-  }
-
-  public static class LongToDurationConverter implements Converter<Long, Duration> {
-
-    public static final LongToDurationConverter INSTANCE = new LongToDurationConverter();
-
-    private LongToDurationConverter() {}
-
-    @Override
-    public Duration convert(Long source) {
-      return source == null ? null : Duration.ofNanos(source);
+      return ZonedDateTime.ofInstant(source.toInstant(), ZoneId.systemDefault());
     }
   }
 }
-

--- a/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConvertersTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConvertersTest.java.mustache
@@ -4,10 +4,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import {{packageName}}.UnitTest;
 import {{packageName}}.technical.infrastructure.secondary.mongodb.JSR310DateConverters.*;
-import java.time.Duration;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.ZoneId;
 import java.time.ZonedDateTime;
 import java.util.Date;
 import org.junit.jupiter.api.DisplayName;
@@ -16,75 +12,21 @@ import org.junit.jupiter.api.Test;
 @UnitTest
 class JSR310DateConvertersTest {
 
-  private static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.parse("2022-02-13T12:00:00+01:00[Europe/Paris]");
-
-  @Test
-  @DisplayName("Should convert LocalDate to Date")
-  void shouldConvertLocalDateToDate() {
-    LocalDate source = ZONED_DATE_TIME.toLocalDate();
-    Date result = LocalDateToDateConverter.INSTANCE.convert(source);
-    assertThat(result).isEqualTo(toDate(source));
-  }
-
-  @Test
-  @DisplayName("Should convert Date to LocalDate")
-  void shouldConvertDateToLocalDate() {
-    Date source = toDate(ZONED_DATE_TIME);
-    LocalDate result = DateToLocalDateConverter.INSTANCE.convert(source);
-    assertThat(result).isEqualTo(ZONED_DATE_TIME.toLocalDate());
-  }
-
-  @Test
-  @DisplayName("Should convert Date to LocalDateTime")
-  void shouldConvertDateToLocalDateTime() {
-    Date source = toDate(ZONED_DATE_TIME);
-    LocalDateTime result = DateToLocalDateTimeConverter.INSTANCE.convert(source);
-    assertThat(result).isEqualTo(ZONED_DATE_TIME.toLocalDateTime());
-  }
-
-  @Test
-  @DisplayName("Should convert LocalDateTime to Date")
-  void shouldConvertLocalDateTimeToDate() {
-    LocalDateTime source = ZONED_DATE_TIME.toLocalDateTime();
-    Date result = LocalDateTimeToDateConverter.INSTANCE.convert(source);
-    assertThat(result).isEqualTo(toDate(ZONED_DATE_TIME));
-  }
-
   @Test
   @DisplayName("Should convert ZonedDateTime to Date")
   void shouldConvertZonedDateTimeToDate() {
-    Date result = ZonedDateTimeToDateConverter.INSTANCE.convert(ZONED_DATE_TIME);
-    assertThat(result).isEqualTo(toDate(ZONED_DATE_TIME));
+    ZonedDateTime source = ZonedDateTime.parse("2022-02-15T12:00:00+01:00[Europe/Paris]");
+    Date expected = Date.from(source.toInstant());
+    Date result = ZonedDateTimeToDateConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(expected);
   }
 
   @Test
   @DisplayName("Should convert Date to ZonedDateTime")
   void shouldConvertDateToZonedDateTime() {
-    Date source = toDate(ZONED_DATE_TIME);
+    ZonedDateTime expected = ZonedDateTime.parse("2022-02-15T12:00:00+01:00[Europe/Paris]");
+    Date source = Date.from(expected.toInstant());
     ZonedDateTime result = DateToZonedDateTimeConverter.INSTANCE.convert(source);
-    assertThat(result).isEqualTo(ZONED_DATE_TIME);
-  }
-
-  @Test
-  @DisplayName("Should convert Duration to Long")
-  void shouldConvertDurationToLong() {
-    Long result = DurationToLongConverter.INSTANCE.convert(Duration.ofDays(2));
-    assertThat(result).isEqualTo(172800000000000L);
-  }
-
-  @Test
-  @DisplayName("Should convert Long to Duration")
-  void shouldConvertLongToDuration() {
-    Duration result = LongToDurationConverter.INSTANCE.convert(172800000000000L);
-    assertThat(result).isEqualTo(Duration.ofDays(2));
-    assertThat(result).isEqualTo(Duration.ofHours(48));
-  }
-
-  private Date toDate(ZonedDateTime zonedDateTime) {
-    return Date.from(zonedDateTime.toInstant());
-  }
-
-  private Date toDate(LocalDate localDate) {
-    return Date.from(localDate.atStartOfDay().atZone(ZoneId.of("Europe/Paris")).toInstant());
+    assertThat(result).isEqualTo(expected);
   }
 }

--- a/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConvertersTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/JSR310DateConvertersTest.java.mustache
@@ -1,0 +1,90 @@
+package {{packageName}}.technical.infrastructure.secondary.mongodb;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import {{packageName}}.UnitTest;
+import {{packageName}}.technical.infrastructure.secondary.mongodb.JSR310DateConverters.*;
+import java.time.Duration;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+import java.time.ZonedDateTime;
+import java.util.Date;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+@UnitTest
+class JSR310DateConvertersTest {
+
+  private static final ZonedDateTime ZONED_DATE_TIME = ZonedDateTime.parse("2022-02-13T12:00:00+01:00[Europe/Paris]");
+
+  @Test
+  @DisplayName("Should convert LocalDate to Date")
+  void shouldConvertLocalDateToDate() {
+    LocalDate source = ZONED_DATE_TIME.toLocalDate();
+    Date result = LocalDateToDateConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(toDate(source));
+  }
+
+  @Test
+  @DisplayName("Should convert Date to LocalDate")
+  void shouldConvertDateToLocalDate() {
+    Date source = toDate(ZONED_DATE_TIME);
+    LocalDate result = DateToLocalDateConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(ZONED_DATE_TIME.toLocalDate());
+  }
+
+  @Test
+  @DisplayName("Should convert Date to LocalDateTime")
+  void shouldConvertDateToLocalDateTime() {
+    Date source = toDate(ZONED_DATE_TIME);
+    LocalDateTime result = DateToLocalDateTimeConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(ZONED_DATE_TIME.toLocalDateTime());
+  }
+
+  @Test
+  @DisplayName("Should convert LocalDateTime to Date")
+  void shouldConvertLocalDateTimeToDate() {
+    LocalDateTime source = ZONED_DATE_TIME.toLocalDateTime();
+    Date result = LocalDateTimeToDateConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(toDate(ZONED_DATE_TIME));
+  }
+
+  @Test
+  @DisplayName("Should convert ZonedDateTime to Date")
+  void shouldConvertZonedDateTimeToDate() {
+    Date result = ZonedDateTimeToDateConverter.INSTANCE.convert(ZONED_DATE_TIME);
+    assertThat(result).isEqualTo(toDate(ZONED_DATE_TIME));
+  }
+
+  @Test
+  @DisplayName("Should convert Date to ZonedDateTime")
+  void shouldConvertDateToZonedDateTime() {
+    Date source = toDate(ZONED_DATE_TIME);
+    ZonedDateTime result = DateToZonedDateTimeConverter.INSTANCE.convert(source);
+    assertThat(result).isEqualTo(ZONED_DATE_TIME);
+  }
+
+  @Test
+  @DisplayName("Should convert Duration to Long")
+  void shouldConvertDurationToLong() {
+    Long result = DurationToLongConverter.INSTANCE.convert(Duration.ofDays(2));
+    assertThat(result).isEqualTo(172800000000000L);
+  }
+
+  @Test
+  @DisplayName("Should convert Long to Duration")
+  void shouldConvertLongToDuration() {
+    Duration result = LongToDurationConverter.INSTANCE.convert(172800000000000L);
+    assertThat(result).isEqualTo(Duration.ofDays(2));
+    assertThat(result).isEqualTo(Duration.ofHours(48));
+  }
+
+  private Date toDate(ZonedDateTime zonedDateTime) {
+    return Date.from(zonedDateTime.toInstant());
+  }
+
+  private Date toDate(LocalDate localDate) {
+    return Date.from(localDate.atStartOfDay().atZone(ZoneId.of("Europe/Paris")).toInstant());
+  }
+}

--- a/src/main/resources/generator/server/springboot/database/mongodb/MongodbDatabaseConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/MongodbDatabaseConfiguration.java.mustache
@@ -13,7 +13,7 @@ import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 
 @Configuration
-@EnableMongoRepositories({ "com.mycompany.myapp" })
+@EnableMongoRepositories({ "{{packageName}}" })
 @Import(value = MongoAutoConfiguration.class)
 public class MongodbDatabaseConfiguration {
 

--- a/src/main/resources/generator/server/springboot/database/mongodb/MongodbDatabaseConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/MongodbDatabaseConfiguration.java.mustache
@@ -1,0 +1,27 @@
+package {{packageName}}.technical.infrastructure.secondary.mongodb;
+
+import {{packageName}}.technical.infrastructure.secondary.mongodb.JSR310DateConverters.DateToZonedDateTimeConverter;
+import {{packageName}}.technical.infrastructure.secondary.mongodb.JSR310DateConverters.ZonedDateTimeToDateConverter;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Import;
+import org.springframework.core.convert.converter.Converter;
+import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+
+@Configuration
+@EnableMongoRepositories({ "com.mycompany.myapp" })
+@Import(value = MongoAutoConfiguration.class)
+public class MongodbDatabaseConfiguration {
+
+  @Bean
+  public MongoCustomConversions customConversions() {
+    List<Converter<?, ?>> converters = new ArrayList<>();
+    converters.add(DateToZonedDateTimeConverter.INSTANCE);
+    converters.add(ZonedDateTimeToDateConverter.INSTANCE);
+    return new MongoCustomConversions(converters);
+  }
+}

--- a/src/main/resources/generator/server/springboot/database/mongodb/MongodbTestContainerExtension.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/MongodbTestContainerExtension.java.mustache
@@ -1,0 +1,36 @@
+package {{packageName}};
+
+import java.util.Collections;
+
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.testcontainers.containers.MongoDBContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class MongodbTestContainerExtension implements BeforeAllCallback {
+  private static final ThreadLocal<MongoDBContainer> THREAD_CONTAINER = new ThreadLocal<>();
+  private final long memoryInBytes = Math.round(1024 * 1024 * 1024 * 0.6);
+  private final long memorySwapInBytes = Math.round(1024 * 1024 * 1024 * 0.8);
+  private final long nanoCpu = Math.round(1_000_000_000L * 0.1);
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    if (null == THREAD_CONTAINER.get()) {
+      MongoDBContainer mongoDBContainer = new MongoDBContainer(DockerImageName.parse("{{mongodbDockerImage}}"))
+        .withReuse(true)
+        .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"))
+        .withCommand("--nojournal --wiredTigerCacheSizeGB 0.25 --wiredTigerCollectionBlockCompressor none --slowOpSampleRate 0 --setParameter ttlMonitorEnabled=false --setParameter diagnosticDataCollectionEnabled=false --setParameter logicalSessionRefreshMillis=6000000 --setParameter enableFlowControl=false --setParameter oplogFetcherUsesExhaust=false --setParameter disableResumableRangeDeleter=true --setParameter enableShardedIndexConsistencyCheck=false --setParameter enableFinerGrainedCatalogCacheRefresh=false --setParameter readHedgingMode=off --setParameter loadRoutingTableOnStartup=false --setParameter rangeDeleterBatchDelayMS=2000000 --setParameter skipShardingConfigurationChecks=true --setParameter syncdelay=3600")
+        .withCreateContainerCmdModifier(cmd -> cmd.getHostConfig()
+          .withMemory(memoryInBytes)
+          .withMemorySwap(memorySwapInBytes)
+          .withNanoCPUs(nanoCpu)
+        );
+      mongoDBContainer.start();
+      THREAD_CONTAINER.set(mongoDBContainer);
+    }
+  }
+
+  public static ThreadLocal<?> getThreadContainer() {
+    return THREAD_CONTAINER;
+  }
+}

--- a/src/main/resources/generator/server/springboot/database/mongodb/TestContainersSpringContextCustomizerFactory.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/TestContainersSpringContextCustomizerFactory.java.mustache
@@ -2,7 +2,7 @@ package {{packageName}};
 
 import java.util.List;
 
-import {{packageName}}.MongoDbTestContainerExtension;
+import {{packageName}}.MongodbTestContainerExtension;
 
 import org.springframework.test.context.ContextConfigurationAttributes;
 import org.springframework.test.context.ContextCustomizer;
@@ -14,7 +14,7 @@ public class TestContainersSpringContextCustomizerFactory implements ContextCust
   @Override
   public ContextCustomizer createContextCustomizer(Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
     return (context, mergedConfig) -> {
-      MongoDBContainer container = (MongoDBContainer) MongoDbTestContainerExtension.getThreadContainer().get();
+      MongoDBContainer container = (MongoDBContainer) MongodbTestContainerExtension.getThreadContainer().get();
       if (container != null) {
         TestPropertyValues.of("spring.data.mongodb.uri=" + container.getReplicaSetUrl())
           .applyTo(context.getEnvironment());

--- a/src/main/resources/generator/server/springboot/database/mongodb/TestContainersSpringContextCustomizerFactory.java.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/TestContainersSpringContextCustomizerFactory.java.mustache
@@ -1,0 +1,24 @@
+package {{packageName}};
+
+import java.util.List;
+
+import {{packageName}}.MongoDbTestContainerExtension;
+
+import org.springframework.test.context.ContextConfigurationAttributes;
+import org.springframework.test.context.ContextCustomizer;
+import org.springframework.test.context.ContextCustomizerFactory;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.testcontainers.containers.MongoDBContainer;
+
+public class TestContainersSpringContextCustomizerFactory implements ContextCustomizerFactory {
+  @Override
+  public ContextCustomizer createContextCustomizer(Class<?> testClass, List<ContextConfigurationAttributes> configAttributes) {
+    return (context, mergedConfig) -> {
+      MongoDBContainer container = (MongoDBContainer) MongoDbTestContainerExtension.getThreadContainer().get();
+      if (container != null) {
+        TestPropertyValues.of("spring.data.mongodb.uri=" + container.getReplicaSetUrl())
+          .applyTo(context.getEnvironment());
+      }
+    };
+  }
+}

--- a/src/main/resources/generator/server/springboot/database/mongodb/mongodb.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/mongodb.yml.mustache
@@ -1,0 +1,11 @@
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
+version: '3.8'
+services:
+  mongodb:
+    image: {{mongodbDockerImage}}
+    # If you want to expose these ports outside your dev PC,
+    # remove the "127.0.0.1:" prefix
+    ports:
+      - 127.0.0.1:27017:27017
+    # volumes:
+    #   - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/

--- a/src/main/resources/generator/server/springboot/database/mongodb/spring.factories.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/spring.factories.mustache
@@ -1,0 +1,1 @@
+org.springframework.test.context.ContextCustomizerFactory = {{packageName}}.TestContainersSpringContextCustomizerFactory

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/MongodbAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/MongodbAssert.java
@@ -1,0 +1,148 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.Mongodb.getMongodbDockerImage;
+
+import java.util.List;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.generator.project.domain.Project;
+
+public final class MongodbAssert {
+
+  private MongodbAssert() {}
+
+  public static void assertDependencies(Project project) {
+    assertFileContent(
+      project,
+      POM_XML,
+      List.of(
+        "<dependency>",
+        "<groupId>org.springframework.boot</groupId>",
+        "<artifactId>spring-boot-starter-data-mongodb</artifactId>",
+        "</dependency>"
+      )
+    );
+
+    assertFileContent(
+      project,
+      POM_XML,
+      List.of("<dependency>", "<groupId>org.mongodb</groupId>", "<artifactId>mongodb-driver-sync</artifactId>", "</dependency>")
+    );
+
+    assertFileContent(project, POM_XML, "<testcontainers.version>");
+    assertFileContent(project, POM_XML, "</testcontainers.version>");
+    assertFileContent(
+      project,
+      POM_XML,
+      List.of(
+        "<dependency>",
+        "<groupId>org.testcontainers</groupId>",
+        "<artifactId>mongodb</artifactId>",
+        "<version>${testcontainers.version}</version>",
+        "<scope>test</scope>",
+        "</dependency>"
+      )
+    );
+  }
+
+  public static void assertDockerMongodb(Project project) {
+    assertFileExist(project, "src/main/docker/mongodb.yml");
+    assertFileContent(project, "src/main/docker/mongodb.yml", getMongodbDockerImage());
+    assertFileContent(project, "src/main/docker/mongodb.yml", "- 127.0.0.1:27017:27017");
+  }
+
+  public static void assertJavaFiles(Project project) {
+    String packageNamePath = project.getPackageNamePath().orElse("com/mycompany/myapp");
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+
+    String mongodbPath = getPath(packageNamePath, "/technical/infrastructure/secondary/mongodb");
+    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "MongodbDatabaseConfiguration.java"));
+    assertFileContent(
+      project,
+      FileUtils.getPath(MAIN_JAVA, mongodbPath, "MongodbDatabaseConfiguration.java"),
+      "package " + packageName + ".technical.infrastructure.secondary.mongodb;"
+    );
+
+    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "JSR310DateConverters.java"));
+    assertFileContent(
+      project,
+      FileUtils.getPath(MAIN_JAVA, mongodbPath, "JSR310DateConverters.java"),
+      "package " + packageName + ".technical.infrastructure.secondary.mongodb;"
+    );
+  }
+
+  public static void assertTestFiles(Project project) {
+    String packagePath = project.getPackageNamePath().orElse("com/mycompany/myapp");
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+
+    String mongodbPath = getPath(packagePath, "/technical/infrastructure/secondary/mongodb");
+    assertFileExist(project, getPath(TEST_JAVA, packagePath, "/technical/infrastructure/secondary/mongodb/JSR310DateConvertersTest.java"));
+    assertFileContent(
+      project,
+      FileUtils.getPath(TEST_JAVA, mongodbPath, "JSR310DateConvertersTest.java"),
+      "package " + packageName + ".technical.infrastructure.secondary.mongodb;"
+    );
+
+    assertFileExist(project, getPath(TEST_JAVA, packagePath, "MongodbTestContainerExtension.java"));
+    assertFileContent(
+      project,
+      getPath(TEST_JAVA, packagePath, "IntegrationTest.java"),
+      "import org.junit.jupiter.api.extension.ExtendWith;"
+    );
+    assertFileContent(project, getPath(TEST_JAVA, packagePath, "IntegrationTest.java"), "@ExtendWith(MongodbTestContainerExtension.class)");
+
+    assertFileExist(project, getPath(TEST_JAVA, packagePath, "TestContainersSpringContextCustomizerFactory.java"));
+    assertFileContent(
+      project,
+      FileUtils.getPath(TEST_JAVA, packagePath, "TestContainersSpringContextCustomizerFactory.java"),
+      "package " + packageName + ";"
+    );
+  }
+
+  public static void assertConfigFiles(Project project) {
+    String baseName = project.getBaseName().orElse("jhipster");
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
+      List.of("spring.data.mongodb.database=" + baseName, "spring.data.mongodb.uri=mongodb://localhost:27017")
+    );
+
+    assertFileExist(project, getPath(TEST_RESOURCES, "META-INF", "spring.factories"));
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, "META-INF", "spring.factories"),
+      "org.springframework.test.context.ContextCustomizerFactory = " + packageName + ".TestContainersSpringContextCustomizerFactory"
+    );
+  }
+
+  public static void assertLoggerInConfig(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, LOGGING_CONFIGURATION),
+      List.of("<logger name=\"org.reflections\" level=\"WARN\" />", "<logger name=\"org.mongodb.driver\" level=\"WARN\" />")
+    );
+
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      List.of(
+        "<logger name=\"org.reflections\" level=\"WARN\" />",
+        "<logger name=\"org.mongodb.driver\" level=\"WARN\" />",
+        "<logger name=\"com.github.dockerjava\" level=\"WARN\" />",
+        "<logger name=\"org.testcontainers\" level=\"WARN\" />"
+      )
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationServiceIT.java
@@ -1,0 +1,254 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.application;
+
+import static tech.jhipster.lite.TestUtils.assertFileContent;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.TestUtils.tmpProject;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
+import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
+
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+class MongodbApplicationServiceIT {
+
+  @Autowired
+  MongodbApplicationService mongodbApplicationService;
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    mongodbApplicationService.init(project);
+
+    assertFileContent(project, POM_XML, springBootStarterDataMongodb());
+    assertFileContent(project, POM_XML, mongodbDriver());
+
+    assertFileExist(project, "src/main/docker/mongodb.yml");
+    assertFileContent(project, "src/main/docker/mongodb.yml", "- 127.0.0.1:27017:27017");
+
+    String packageNamePath = getPath("com/mycompany/myapp");
+    String mongodbPath = getPath("com/mycompany/myapp/technical/infrastructure/secondary/mongodb");
+    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "MongodbDatabaseConfiguration.java"));
+    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "JSR310DateConverters.java"));
+    assertFileExist(project, getPath(TEST_JAVA, mongodbPath, "JSR310DateConvertersTest.java"));
+    assertFileExist(project, getPath(TEST_JAVA, packageNamePath, "MongodbTestContainerExtension.java"));
+    assertFileExist(project, getPath(TEST_JAVA, packageNamePath, "TestContainersSpringContextCustomizerFactory.java"));
+    assertFileContent(
+      project,
+      getPath(TEST_JAVA, packageNamePath, "IntegrationTest.java"),
+      "import org.junit.jupiter.api.extension.ExtendWith;"
+    );
+    assertFileContent(
+      project,
+      getPath(TEST_JAVA, packageNamePath, "IntegrationTest.java"),
+      "@ExtendWith(MongodbTestContainerExtension.class)"
+    );
+
+    assertFileExist(project, getPath(TEST_RESOURCES, "META-INF", "spring.factories"));
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, "META-INF", "spring.factories"),
+      "org.springframework.test.context.ContextCustomizerFactory = com.mycompany.myapp.TestContainersSpringContextCustomizerFactory"
+    );
+
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
+      List.of("spring.data.mongodb.database=jhipster", "spring.data.mongodb.uri=mongodb://localhost:27017")
+    );
+    assertFileContent(project, POM_XML, "<testcontainers.version>");
+    assertFileContent(project, POM_XML, "</testcontainers.version>");
+    assertFileContent(project, POM_XML, testcontainers());
+    assertLoggerInConfig(project);
+  }
+
+  @Test
+  @DisplayName("should add Spring Data MongoDB dependency")
+  void shouldAddSpringDataMongodb() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    mongodbApplicationService.addSpringDataMongodb(project);
+
+    assertFileContent(project, POM_XML, springBootStarterDataMongodb());
+  }
+
+  @Test
+  @DisplayName("should add mongodb driver")
+  void shouldAddMongodbDriver() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+
+    mongodbApplicationService.addMongodbDriver(project);
+
+    assertFileContent(project, POM_XML, mongodbDriver());
+  }
+
+  @Test
+  @DisplayName("should add Docker compose")
+  void shouldAddDockerCompose() {
+    Project project = tmpProject();
+
+    mongodbApplicationService.addDockerCompose(project);
+
+    assertFileExist(project, "src/main/docker/mongodb.yml");
+    assertFileContent(project, "src/main/docker/mongodb.yml", "- 127.0.0.1:27017:27017");
+  }
+
+  @Test
+  @DisplayName("should add Java files")
+  void shouldAddJavaFiles() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "chips");
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
+
+    mongodbApplicationService.addJavaFiles(project);
+
+    assertFileExist(
+      project,
+      getPath(MAIN_JAVA, "tech/jhipster/chips", "/technical/infrastructure/secondary/mongodb/JSR310DateConverters.java")
+    );
+    assertFileExist(
+      project,
+      getPath(TEST_JAVA, "tech/jhipster/chips", "/technical/infrastructure/secondary/mongodb/JSR310DateConvertersTest.java")
+    );
+    assertFileExist(project, getPath(TEST_JAVA, "tech/jhipster/chips", "MongodbTestContainerExtension.java"));
+    assertFileExist(project, getPath(TEST_JAVA, "tech/jhipster/chips", "TestContainersSpringContextCustomizerFactory.java"));
+  }
+
+  @Test
+  @DisplayName("should add Configuration files")
+  void shouldAddConfigurationFiles() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "chips");
+
+    mongodbApplicationService.addConfigurationFiles(project);
+
+    assertFileExist(project, getPath(TEST_RESOURCES, "META-INF", "spring.factories"));
+  }
+
+  @Test
+  @DisplayName("should add properties")
+  void shouldAddProperties() {
+    Project project = tmpProject();
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
+    project.addConfig(BASE_NAME, "chips");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    mongodbApplicationService.addProperties(project);
+
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
+      List.of("spring.data.mongodb.database=chips", "spring.data.mongodb.uri=mongodb://localhost:27017")
+    );
+  }
+
+  @Test
+  @DisplayName("should add logging configuration")
+  void shouldAddLoggingConfiguration() {
+    Project project = tmpProject();
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
+    project.addConfig(BASE_NAME, "chips");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    mongodbApplicationService.addLogger(project);
+
+    assertLoggerInConfig(project);
+  }
+
+  @Test
+  @DisplayName("should add testcontainers")
+  void shouldAddTestcontainers() {
+    Project project = tmpProject();
+    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
+    project.addConfig(BASE_NAME, "chips");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.addApplicationTestProperties(project);
+
+    mongodbApplicationService.addTestContainers(project);
+
+    assertFileContent(project, POM_XML, "<testcontainers.version>");
+    assertFileContent(project, POM_XML, "</testcontainers.version>");
+    assertFileContent(project, POM_XML, testcontainers());
+  }
+
+  private void assertLoggerInConfig(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, LOGGING_CONFIGURATION),
+      List.of("<logger name=\"org.reflections\" level=\"WARN\" />", "<logger name=\"org.mongodb.driver\" level=\"WARN\" />")
+    );
+
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      List.of(
+        "<logger name=\"org.reflections\" level=\"WARN\" />",
+        "<logger name=\"org.mongodb.driver\" level=\"WARN\" />",
+        "<logger name=\"com.github.dockerjava\" level=\"WARN\" />",
+        "<logger name=\"org.testcontainers\" level=\"WARN\" />"
+      )
+    );
+  }
+
+  private List<String> springBootStarterDataMongodb() {
+    return List.of(
+      "<dependency>",
+      "<groupId>org.springframework.boot</groupId>",
+      "<artifactId>spring-boot-starter-data-mongodb</artifactId>",
+      "</dependency>"
+    );
+  }
+
+  private List<String> mongodbDriver() {
+    return List.of("<dependency>", "<groupId>org.mongodb</groupId>", "<artifactId>mongodb-driver-sync</artifactId>", "</dependency>");
+  }
+
+  private List<String> testcontainers() {
+    return List.of(
+      "<dependency>",
+      "<groupId>org.testcontainers</groupId>",
+      "<artifactId>mongodb</artifactId>",
+      "<version>${testcontainers.version}</version>",
+      "<scope>test</scope>",
+      "</dependency>"
+    );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/application/MongodbApplicationServiceIT.java
@@ -1,21 +1,13 @@
 package tech.jhipster.lite.generator.server.springboot.database.mongodb.application;
 
-import static tech.jhipster.lite.TestUtils.assertFileContent;
-import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.TestUtils.tmpProject;
-import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
-import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
-import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
-import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertConfigFiles;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertDependencies;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertDockerMongodb;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertJavaFiles;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertLoggerInConfig;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertTestFiles;
 
-import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -41,6 +33,7 @@ class MongodbApplicationServiceIT {
   SpringBootApplicationService springBootApplicationService;
 
   @Test
+  @DisplayName("Should init project with default values")
   void shouldInit() {
     Project project = tmpProject();
     initApplicationService.init(project);
@@ -49,206 +42,11 @@ class MongodbApplicationServiceIT {
 
     mongodbApplicationService.init(project);
 
-    assertFileContent(project, POM_XML, springBootStarterDataMongodb());
-    assertFileContent(project, POM_XML, mongodbDriver());
-
-    assertFileExist(project, "src/main/docker/mongodb.yml");
-    assertFileContent(project, "src/main/docker/mongodb.yml", "- 127.0.0.1:27017:27017");
-
-    String packageNamePath = getPath("com/mycompany/myapp");
-    String mongodbPath = getPath("com/mycompany/myapp/technical/infrastructure/secondary/mongodb");
-    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "MongodbDatabaseConfiguration.java"));
-    assertFileExist(project, getPath(MAIN_JAVA, mongodbPath, "JSR310DateConverters.java"));
-    assertFileExist(project, getPath(TEST_JAVA, mongodbPath, "JSR310DateConvertersTest.java"));
-    assertFileExist(project, getPath(TEST_JAVA, packageNamePath, "MongodbTestContainerExtension.java"));
-    assertFileExist(project, getPath(TEST_JAVA, packageNamePath, "TestContainersSpringContextCustomizerFactory.java"));
-    assertFileContent(
-      project,
-      getPath(TEST_JAVA, packageNamePath, "IntegrationTest.java"),
-      "import org.junit.jupiter.api.extension.ExtendWith;"
-    );
-    assertFileContent(
-      project,
-      getPath(TEST_JAVA, packageNamePath, "IntegrationTest.java"),
-      "@ExtendWith(MongodbTestContainerExtension.class)"
-    );
-
-    assertFileExist(project, getPath(TEST_RESOURCES, "META-INF", "spring.factories"));
-    assertFileContent(
-      project,
-      getPath(TEST_RESOURCES, "META-INF", "spring.factories"),
-      "org.springframework.test.context.ContextCustomizerFactory = com.mycompany.myapp.TestContainersSpringContextCustomizerFactory"
-    );
-
-    assertFileContent(
-      project,
-      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
-      List.of("spring.data.mongodb.database=jhipster", "spring.data.mongodb.uri=mongodb://localhost:27017")
-    );
-    assertFileContent(project, POM_XML, "<testcontainers.version>");
-    assertFileContent(project, POM_XML, "</testcontainers.version>");
-    assertFileContent(project, POM_XML, testcontainers());
+    assertDependencies(project);
+    assertDockerMongodb(project);
+    assertJavaFiles(project);
+    assertTestFiles(project);
+    assertConfigFiles(project);
     assertLoggerInConfig(project);
-  }
-
-  @Test
-  @DisplayName("should add Spring Data MongoDB dependency")
-  void shouldAddSpringDataMongodb() {
-    Project project = tmpProject();
-    initApplicationService.init(project);
-    mavenApplicationService.addPomXml(project);
-
-    mongodbApplicationService.addSpringDataMongodb(project);
-
-    assertFileContent(project, POM_XML, springBootStarterDataMongodb());
-  }
-
-  @Test
-  @DisplayName("should add mongodb driver")
-  void shouldAddMongodbDriver() {
-    Project project = tmpProject();
-    initApplicationService.init(project);
-    mavenApplicationService.addPomXml(project);
-
-    mongodbApplicationService.addMongodbDriver(project);
-
-    assertFileContent(project, POM_XML, mongodbDriver());
-  }
-
-  @Test
-  @DisplayName("should add Docker compose")
-  void shouldAddDockerCompose() {
-    Project project = tmpProject();
-
-    mongodbApplicationService.addDockerCompose(project);
-
-    assertFileExist(project, "src/main/docker/mongodb.yml");
-    assertFileContent(project, "src/main/docker/mongodb.yml", "- 127.0.0.1:27017:27017");
-  }
-
-  @Test
-  @DisplayName("should add Java files")
-  void shouldAddJavaFiles() {
-    Project project = tmpProject();
-    project.addConfig(BASE_NAME, "chips");
-    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
-
-    mongodbApplicationService.addJavaFiles(project);
-
-    assertFileExist(
-      project,
-      getPath(MAIN_JAVA, "tech/jhipster/chips", "/technical/infrastructure/secondary/mongodb/JSR310DateConverters.java")
-    );
-    assertFileExist(
-      project,
-      getPath(TEST_JAVA, "tech/jhipster/chips", "/technical/infrastructure/secondary/mongodb/JSR310DateConvertersTest.java")
-    );
-    assertFileExist(project, getPath(TEST_JAVA, "tech/jhipster/chips", "MongodbTestContainerExtension.java"));
-    assertFileExist(project, getPath(TEST_JAVA, "tech/jhipster/chips", "TestContainersSpringContextCustomizerFactory.java"));
-  }
-
-  @Test
-  @DisplayName("should add Configuration files")
-  void shouldAddConfigurationFiles() {
-    Project project = tmpProject();
-    project.addConfig(BASE_NAME, "chips");
-
-    mongodbApplicationService.addConfigurationFiles(project);
-
-    assertFileExist(project, getPath(TEST_RESOURCES, "META-INF", "spring.factories"));
-  }
-
-  @Test
-  @DisplayName("should add properties")
-  void shouldAddProperties() {
-    Project project = tmpProject();
-    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
-    project.addConfig(BASE_NAME, "chips");
-    initApplicationService.init(project);
-    mavenApplicationService.addPomXml(project);
-    springBootApplicationService.init(project);
-
-    mongodbApplicationService.addProperties(project);
-
-    assertFileContent(
-      project,
-      getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES),
-      List.of("spring.data.mongodb.database=chips", "spring.data.mongodb.uri=mongodb://localhost:27017")
-    );
-  }
-
-  @Test
-  @DisplayName("should add logging configuration")
-  void shouldAddLoggingConfiguration() {
-    Project project = tmpProject();
-    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
-    project.addConfig(BASE_NAME, "chips");
-    initApplicationService.init(project);
-    mavenApplicationService.addPomXml(project);
-    springBootApplicationService.init(project);
-
-    mongodbApplicationService.addLogger(project);
-
-    assertLoggerInConfig(project);
-  }
-
-  @Test
-  @DisplayName("should add testcontainers")
-  void shouldAddTestcontainers() {
-    Project project = tmpProject();
-    project.addConfig(PACKAGE_NAME, "tech.jhipster.chips");
-    project.addConfig(BASE_NAME, "chips");
-    initApplicationService.init(project);
-    mavenApplicationService.addPomXml(project);
-    springBootApplicationService.addApplicationTestProperties(project);
-
-    mongodbApplicationService.addTestContainers(project);
-
-    assertFileContent(project, POM_XML, "<testcontainers.version>");
-    assertFileContent(project, POM_XML, "</testcontainers.version>");
-    assertFileContent(project, POM_XML, testcontainers());
-  }
-
-  private void assertLoggerInConfig(Project project) {
-    assertFileContent(
-      project,
-      getPath(MAIN_RESOURCES, LOGGING_CONFIGURATION),
-      List.of("<logger name=\"org.reflections\" level=\"WARN\" />", "<logger name=\"org.mongodb.driver\" level=\"WARN\" />")
-    );
-
-    assertFileContent(
-      project,
-      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
-      List.of(
-        "<logger name=\"org.reflections\" level=\"WARN\" />",
-        "<logger name=\"org.mongodb.driver\" level=\"WARN\" />",
-        "<logger name=\"com.github.dockerjava\" level=\"WARN\" />",
-        "<logger name=\"org.testcontainers\" level=\"WARN\" />"
-      )
-    );
-  }
-
-  private List<String> springBootStarterDataMongodb() {
-    return List.of(
-      "<dependency>",
-      "<groupId>org.springframework.boot</groupId>",
-      "<artifactId>spring-boot-starter-data-mongodb</artifactId>",
-      "</dependency>"
-    );
-  }
-
-  private List<String> mongodbDriver() {
-    return List.of("<dependency>", "<groupId>org.mongodb</groupId>", "<artifactId>mongodb-driver-sync</artifactId>", "</dependency>");
-  }
-
-  private List<String> testcontainers() {
-    return List.of(
-      "<dependency>",
-      "<groupId>org.testcontainers</groupId>",
-      "<artifactId>mongodb</artifactId>",
-      "<version>${testcontainers.version}</version>",
-      "<scope>test</scope>",
-      "</dependency>"
-    );
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbDomainServiceTest.java
@@ -1,0 +1,68 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.domain;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static tech.jhipster.lite.TestUtils.tmpProjectWithPomXml;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
+import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class MongodbDomainServiceTest {
+
+  @Mock
+  ProjectRepository projectRepository;
+
+  @Mock
+  BuildToolService buildToolService;
+
+  @Mock
+  SpringBootCommonService springBootCommonService;
+
+  @InjectMocks
+  MongodbDomainService mongodbDomainService;
+
+  @Test
+  void shouldInit() {
+    Project project = tmpProjectWithPomXml();
+    when(buildToolService.getVersion(project, "testcontainers")).thenReturn(Optional.of("0.0.0"));
+
+    mongodbDomainService.init(project);
+
+    verify(buildToolService, times(3)).addDependency(any(Project.class), any(Dependency.class));
+
+    verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
+    verify(projectRepository, times(6)).template(any(Project.class), anyString(), anyString(), anyString());
+
+    verify(springBootCommonService).addPropertiesComment(any(Project.class), anyString());
+    verify(springBootCommonService, times(2)).addProperties(any(Project.class), anyString(), any());
+    verify(springBootCommonService).addPropertiesNewLine(any(Project.class));
+    verify(springBootCommonService, times(2)).addLogger(any(Project.class), anyString(), any(Level.class));
+    verify(springBootCommonService, times(4)).addLoggerTest(any(Project.class), anyString(), any(Level.class));
+    verify(projectRepository, times(2)).replaceText(any(Project.class), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotInit() {
+    Project project = tmpProjectWithPomXml();
+
+    assertThatThrownBy(() -> mongodbDomainService.init(project)).isExactlyInstanceOf(GeneratorException.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/domain/MongodbTest.java
@@ -1,0 +1,34 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+
+@UnitTest
+class MongodbTest {
+
+  @Test
+  void shouldGetDockerImageName() {
+    assertThat(Mongodb.getMongodbDockerImage()).isEqualTo("mongo:4.4.11");
+  }
+
+  @Test
+  void shouldGetMongodbDockerVersion() {
+    assertThat(Mongodb.getMongodbDockerVersion()).isEqualTo(Mongodb.MONGODB_DOCKER_VERSION);
+  }
+
+  @Test
+  void shouldGetMongodbDockerImage() {
+    assertThat(Mongodb.getMongodbDockerImage()).isEqualTo(Mongodb.MONGODB_DOCKER_IMAGE);
+  }
+
+  @Test
+  void shouldMongodbDriver() {
+    Dependency dependency = Mongodb.mongodbDriver();
+
+    assertThat(dependency.getGroupId()).isEqualTo("org.mongodb");
+    assertThat(dependency.getArtifactId()).isEqualTo("mongodb-driver-sync");
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfigurationIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/config/MongodbBeanConfigurationIT.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastructure.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.generator.server.springboot.database.mongodb.domain.MongodbDomainService;
+
+@IntegrationTest
+class MongodbBeanConfigurationIT {
+
+  @Autowired
+  ApplicationContext applicationContext;
+
+  @Test
+  void shouldGetBean() {
+    assertThat(applicationContext.getBean("mongodbService")).isNotNull().isInstanceOf(MongodbDomainService.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResourceIT.java
@@ -1,0 +1,73 @@
+package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastructure.primary.rest;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
+import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import tech.jhipster.lite.IntegrationTest;
+import tech.jhipster.lite.TestUtils;
+import tech.jhipster.lite.common.domain.FileUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
+import tech.jhipster.lite.generator.init.application.InitApplicationService;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
+import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
+
+@IntegrationTest
+@AutoConfigureMockMvc
+class MongodbResourceIT {
+
+  @Autowired
+  InitApplicationService initApplicationService;
+
+  @Autowired
+  MavenApplicationService mavenApplicationService;
+
+  @Autowired
+  SpringBootApplicationService springBootApplicationService;
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @Test
+  void shouldInit() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class);
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    projectDTO.folder(FileUtils.tmpDirForTest());
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/databases/mongodb")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    String projectPath = projectDTO.getFolder();
+    assertFileExist(
+      projectPath,
+      getPath(MAIN_JAVA, "tech/jhipster/chips/technical/infrastructure/secondary/mongodb/JSR310DateConverters.java")
+    );
+    assertFileExist(
+      projectPath,
+      getPath(TEST_JAVA, "tech/jhipster/chips/technical/infrastructure/secondary/mongodb/JSR310DateConvertersTest.java")
+    );
+
+    assertFileExist(projectPath, "src/main/docker/mongodb.yml");
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/rest/MongodbResourceIT.java
@@ -2,10 +2,12 @@ package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastr
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static tech.jhipster.lite.TestUtils.assertFileExist;
-import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertConfigFiles;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertDependencies;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertDockerMongodb;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertJavaFiles;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertLoggerInConfig;
+import static tech.jhipster.lite.generator.server.springboot.database.mongodb.MongodbAssert.assertTestFiles;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -58,16 +60,11 @@ class MongodbResourceIT {
       )
       .andExpect(status().isOk());
 
-    String projectPath = projectDTO.getFolder();
-    assertFileExist(
-      projectPath,
-      getPath(MAIN_JAVA, "tech/jhipster/chips/technical/infrastructure/secondary/mongodb/JSR310DateConverters.java")
-    );
-    assertFileExist(
-      projectPath,
-      getPath(TEST_JAVA, "tech/jhipster/chips/technical/infrastructure/secondary/mongodb/JSR310DateConvertersTest.java")
-    );
-
-    assertFileExist(projectPath, "src/main/docker/mongodb.yml");
+    assertDependencies(project);
+    assertDockerMongodb(project);
+    assertJavaFiles(project);
+    assertTestFiles(project);
+    assertConfigFiles(project);
+    assertLoggerInConfig(project);
   }
 }

--- a/tests-ci/config/tomcat-mongodb.json
+++ b/tests-ci/config/tomcat-mongodb.json
@@ -1,0 +1,9 @@
+{
+  "folder": "/tmp/jhlite/tomcat-mongodb",
+  "generator-jhipster": {
+    "projectName": "Beer Project",
+    "baseName": "beer",
+    "prettierDefaultIndent": 2,
+    "packageName": "tech.jhipster.beer"
+  }
+}

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -108,6 +108,17 @@ elif [[ $filename == 'undertow-consul' ]]; then
   callApi "/api/servers/spring-boot/mvc/web/actuator"
   callApi "/api/servers/spring-boot/spring-cloud/consul"
 
+elif [[ $filename == 'tomcat-mongodb' ]]; then
+  callApi "/api/projects/init"
+  callApi "/api/build-tools/maven"
+  callApi "/api/servers/java/base"
+  callApi "/api/servers/java/jacoco-minimum-coverage"
+  callApi "/api/servers/spring-boot"
+
+  callApi "/api/servers/spring-boot/mvc/web/tomcat"
+  callApi "/api/servers/spring-boot/mvc/web/actuator"
+  callApi "/api/servers/spring-boot/databases/mongodb"
+
 else
   echo "*** Unknown configuration..."
   exit 1


### PR DESCRIPTION
Related to #421 

Add MongoDB Support with Spring Data

You can do:

- POST /api/projects/init
- POST /api/build-tools/maven
- POST /api/build-tools/maven
- POST /api/servers/spring-boot/mvc/web/tomcat
- POST /api/servers/spring-boot/databases/mongodb