### PR TITLE
Update logback config for Liquibase

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
@@ -107,6 +107,7 @@ public class LiquibaseDomainService implements LiquibaseService {
   public void addLoggerInConfiguration(Project project) {
     addLogger(project, "liquibase", Level.WARN);
     addLogger(project, "LiquibaseSchemaResolver", Level.INFO);
+    addLogger(project, "com.zaxxer.hikari", Level.INFO);
   }
 
   public void addLogger(Project project, String packageName, Level level) {

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseApplicationServiceIT.java
@@ -3,16 +3,9 @@ package tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.app
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static tech.jhipster.lite.TestUtils.*;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
-import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
-import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseChangelogMasterXml;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseJava;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseSqlUser;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.initClock;
+import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.*;
 import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.domain.Liquibase.NEEDLE_LIQUIBASE;
 
 import java.time.Clock;
@@ -166,24 +159,6 @@ class LiquibaseApplicationServiceIT {
     liquibaseApplicationService.addLoggerInConfiguration(project);
 
     assertLoggerInConfig(project);
-  }
-
-  private void assertLoggerInConfig(Project project) {
-    assertFileContent(
-      project,
-      getPath(MAIN_RESOURCES, LOGGING_CONFIGURATION),
-      List.of("<logger name=\"liquibase\" level=\"WARN\" />", "<logger name=\"LiquibaseSchemaResolver\" level=\"INFO\" />")
-    );
-
-    assertFileContent(
-      project,
-      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
-      List.of(
-        "<logger name=\"org.hibernate.validator\" level=\"WARN\" />",
-        "<logger name=\"org.hibernate\" level=\"WARN\" />",
-        "<logger name=\"org.hibernate.ejb.HibernatePersistence\" level=\"OFF\" />"
-      )
-    );
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
@@ -5,10 +5,12 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.*;
 
 import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
+import java.util.List;
 import tech.jhipster.lite.generator.project.domain.Project;
 
 public class LiquibaseAssertFiles {
@@ -65,5 +67,32 @@ public class LiquibaseAssertFiles {
   public static void initClock(Clock clock) {
     when(clock.getZone()).thenReturn(DEFAULT_TIMEZONE);
     when(clock.instant()).thenReturn(Instant.parse(CURRENT_DATE));
+  }
+
+  public static void assertLoggerInConfig(Project project) {
+    assertFileContent(
+      project,
+      getPath(MAIN_RESOURCES, LOGGING_CONFIGURATION),
+      List.of("<logger name=\"liquibase\" level=\"WARN\" />", "<logger name=\"LiquibaseSchemaResolver\" level=\"INFO\" />")
+    );
+
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      List.of(
+        "<logger name=\"org.hibernate.validator\" level=\"WARN\" />",
+        "<logger name=\"org.hibernate\" level=\"WARN\" />",
+        "<logger name=\"org.hibernate.ejb.HibernatePersistence\" level=\"OFF\" />"
+      )
+    );
+    assertFileContent(
+      project,
+      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
+      List.of(
+        "<logger name=\"liquibase\" level=\"WARN\" />",
+        "<logger name=\"LiquibaseSchemaResolver\" level=\"INFO\" />",
+        "<logger name=\"com.zaxxer.hikari\" level=\"INFO\" />"
+      )
+    );
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
@@ -80,15 +80,6 @@ public class LiquibaseAssertFiles {
       project,
       getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
       List.of(
-        "<logger name=\"org.hibernate.validator\" level=\"WARN\" />",
-        "<logger name=\"org.hibernate\" level=\"WARN\" />",
-        "<logger name=\"org.hibernate.ejb.HibernatePersistence\" level=\"OFF\" />"
-      )
-    );
-    assertFileContent(
-      project,
-      getPath(TEST_RESOURCES, LOGGING_TEST_CONFIGURATION),
-      List.of(
         "<logger name=\"liquibase\" level=\"WARN\" />",
         "<logger name=\"LiquibaseSchemaResolver\" level=\"INFO\" />",
         "<logger name=\"com.zaxxer.hikari\" level=\"INFO\" />"


### PR DESCRIPTION
Part of #584 

Before logback configuration
````
[INFO] Running tech.jhipster.beer.technical.infrastructure.secondary.liquibase.SpringLiquibaseUtilTest
2022-02-21 18:53:32.495 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
2022-02-21 18:53:33.043 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
2022-02-21 18:53:33.069 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
2022-02-21 18:53:33.089 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
2022-02-21 18:53:33.102 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
2022-02-21 18:53:33.510 DEBUG   --- [           main] com.zaxxer.hikari.HikariConfig           : Driver class org.h2.Driver found in Thread context class loader jdk.internal.loader.ClassLoaders$AppClassLoader@5e2de80c
````

After
````
[INFO] Running tech.jhipster.beer.technical.infrastructure.secondary.liquibase.SpringLiquibaseUtilTest
````