### PR TITLE
Revert "Bump @typescript-eslint/parser from 5.11.0 to 5.12.0 in /src/main/resources/generator/dependencies/vite/vue3"

### DIFF
--- a/src/main/resources/generator/dependencies/vite/vue3/package.json
+++ b/src/main/resources/generator/dependencies/vite/vue3/package.json
@@ -9,7 +9,7 @@
   "devDependencies": {
     "@rushstack/eslint-patch": "1.1.0",
     "@types/jest": "27.4.0",
-    "@typescript-eslint/parser": "5.12.0",
+    "@typescript-eslint/parser": "5.11.0",
     "@vitejs/plugin-vue": "2.2.0",
     "@vue/eslint-config-typescript": "10.0.0",
     "@vue/test-utils": "2.0.0-rc.18",


### PR DESCRIPTION
Reverts jhipster/jhipster-lite#732