### PR TITLE
Add capacity to configure logging in test application properties

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/common/application/SpringBootCommonApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/common/application/SpringBootCommonApplicationService.java
@@ -30,6 +30,10 @@ public class SpringBootCommonApplicationService {
     springBootCommonService.addPropertiesTest(project, key, value);
   }
 
+  public void addPropertiesTestLogging(Project project, String key, Level value) {
+    springBootCommonService.addPropertiesTestLogging(project, key, value);
+  }
+
   public void addPropertiesNewLine(Project project) {
     springBootCommonService.addPropertiesNewLine(project);
   }
@@ -42,6 +46,10 @@ public class SpringBootCommonApplicationService {
     springBootCommonService.addPropertiesTestNewLine(project);
   }
 
+  public void addPropertiesTestLoggingNewLine(Project project) {
+    springBootCommonService.addPropertiesTestLoggingNewLine(project);
+  }
+
   public void addPropertiesComment(Project project, String text) {
     springBootCommonService.addPropertiesComment(project, text);
   }
@@ -52,6 +60,10 @@ public class SpringBootCommonApplicationService {
 
   public void addPropertiesTestComment(Project project, String text) {
     springBootCommonService.addPropertiesTestComment(project, text);
+  }
+
+  public void addPropertiesTestLoggingComment(Project project, String text) {
+    springBootCommonService.addPropertiesTestLoggingComment(project, text);
   }
 
   public void addLogger(Project project, String packageName, Level level) {

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/common/domain/SpringBootCommonDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/common/domain/SpringBootCommonDomainService.java
@@ -6,6 +6,7 @@ import static tech.jhipster.lite.generator.project.domain.Constants.*;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.BASE_NAME;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.PACKAGE_NAME;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.*;
+import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.NEEDLE_APPLICATION_TEST_LOGGING_PROPERTIES;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.NEEDLE_APPLICATION_TEST_PROPERTIES;
 
 import java.util.Optional;
@@ -47,6 +48,18 @@ public class SpringBootCommonDomainService implements SpringBootCommonService {
     addKeyValueToProperties(project, key, value, TEST_RESOURCES, APPLICATION_PROPERTIES, NEEDLE_APPLICATION_TEST_PROPERTIES);
   }
 
+  @Override
+  public void addPropertiesTestLogging(Project project, String key, Level value) {
+    addKeyValueToProperties(
+      project,
+      "logging.level." + key,
+      value,
+      TEST_RESOURCES,
+      APPLICATION_PROPERTIES,
+      NEEDLE_APPLICATION_TEST_LOGGING_PROPERTIES
+    );
+  }
+
   private void addKeyValueToProperties(
     Project project,
     String key,
@@ -80,6 +93,11 @@ public class SpringBootCommonDomainService implements SpringBootCommonService {
     addNewLineToProperties(project, TEST_RESOURCES, APPLICATION_PROPERTIES, NEEDLE_APPLICATION_TEST_PROPERTIES);
   }
 
+  @Override
+  public void addPropertiesTestLoggingNewLine(Project project) {
+    addNewLineToProperties(project, TEST_RESOURCES, APPLICATION_PROPERTIES, NEEDLE_APPLICATION_TEST_LOGGING_PROPERTIES);
+  }
+
   private void addNewLineToProperties(Project project, String folderProperties, String fileProperties, String needleProperties) {
     String propertiesWithNeedle = LF + needleProperties;
     projectRepository.replaceText(
@@ -104,6 +122,11 @@ public class SpringBootCommonDomainService implements SpringBootCommonService {
   @Override
   public void addPropertiesTestComment(Project project, String text) {
     addCommentToProperties(project, text, TEST_RESOURCES, APPLICATION_PROPERTIES, NEEDLE_APPLICATION_TEST_PROPERTIES);
+  }
+
+  @Override
+  public void addPropertiesTestLoggingComment(Project project, String text) {
+    addCommentToProperties(project, text, TEST_RESOURCES, APPLICATION_PROPERTIES, NEEDLE_APPLICATION_TEST_LOGGING_PROPERTIES);
   }
 
   private void addCommentToProperties(

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/common/domain/SpringBootCommonService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/common/domain/SpringBootCommonService.java
@@ -9,12 +9,15 @@ public interface SpringBootCommonService {
   void addProperties(Project project, String key, Object value);
   void addPropertiesLocal(Project project, String key, Object value);
   void addPropertiesTest(Project project, String key, Object value);
+  void addPropertiesTestLogging(Project project, String key, Level value);
   void addPropertiesNewLine(Project project);
   void addPropertiesLocalNewLine(Project project);
   void addPropertiesTestNewLine(Project project);
+  void addPropertiesTestLoggingNewLine(Project project);
   void addPropertiesComment(Project project, String text);
   void addPropertiesLocalComment(Project project, String text);
   void addPropertiesTestComment(Project project, String text);
+  void addPropertiesTestLoggingComment(Project project, String text);
 
   void addLogger(Project project, String packageName, Level level);
   void addLoggerTest(Project project, String packageName, Level level);

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBoot.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBoot.java
@@ -5,6 +5,7 @@ public class SpringBoot {
   public static final String NEEDLE_APPLICATION_PROPERTIES = "# jhipster-needle-application-properties";
   public static final String NEEDLE_APPLICATION_LOCAL_PROPERTIES = "# jhipster-needle-application-local-properties";
   public static final String NEEDLE_APPLICATION_TEST_PROPERTIES = "# jhipster-needle-application-test-properties";
+  public static final String NEEDLE_APPLICATION_TEST_LOGGING_PROPERTIES = "# jhipster-needle-application-test-logging-properties";
   public static final String NEEDLE_LOGBACK_LOGGER = "<!-- jhipster-needle-logback-add-log -->";
 
   public static final String APPLICATION_PROPERTIES = "application.properties";

--- a/src/main/resources/generator/server/springboot/core/application-test.properties.mustache
+++ b/src/main/resources/generator/server/springboot/core/application-test.properties.mustache
@@ -5,6 +5,9 @@
 #====================================================================
 
 spring.main.banner-mode=off
-logging.level.{{packageName}}=INFO
+
+# Logging configuration
+logging.level.{{packageName}}=OFF
+# jhipster-needle-application-test-logging-properties
 
 # jhipster-needle-application-test-properties

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/common/application/SpringBootCommonApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/common/application/SpringBootCommonApplicationServiceIT.java
@@ -215,6 +215,29 @@ class SpringBootCommonApplicationServiceIT {
   }
 
   @Nested
+  class TestLoggingPropertiesIT {
+
+    @Test
+    void shouldNotAddPropertiesLoggingTest() {
+      Project project = tmpProject();
+
+      assertThatThrownBy(() -> springBootCommonApplicationService.addPropertiesTestLogging(project, "tech.jhipster.beer", Level.OFF))
+        .isExactlyInstanceOf(GeneratorException.class);
+    }
+
+    @Test
+    void shouldAddPropertiesLoggingTest() {
+      Project project = tmpProjectWithSpringBootProperties();
+
+      springBootCommonApplicationService.addPropertiesTestLogging(project, "tech.jhipster.beer", Level.OFF);
+
+      String applicationProperties = getPath(TEST_RESOURCES, "config/application.properties");
+      assertFileContent(project, applicationProperties, "logging.level.tech.jhipster.beer=OFF");
+      assertFileContent(project, applicationProperties, "# jhipster-needle-application-test-logging-properties");
+    }
+  }
+
+  @Nested
   class PropertiesNewLineIT {
 
     @Test
@@ -292,6 +315,33 @@ class SpringBootCommonApplicationServiceIT {
   }
 
   @Nested
+  class PropertiesTestLoggingNewLineIT {
+
+    @Test
+    void shouldNotAddPropertiesTestLoggingNewLine() {
+      Project project = tmpProject();
+
+      assertThatThrownBy(() -> springBootCommonApplicationService.addPropertiesTestLoggingNewLine(project))
+        .isExactlyInstanceOf(GeneratorException.class);
+    }
+
+    @Test
+    void shouldAddPropertieTestsNewLine() throws IOException {
+      Project project = tmpProjectWithSpringBootProperties();
+
+      springBootCommonApplicationService.addPropertiesTestLogging(project, "tech.jhipster.beer", Level.WARN);
+      springBootCommonApplicationService.addPropertiesTestLoggingNewLine(project);
+
+      String applicationProperties = getPath(TEST_RESOURCES, "config/application.properties");
+      assertFileContentRegexp(
+        project,
+        applicationProperties,
+        "logging.level.tech.jhipster.beer=WARN" + LF + LF + "# jhipster-needle-application-test-logging-properties"
+      );
+    }
+  }
+
+  @Nested
   class PropertiesCommentIT {
 
     @Test
@@ -357,6 +407,29 @@ class SpringBootCommonApplicationServiceIT {
       String applicationProperties = getPath(TEST_RESOURCES, "config/application.properties");
       assertFileContent(project, applicationProperties, "# new comment");
       assertFileContent(project, applicationProperties, "# jhipster-needle-application-test-properties");
+    }
+  }
+
+  @Nested
+  class PropertiesTestLoggingCommentIT {
+
+    @Test
+    void shouldNotAddPropertiesTestLoggingComment() {
+      Project project = tmpProject();
+
+      assertThatThrownBy(() -> springBootCommonApplicationService.addPropertiesTestLoggingComment(project, "new comment"))
+        .isExactlyInstanceOf(GeneratorException.class);
+    }
+
+    @Test
+    void shouldAddPropertiesTestComment() {
+      Project project = tmpProjectWithSpringBootProperties();
+
+      springBootCommonApplicationService.addPropertiesTestLoggingComment(project, "new comment");
+
+      String applicationProperties = getPath(TEST_RESOURCES, "config/application.properties");
+      assertFileContent(project, applicationProperties, "# new comment");
+      assertFileContent(project, applicationProperties, "# jhipster-needle-application-test-logging-properties");
     }
   }
 

--- a/src/test/resources/generator/server/springboot/core/application.test.properties
+++ b/src/test/resources/generator/server/springboot/core/application.test.properties
@@ -5,4 +5,7 @@
 #====================================================================
 
 spring.main.banner-mode=off
+
+# jhipster-needle-application-test-logging-properties
+
 # jhipster-needle-application-test-properties


### PR DESCRIPTION
Adding capacity to configure logging in test application properties is the first step to reduce the logs in integration tests.

Part of #584
