### PR TITLE
Revert "Bump @typescript-eslint/parser from 5.11.0 to 5.12.0 in /src/main/resources/generator/dependencies/common"

### DIFF
--- a/src/main/resources/generator/dependencies/common/package.json
+++ b/src/main/resources/generator/dependencies/common/package.json
@@ -8,7 +8,7 @@
     "@types/jest": "27.4.0",
     "@types/node": "17.0.18",
     "@typescript-eslint/eslint-plugin": "5.12.0",
-    "@typescript-eslint/parser": "5.12.0",
+    "@typescript-eslint/parser": "5.11.0",
     "eslint": "8.9.0",
     "eslint-import-resolver-typescript": "2.5.0",
     "eslint-plugin-import": "2.25.4",


### PR DESCRIPTION
Reverts jhipster/jhipster-lite#729