### PR TITLE
Sonar-maven-plugin and Properties-maven-plugin: use get version, managed by dependabot

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/Sonar.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/Sonar.java
@@ -2,14 +2,9 @@ package tech.jhipster.lite.generator.server.sonar.domain;
 
 public class Sonar {
 
-  public static final String SONARSOURCE_MAVEN_PLUGIN_VERSION = "3.9.1.2184";
   public static final String SONARQUBE_DOCKER_IMAGE = "sonarqube:9.2.4-community";
 
   private Sonar() {}
-
-  public static String getMavenPluginVersion() {
-    return SONARSOURCE_MAVEN_PLUGIN_VERSION;
-  }
 
   public static String getSonarqubeDockerImage() {
     return SONARQUBE_DOCKER_IMAGE;

--- a/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainService.java
@@ -2,8 +2,8 @@ package tech.jhipster.lite.generator.server.sonar.domain;
 
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PROJECT_NAME;
-import static tech.jhipster.lite.generator.server.sonar.domain.Sonar.getMavenPluginVersion;
 
+import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.buildtool.generic.domain.Plugin;
 import tech.jhipster.lite.generator.project.domain.Project;
@@ -60,7 +60,14 @@ public class SonarDomainService implements SonarService {
         </executions>"""
       )
       .build();
-    buildToolService.addProperty(project, "properties-maven-plugin.version", "1.0.0");
+    buildToolService
+      .getVersion(project, "properties-maven-plugin")
+      .ifPresentOrElse(
+        version -> buildToolService.addProperty(project, "properties-maven-plugin.version", version),
+        () -> {
+          throw new GeneratorException("Version not found: properties-maven-plugin");
+        }
+      );
     buildToolService.addPlugin(project, plugin);
   }
 
@@ -71,7 +78,14 @@ public class SonarDomainService implements SonarService {
       .artifactId("sonar-maven-plugin")
       .version("\\${sonar-maven-plugin.version}")
       .build();
-    buildToolService.addProperty(project, "sonar-maven-plugin.version", getMavenPluginVersion());
+    buildToolService
+      .getVersion(project, "sonar-maven-plugin")
+      .ifPresentOrElse(
+        version -> buildToolService.addProperty(project, "sonar-maven-plugin.version", version),
+        () -> {
+          throw new GeneratorException("Version not found: sonar-maven-plugin");
+        }
+      );
     buildToolService.addPluginManagement(project, plugin);
   }
 

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -25,6 +25,8 @@
     <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
     <checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
     <maven-antrun-plugin.version>3.0.0</maven-antrun-plugin.version>
+    <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
+    <sonar-maven-plugin.version>3.9.1.2184</sonar-maven-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -78,6 +80,16 @@
         <groupId>com.github.eirslett</groupId>
         <artifactId>frontend-maven-plugin</artifactId>
         <version>${frontend-maven-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>properties-maven-plugin</artifactId>
+        <version>${properties-maven-plugin.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.sonarsource.scanner.maven</groupId>
+        <artifactId>sonar-maven-plugin</artifactId>
+        <version>${sonar-maven-plugin.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainServiceTest.java
@@ -72,6 +72,8 @@ class SonarDomainServiceTest {
   void shouldNotAddSonarJavaBackendAndFrontend() {
     Project project = tmpProjectWithPomXml();
 
+    when(buildToolService.getVersion(any(Project.class), eq("properties-maven-plugin"))).thenReturn(Optional.of("0.0.0"));
+
     Assertions
       .assertThatThrownBy(() -> sonarDomainService.addSonarJavaBackendAndFrontend(project))
       .isExactlyInstanceOf(GeneratorException.class);

--- a/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarDomainServiceTest.java
@@ -1,0 +1,79 @@
+package tech.jhipster.lite.generator.server.sonar.domain;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static tech.jhipster.lite.TestUtils.tmpProjectWithPomXml;
+
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Plugin;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class SonarDomainServiceTest {
+
+  @Mock
+  ProjectRepository projectRepository;
+
+  @Mock
+  BuildToolService buildToolService;
+
+  @InjectMocks
+  SonarDomainService sonarDomainService;
+
+  @Test
+  void shouldAddSonarJavaBackend() {
+    Project project = tmpProjectWithPomXml();
+    when(buildToolService.getVersion(any(Project.class), anyString())).thenReturn(Optional.of("0.0.0"));
+
+    sonarDomainService.addSonarJavaBackend(project);
+
+    verify(buildToolService, times(2)).addProperty(any(Project.class), anyString(), anyString());
+    verify(buildToolService).addPlugin(any(Project.class), any(Plugin.class));
+    verify(buildToolService).addPluginManagement(any(Project.class), any(Plugin.class));
+
+    verify(projectRepository).template(any(Project.class), anyString(), anyString());
+    verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotAddSonarJavaBackend() {
+    Project project = tmpProjectWithPomXml();
+
+    Assertions.assertThatThrownBy(() -> sonarDomainService.addSonarJavaBackend(project)).isExactlyInstanceOf(GeneratorException.class);
+  }
+
+  @Test
+  void shouldAddSonarJavaBackendAndFrontend() {
+    Project project = tmpProjectWithPomXml();
+    when(buildToolService.getVersion(any(Project.class), anyString())).thenReturn(Optional.of("0.0.0"));
+
+    sonarDomainService.addSonarJavaBackendAndFrontend(project);
+
+    verify(buildToolService, times(2)).addProperty(any(Project.class), anyString(), anyString());
+    verify(buildToolService).addPlugin(any(Project.class), any(Plugin.class));
+    verify(buildToolService).addPluginManagement(any(Project.class), any(Plugin.class));
+
+    verify(projectRepository, times(2)).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldNotAddSonarJavaBackendAndFrontend() {
+    Project project = tmpProjectWithPomXml();
+
+    Assertions
+      .assertThatThrownBy(() -> sonarDomainService.addSonarJavaBackendAndFrontend(project))
+      .isExactlyInstanceOf(GeneratorException.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/sonar/domain/SonarTest.java
@@ -9,11 +9,6 @@ import tech.jhipster.lite.UnitTest;
 class SonarTest {
 
   @Test
-  void shouldGetMavenPluginVersion() {
-    assertThat(Sonar.getMavenPluginVersion()).isEqualTo("3.9.1.2184");
-  }
-
-  @Test
   void shouldGetSonarqubeDockerVersion() {
     assertThat(Sonar.getSonarqubeDockerImage()).isEqualTo("sonarqube:9.2.4-community");
   }


### PR DESCRIPTION
- related to https://github.com/jhipster/jhipster-lite/issues/615