### PR TITLE
Add logback test config on JwtSecurity

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainService.java
@@ -13,6 +13,7 @@ import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
 import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
 
 public class JwtSecurityDomainService implements JwtSecurityService {
@@ -41,6 +42,7 @@ public class JwtSecurityDomainService implements JwtSecurityService {
     addPropertyAndDependency(project);
     addJavaFiles(project);
     addProperties(project);
+    addLoggerInConfiguration(project);
 
     updateExceptionTranslator(project);
   }
@@ -188,5 +190,16 @@ public class JwtSecurityDomainService implements JwtSecurityService {
     result.put("application.cors.max-age", "1800");
     result.put("application.cors.allowed-origin-patterns", "https://*.githubpreview.dev");
     return result;
+  }
+
+  @Override
+  public void addLoggerInConfiguration(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+    addLogger(project, packageName + ".security.jwt.infrastructure.config", Level.WARN);
+  }
+
+  public void addLogger(Project project, String packageName, Level level) {
+    springBootCommonService.addLoggerTest(project, packageName, level);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityService.java
@@ -5,4 +5,5 @@ import tech.jhipster.lite.generator.project.domain.Project;
 public interface JwtSecurityService {
   void init(Project project);
   void addBasicAuth(Project project);
+  void addLoggerInConfiguration(Project project);
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityApplicationServiceIT.java
@@ -4,7 +4,12 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.tmpProject;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.*;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertBasicAuthJavaFiles;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertBasicAuthProperties;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertJwtSecurityFilesExists;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertJwtSecurityProperties;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertLoggerInConfiguration;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertPomXmlProperties;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -60,6 +65,8 @@ class JwtSecurityApplicationServiceIT {
       )
     );
     assertFileContent(project, getPath(TEST_JAVA, integrationTest), List.of("@WithMockUser", "public @interface"));
+
+    assertLoggerInConfiguration(project);
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityApplicationServiceIT.java
@@ -4,12 +4,7 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.tmpProject;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertBasicAuthJavaFiles;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertBasicAuthProperties;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertJwtSecurityFilesExists;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertJwtSecurityProperties;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertLoggerInConfiguration;
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.assertPomXmlProperties;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.application.JwtSecurityAssertFiles.*;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/application/JwtSecurityAssertFiles.java
@@ -4,7 +4,7 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
-import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.*;
 import static tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.domain.JwtSecurityDomainService.SECURITY_JWT_PATH;
 
 import java.util.List;
@@ -151,5 +151,14 @@ public class JwtSecurityAssertFiles {
 
     assertFileContent(project, getPath(MAIN_RESOURCES, "config/application.properties"), properties);
     assertFileContent(project, getPath(TEST_RESOURCES, "config/application.properties"), properties);
+  }
+
+  public static void assertLoggerInConfiguration(Project project) {
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      "<logger name=\"" + packageName + ".security.jwt.infrastructure.config\" level=\"WARN\" />"
+    );
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/domain/JwtSecurityDomainServiceTest.java
@@ -20,6 +20,7 @@ import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
 import tech.jhipster.lite.generator.project.infrastructure.secondary.GitUtils;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
 import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
 
 @UnitTest
@@ -55,6 +56,8 @@ class JwtSecurityDomainServiceTest {
     verify(springBootCommonService, times(3)).addProperties(any(Project.class), anyString(), any());
     verify(springBootCommonService, times(10)).addPropertiesTest(any(Project.class), anyString(), any());
     verify(springBootCommonService, times(7)).addPropertiesLocal(any(Project.class), anyString(), any());
+
+    verify(springBootCommonService).addLoggerTest(any(Project.class), anyString(), any(Level.class));
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/infrastructure/rest/JwtSecurityResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/infrastructure/rest/JwtSecurityResourceIT.java
@@ -70,6 +70,7 @@ class JwtSecurityResourceIT {
     assertPomXmlProperties(project);
     assertJwtSecurityFilesExists(project);
     assertJwtSecurityProperties(project);
+    assertLoggerInConfiguration(project);
   }
 
   @Test


### PR DESCRIPTION
Part of #584 

Before loback configuration
```
[INFO] Running tech.jhipster.beer.security.jwt.infrastructure.config.TokenProviderTest
2022-02-21 11:35:10.027  INFO   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Invalid JWT token.
2022-02-21 11:35:10.058  INFO   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Invalid JWT token.
2022-02-21 11:35:10.070  INFO   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Invalid JWT token.
2022-02-21 11:35:10.077  WARN   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Warning: the JWT key used is not Base64-encoded. We recommend using the `jhipster.security.authentication.jwt.base64-secret` key for optimum security.
2022-02-21 11:35:10.112  INFO   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Invalid JWT token.
2022-02-21 11:35:10.144  INFO   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Invalid JWT token.
```
With 
```
[INFO] Running tech.jhipster.beer.security.jwt.infrastructure.config.TokenProviderTest
2022-02-21 11:34:08.336  WARN   --- [           main] t.j.b.s.j.i.config.TokenProvider         : Warning: the JWT key used is not Base64-encoded. We recommend using the `jhipster.security.authentication.jwt.base64-secret` key for optimum security.
```
