### PR TITLE
Add logback test configuration for Logstash

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashApplicationService.java
@@ -28,4 +28,8 @@ public class LogstashApplicationService {
   public void addProperties(Project project) {
     logstashService.addProperties(project);
   }
+
+  public void addLoggerInConfiguration(Project project) {
+    logstashService.addLoggerInConfiguration(project);
+  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
@@ -12,6 +12,7 @@ import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
 import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
 
 public class LogstashDomainService implements LogstashService {
@@ -38,6 +39,7 @@ public class LogstashDomainService implements LogstashService {
     addDependencies(project);
     addJavaFiles(project);
     addProperties(project);
+    addLoggerInConfiguration(project);
   }
 
   @Override
@@ -91,5 +93,18 @@ public class LogstashDomainService implements LogstashService {
 
   private void templateToLogstash(Project project, String source, String type, String sourceFilename, String destination) {
     projectRepository.template(project, getPath(SOURCE, type), sourceFilename, getPath(destination, source, DESTINATION));
+  }
+
+  @Override
+  public void addLoggerInConfiguration(Project project) {
+    project.addDefaultConfig(PACKAGE_NAME);
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+    String destinationPackage = DESTINATION.replaceAll("/", ".");
+    addLogger(project, packageName + "." + destinationPackage, Level.WARN);
+    addLogger(project, "org.jboss.logging", Level.WARN);
+  }
+
+  private void addLogger(Project project, String packageName, Level level) {
+    springBootCommonService.addLoggerTest(project, packageName, level);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainService.java
@@ -99,7 +99,7 @@ public class LogstashDomainService implements LogstashService {
   public void addLoggerInConfiguration(Project project) {
     project.addDefaultConfig(PACKAGE_NAME);
     String packageName = project.getPackageName().orElse("com.mycompany.myapp");
-    String destinationPackage = DESTINATION.replaceAll("/", ".");
+    String destinationPackage = DESTINATION.replace("/", ".");
     addLogger(project, packageName + "." + destinationPackage, Level.WARN);
     addLogger(project, "org.jboss.logging", Level.WARN);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashService.java
@@ -8,4 +8,5 @@ public interface LogstashService {
   void addDependencies(Project project);
   void addJavaFiles(Project project);
   void addProperties(Project project);
+  void addLoggerInConfiguration(Project project);
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashApplicationServiceIT.java
@@ -34,17 +34,15 @@ class LogstashApplicationServiceIT {
     project.addConfig(BASE_NAME, "foo");
 
     initApplicationService.init(project);
-
     mavenApplicationService.addPomXml(project);
     springBootApplicationService.init(project);
 
     logstashApplicationService.init(project);
 
     assertDependencies(project);
-
     assertJavaFiles(project);
-
     assertProperties(project);
+    assertLoggerInConfiguration(project);
   }
 
   @Test
@@ -85,5 +83,18 @@ class LogstashApplicationServiceIT {
     logstashApplicationService.addProperties(project);
 
     assertProperties(project);
+  }
+
+  @Test
+  void shouldAddLoggerConfiguration() {
+    Project project = tmpProject();
+    project.addConfig(BASE_NAME, "bar");
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+
+    logstashApplicationService.addLoggerInConfiguration(project);
+
+    assertLoggerInConfiguration(project);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashAssert.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/application/LogstashAssert.java
@@ -4,6 +4,7 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.*;
 
 import java.util.List;
 import tech.jhipster.lite.generator.project.domain.DefaultConfig;
@@ -64,6 +65,18 @@ public class LogstashAssert {
         "application.logging.logstash.tcp.port=5000",
         "application.logging.logstash.tcp.ring-buffer-size=8192",
         "application.logging.logstash.tcp.shutdown_grace_period=PT1M"
+      )
+    );
+  }
+
+  public static void assertLoggerInConfiguration(Project project) {
+    String packageName = project.getPackageName().orElse("com.mycompany.myapp");
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      List.of(
+        "<logger name=\"" + packageName + ".technical.infrastructure.secondary.logstash\" level=\"WARN\" />",
+        "<logger name=\"org.jboss.logging\" level=\"WARN\" />"
       )
     );
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/domain/LogstashDomainServiceTest.java
@@ -18,6 +18,7 @@ import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
 import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
 
 @UnitTest
@@ -49,6 +50,8 @@ class LogstashDomainServiceTest {
     verify(projectRepository, times(7)).template(any(Project.class), anyString(), anyString(), anyString());
 
     verify(springBootCommonService, times(5)).addProperties(any(Project.class), anyString(), any());
+
+    verify(springBootCommonService, times(2)).addLoggerTest(any(Project.class), anyString(), any(Level.class));
   }
 
   @Test
@@ -85,5 +88,14 @@ class LogstashDomainServiceTest {
     logstashDomainService.addProperties(project);
 
     verify(springBootCommonService, times(5)).addProperties(any(Project.class), anyString(), any());
+  }
+
+  @Test
+  void shouldAddLoggerInConfiguration() {
+    Project project = tmpProjectWithPomXml();
+
+    logstashDomainService.addLoggerInConfiguration(project);
+
+    verify(springBootCommonService, times(2)).addLoggerTest(any(Project.class), anyString(), any(Level.class));
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/infrastructure/primary/rest/LogstashResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/infrastructure/primary/rest/LogstashResourceIT.java
@@ -58,5 +58,6 @@ class LogstashResourceIT {
     assertDependencies(project);
     assertJavaFiles(project);
     assertProperties(project);
+    assertLoggerInConfiguration(project);
   }
 }


### PR DESCRIPTION
Part of #584

Before loback configuration
```
[INFO] Running tech.jhipster.beer.technical.infrastructure.secondary.logstash.LogstashTcpConfigurationTest
2022-02-21 11:42:29.825 DEBUG 30100 --- [kground-preinit] org.jboss.logging                        : Logging Provider: org.jboss.logging.Log4j2LoggerProvider
2022-02-21 11:42:29.894  INFO 30100 --- [           main] j.b.t.i.s.l.LogstashTcpConfigurationTest : Starting LogstashTcpConfigurationTest using Java 17.0.1 on WhilyPc with PID 30100 (started by whily in D:\whily\Documents\jhipster\jhipster-beer)
2022-02-21 11:42:29.894  INFO 30100 --- [           main] j.b.t.i.s.l.LogstashTcpConfigurationTest : No active profile set, falling back to default profiles: default
2022-02-21 11:42:31.399  INFO 30100 --- [           main] j.b.t.i.s.l.LogstashTcpConfigurationTest : Started LogstashTcpConfigurationTest in 2.382 seconds (JVM running for 5.511)
```

After
```
[INFO] Running tech.jhipster.beer.technical.infrastructure.secondary.logstash.LogstashTcpConfigurationTest
```