### PR TITLE
feat(kafka): add akhq support

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationService.java
@@ -20,4 +20,8 @@ public class KafkaApplicationService {
   public void addDummyProducer(final Project project) {
     kafkaService.addDummyProducer(project);
   }
+
+  public void addAkhqSupport(final Project project) {
+    kafkaService.addAkhqSupport(project);
+  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationService.java
@@ -21,7 +21,7 @@ public class KafkaApplicationService {
     kafkaService.addDummyProducer(project);
   }
 
-  public void addAkhqSupport(final Project project) {
-    kafkaService.addAkhqSupport(project);
+  public void addAkhq(final Project project) {
+    kafkaService.addAkhq(project);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
@@ -1,0 +1,12 @@
+package tech.jhipster.lite.generator.server.springboot.broker.kafka.domain;
+
+public class Akhq {
+
+  public static final String AKHQ_DOCKER_IMAGE = "tchiotludo/akhq";
+
+  private Akhq() {}
+
+  public static String getAkhqDockerImage() {
+    return AKHQ_DOCKER_IMAGE;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
@@ -3,10 +3,15 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.domain;
 public class Akhq {
 
   public static final String AKHQ_DOCKER_IMAGE = "tchiotludo/akhq";
+  public static final String AFHQ_DOCKER_COMPOSE_FILE = "akhq.yml";
 
   private Akhq() {}
 
   public static String getAkhqDockerImage() {
     return AKHQ_DOCKER_IMAGE;
+  }
+
+  public static String getAkhqDockerComposeFile() {
+    return AFHQ_DOCKER_COMPOSE_FILE;
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Akhq.java
@@ -3,15 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.domain;
 public class Akhq {
 
   public static final String AKHQ_DOCKER_IMAGE = "tchiotludo/akhq";
-  public static final String AFHQ_DOCKER_COMPOSE_FILE = "akhq.yml";
+  public static final String AKHQ_DOCKER_COMPOSE_FILE = "akhq.yml";
 
   private Akhq() {}
-
-  public static String getAkhqDockerImage() {
-    return AKHQ_DOCKER_IMAGE;
-  }
-
-  public static String getAkhqDockerComposeFile() {
-    return AFHQ_DOCKER_COMPOSE_FILE;
-  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Kafka.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Kafka.java
@@ -3,10 +3,15 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.domain;
 public class Kafka {
 
   public static final String KAFKA_DOCKER_IMAGE = "confluentinc/cp-kafka";
+  public static final String KAFKA_DOCKER_COMPOSE_FILE = "kafka.yml";
 
   private Kafka() {}
 
   public static String getKafkaDockerImage() {
     return KAFKA_DOCKER_IMAGE;
+  }
+
+  public static String getKafkaDockerComposeFile() {
+    return KAFKA_DOCKER_COMPOSE_FILE;
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Kafka.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Kafka.java
@@ -6,12 +6,4 @@ public class Kafka {
   public static final String KAFKA_DOCKER_COMPOSE_FILE = "kafka.yml";
 
   private Kafka() {}
-
-  public static String getKafkaDockerImage() {
-    return KAFKA_DOCKER_IMAGE;
-  }
-
-  public static String getKafkaDockerComposeFile() {
-    return KAFKA_DOCKER_COMPOSE_FILE;
-  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
@@ -76,10 +76,10 @@ public class KafkaDomainService implements KafkaService {
   }
 
   @Override
-  public void addAkhqSupport(Project project) {
+  public void addAkhq(Project project) {
     final String akhqDockerImage = dockerService.getImageNameWithVersion(Akhq.getAkhqDockerImage()).orElseThrow();
     project.addConfig("akhqDockerImage", akhqDockerImage);
-    projectRepository.template(project, SOURCE, "akhq.yml", "src/main/docker", "akhq.yml");
+    projectRepository.template(project, SOURCE, Akhq.getAkhqDockerComposeFile(), MAIN_DOCKER, Akhq.getAkhqDockerComposeFile());
   }
 
   private void addApacheKafkaClient(final Project project) {
@@ -94,7 +94,7 @@ public class KafkaDomainService implements KafkaService {
     project.addDefaultConfig(BASE_NAME);
     project.addConfig("zookeeperDockerImage", zookeeperDockerImage);
     project.addConfig("kafkaDockerImage", kafkaDockerImage);
-    projectRepository.template(project, SOURCE, "kafka.yml", "src/main/docker", "kafka.yml");
+    projectRepository.template(project, SOURCE, Kafka.getKafkaDockerComposeFile(), MAIN_DOCKER, Kafka.getKafkaDockerComposeFile());
   }
 
   private void addProperties(final Project project) {

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
@@ -75,6 +75,13 @@ public class KafkaDomainService implements KafkaService {
     }
   }
 
+  @Override
+  public void addAkhqSupport(Project project) {
+    final String akhqDockerImage = dockerService.getImageNameWithVersion(Akhq.getAkhqDockerImage()).orElseThrow();
+    project.addConfig("akhqDockerImage", akhqDockerImage);
+    projectRepository.template(project, SOURCE, "akhq.yml", "src/main/docker", "akhq.yml");
+  }
+
   private void addApacheKafkaClient(final Project project) {
     final Dependency dependency = Dependency.builder().groupId("org.apache.kafka").artifactId("kafka-clients").build();
     buildToolService.addDependency(project, dependency);

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainService.java
@@ -3,6 +3,10 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.domain;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
 import static tech.jhipster.lite.generator.project.domain.DefaultConfig.*;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq.AKHQ_DOCKER_COMPOSE_FILE;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq.AKHQ_DOCKER_IMAGE;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka.KAFKA_DOCKER_COMPOSE_FILE;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka.KAFKA_DOCKER_IMAGE;
 
 import java.util.TreeMap;
 import tech.jhipster.lite.common.domain.WordUtils;
@@ -77,9 +81,9 @@ public class KafkaDomainService implements KafkaService {
 
   @Override
   public void addAkhq(Project project) {
-    final String akhqDockerImage = dockerService.getImageNameWithVersion(Akhq.getAkhqDockerImage()).orElseThrow();
+    final String akhqDockerImage = dockerService.getImageNameWithVersion(AKHQ_DOCKER_IMAGE).orElseThrow();
     project.addConfig("akhqDockerImage", akhqDockerImage);
-    projectRepository.template(project, SOURCE, Akhq.getAkhqDockerComposeFile(), MAIN_DOCKER, Akhq.getAkhqDockerComposeFile());
+    projectRepository.template(project, SOURCE, AKHQ_DOCKER_COMPOSE_FILE, MAIN_DOCKER, AKHQ_DOCKER_COMPOSE_FILE);
   }
 
   private void addApacheKafkaClient(final Project project) {
@@ -88,13 +92,13 @@ public class KafkaDomainService implements KafkaService {
   }
 
   private void addDockerCompose(final Project project) {
-    final String zookeeperDockerImage = dockerService.getImageNameWithVersion(Zookeeper.getZookeeperDockerImage()).orElseThrow();
-    final String kafkaDockerImage = dockerService.getImageNameWithVersion(Kafka.getKafkaDockerImage()).orElseThrow();
+    final String zookeeperDockerImage = dockerService.getImageNameWithVersion(Zookeeper.ZOOKEEPER_DOCKER_IMAGE).orElseThrow();
+    final String kafkaDockerImage = dockerService.getImageNameWithVersion(KAFKA_DOCKER_IMAGE).orElseThrow();
 
     project.addDefaultConfig(BASE_NAME);
     project.addConfig("zookeeperDockerImage", zookeeperDockerImage);
     project.addConfig("kafkaDockerImage", kafkaDockerImage);
-    projectRepository.template(project, SOURCE, Kafka.getKafkaDockerComposeFile(), MAIN_DOCKER, Kafka.getKafkaDockerComposeFile());
+    projectRepository.template(project, SOURCE, KAFKA_DOCKER_COMPOSE_FILE, MAIN_DOCKER, KAFKA_DOCKER_COMPOSE_FILE);
   }
 
   private void addProperties(final Project project) {

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaService.java
@@ -6,4 +6,6 @@ public interface KafkaService {
   void init(Project project);
 
   void addDummyProducer(Project project);
+
+  void addAkhqSupport(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaService.java
@@ -7,5 +7,5 @@ public interface KafkaService {
 
   void addDummyProducer(Project project);
 
-  void addAkhqSupport(Project project);
+  void addAkhq(Project project);
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Zookeeper.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/Zookeeper.java
@@ -5,8 +5,4 @@ public class Zookeeper {
   public static final String ZOOKEEPER_DOCKER_IMAGE = "confluentinc/cp-zookeeper";
 
   private Zookeeper() {}
-
-  public static String getZookeeperDockerImage() {
-    return ZOOKEEPER_DOCKER_IMAGE;
-  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
@@ -41,10 +41,10 @@ class KafkaResource {
     kafkaApplicationService.addDummyProducer(project);
   }
 
-  @Operation(summary = "Add AKHQ support")
-  @ApiResponse(responseCode = "500", description = "An error occurred while adding AKHQ support")
-  @PostMapping("/akhq-support")
-  @GeneratorStep(id = "springboot-kafka-akhq-support")
+  @Operation(summary = "Add AKHQ")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding AKHQ")
+  @PostMapping("/akhq")
+  @GeneratorStep(id = "springboot-kafka-akhq")
   public void addAkhq(final @RequestBody ProjectDTO projectDTO) {
     final Project project = ProjectDTO.toProject(projectDTO);
     kafkaApplicationService.addAkhq(project);

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
@@ -35,9 +35,18 @@ class KafkaResource {
   @Operation(summary = "Add a dummy Kafka producer")
   @ApiResponse(responseCode = "500", description = "An error occurred while adding a dummy Kafka producer")
   @PostMapping("/dummy-producer")
-  @GeneratorStep(id = "springboot-kafka-producer")
+  @GeneratorStep(id = "springboot-kafka-dummy-producer")
   public void addDummyProducer(final @RequestBody ProjectDTO projectDTO) {
     final Project project = ProjectDTO.toProject(projectDTO);
     kafkaApplicationService.addDummyProducer(project);
+  }
+
+  @Operation(summary = "Add AKHQ support")
+  @ApiResponse(responseCode = "500", description = "An error occurred while adding AKHQ support")
+  @PostMapping("/akhq-support")
+  @GeneratorStep(id = "springboot-kafka-akhq-support")
+  public void addAkhqSupport(final @RequestBody ProjectDTO projectDTO) {
+    final Project project = ProjectDTO.toProject(projectDTO);
+    kafkaApplicationService.addAkhqSupport(project);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResource.java
@@ -45,8 +45,8 @@ class KafkaResource {
   @ApiResponse(responseCode = "500", description = "An error occurred while adding AKHQ support")
   @PostMapping("/akhq-support")
   @GeneratorStep(id = "springboot-kafka-akhq-support")
-  public void addAkhqSupport(final @RequestBody ProjectDTO projectDTO) {
+  public void addAkhq(final @RequestBody ProjectDTO projectDTO) {
     final Project project = ProjectDTO.toProject(projectDTO);
-    kafkaApplicationService.addAkhqSupport(project);
+    kafkaApplicationService.addAkhq(project);
   }
 }

--- a/src/main/resources/generator/dependencies/Dockerfile
+++ b/src/main/resources/generator/dependencies/Dockerfile
@@ -9,3 +9,4 @@ FROM mysql:8.0.28
 FROM postgres:14.2
 FROM confluentinc/cp-zookeeper:7.0.1
 FROM confluentinc/cp-kafka:7.0.1
+FROM tchiotludo/akhq:0.20.0

--- a/src/main/resources/generator/server/springboot/broker/kafka/akhq.yml.mustache
+++ b/src/main/resources/generator/server/springboot/broker/kafka/akhq.yml.mustache
@@ -1,0 +1,13 @@
+version: '3.8'
+services:
+  akhq:
+    image: {{akhqDockerImage}}
+    environment:
+      AKHQ_CONFIGURATION: |
+        akhq:
+          connections:
+            docker-kafka-server:
+              properties:
+                bootstrap.servers: "kafka:29092"
+    ports:
+      - 11817:8080

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
@@ -3,6 +3,8 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.application;
 import static tech.jhipster.lite.TestUtils.*;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq.AKHQ_DOCKER_COMPOSE_FILE;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka.KAFKA_DOCKER_COMPOSE_FILE;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.APPLICATION_PROPERTIES;
 
 import java.util.List;
@@ -13,8 +15,6 @@ import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplication
 import tech.jhipster.lite.generator.docker.domain.DockerService;
 import tech.jhipster.lite.generator.init.application.InitApplicationService;
 import tech.jhipster.lite.generator.project.domain.Project;
-import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq;
-import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka;
 import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
 
 @IntegrationTest
@@ -45,7 +45,7 @@ class KafkaApplicationServiceIT {
     kafkaApplicationService.init(project);
     assertFileContent(project, POM_XML, kafkaClients());
 
-    String pathToKafkaDockerComposeFile = MAIN_DOCKER + "/" + Kafka.getKafkaDockerComposeFile();
+    String pathToKafkaDockerComposeFile = MAIN_DOCKER + "/" + KAFKA_DOCKER_COMPOSE_FILE;
     assertFileExist(project, pathToKafkaDockerComposeFile);
     assertFileContent(project, pathToKafkaDockerComposeFile, "KAFKA_BROKER_ID: 1");
 
@@ -106,7 +106,7 @@ class KafkaApplicationServiceIT {
 
     kafkaApplicationService.addAkhq(project);
 
-    String pathToAkhqDockerComposeFile = MAIN_DOCKER + "/" + Akhq.getAkhqDockerComposeFile();
+    String pathToAkhqDockerComposeFile = MAIN_DOCKER + "/" + AKHQ_DOCKER_COMPOSE_FILE;
     assertFileExist(project, pathToAkhqDockerComposeFile);
     assertFileContent(project, pathToAkhqDockerComposeFile, "AKHQ_CONFIGURATION");
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
@@ -13,6 +13,8 @@ import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplication
 import tech.jhipster.lite.generator.docker.domain.DockerService;
 import tech.jhipster.lite.generator.init.application.InitApplicationService;
 import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq;
+import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka;
 import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
 
 @IntegrationTest
@@ -43,8 +45,9 @@ class KafkaApplicationServiceIT {
     kafkaApplicationService.init(project);
     assertFileContent(project, POM_XML, kafkaClients());
 
-    assertFileExist(project, "src/main/docker/kafka.yml");
-    assertFileContent(project, "src/main/docker/kafka.yml", "KAFKA_BROKER_ID: 1");
+    String pathToKafkaDockerComposeFile = MAIN_DOCKER + "/" + Kafka.getKafkaDockerComposeFile();
+    assertFileExist(project, pathToKafkaDockerComposeFile);
+    assertFileContent(project, pathToKafkaDockerComposeFile, "KAFKA_BROKER_ID: 1");
 
     assertFileContent(project, getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES), "# Kafka Configuration");
     assertFileContent(project, getPath(MAIN_RESOURCES, "config", APPLICATION_PROPERTIES), "kafka.bootstrap-servers=localhost:9092");
@@ -94,17 +97,18 @@ class KafkaApplicationServiceIT {
   }
 
   @Test
-  void shouldAddAkhqSupport() {
+  void shouldAddAkhq() {
     Project project = tmpProject();
     initApplicationService.init(project);
     mavenApplicationService.addPomXml(project);
     springBootApplicationService.init(project);
     kafkaApplicationService.init(project);
 
-    kafkaApplicationService.addAkhqSupport(project);
+    kafkaApplicationService.addAkhq(project);
 
-    assertFileExist(project, "src/main/docker/akhq.yml");
-    assertFileContent(project, "src/main/docker/akhq.yml", "AKHQ_CONFIGURATION");
+    String pathToAkhqDockerComposeFile = MAIN_DOCKER + "/" + Akhq.getAkhqDockerImage();
+    assertFileExist(project, pathToAkhqDockerComposeFile);
+    assertFileContent(project, pathToAkhqDockerComposeFile, "AKHQ_CONFIGURATION");
   }
 
   private List<String> kafkaClients() {

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
@@ -93,6 +93,20 @@ class KafkaApplicationServiceIT {
     assertFileContent(project, getPath(TEST_JAVA, dummyProducerTestPath, "DummyProducerIT.java"), "class DummyProducerIT");
   }
 
+  @Test
+  void shouldAddAkhqSupport() {
+    Project project = tmpProject();
+    initApplicationService.init(project);
+    mavenApplicationService.addPomXml(project);
+    springBootApplicationService.init(project);
+    kafkaApplicationService.init(project);
+
+    kafkaApplicationService.addAkhqSupport(project);
+
+    assertFileExist(project, "src/main/docker/akhq.yml");
+    assertFileContent(project, "src/main/docker/akhq.yml", "AKHQ_CONFIGURATION");
+  }
+
   private List<String> kafkaClients() {
     return List.of("<dependency>", "<groupId>org.apache.kafka</groupId>", "<artifactId>kafka-clients</artifactId>", "</dependency>");
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/application/KafkaApplicationServiceIT.java
@@ -106,7 +106,7 @@ class KafkaApplicationServiceIT {
 
     kafkaApplicationService.addAkhq(project);
 
-    String pathToAkhqDockerComposeFile = MAIN_DOCKER + "/" + Akhq.getAkhqDockerImage();
+    String pathToAkhqDockerComposeFile = MAIN_DOCKER + "/" + Akhq.getAkhqDockerComposeFile();
     assertFileExist(project, pathToAkhqDockerComposeFile);
     assertFileContent(project, pathToAkhqDockerComposeFile, "AKHQ_CONFIGURATION");
   }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainServiceTest.java
@@ -70,11 +70,11 @@ class KafkaDomainServiceTest {
   }
 
   @Test
-  void shouldAddAkhqSupport() {
+  void shouldAddAkhq() {
     Project project = tmpProjectWithPomXml();
     when(dockerService.getImageNameWithVersion(anyString())).thenReturn(Optional.of("dummy"));
 
-    kafkaDomainService.addAkhqSupport(project);
+    kafkaDomainService.addAkhq(project);
 
     verify(dockerService).getImageNameWithVersion(anyString());
     verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString(), anyString());

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/domain/KafkaDomainServiceTest.java
@@ -51,7 +51,7 @@ class KafkaDomainServiceTest {
     verify(buildToolService, times(2)).addDependency(any(Project.class), any(Dependency.class));
     verify(dockerService, times(2)).getImageNameWithVersion(anyString());
     verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
-    verify(projectRepository, times(1)).template(any(Project.class), anyString(), anyString(), anyString());
+    verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString());
     verify(springBootCommonService, times(9)).addProperties(any(Project.class), anyString(), any());
     verify(springBootCommonService, times(9)).addPropertiesTest(any(Project.class), anyString(), any());
     verify(springBootCommonService).updateIntegrationTestAnnotation(any(Project.class), anyString());
@@ -67,6 +67,17 @@ class KafkaDomainServiceTest {
     verify(springBootCommonService).addProperties(any(Project.class), anyString(), any());
     verify(springBootCommonService).addPropertiesTest(any(Project.class), anyString(), any());
     verify(projectRepository, times(6)).template(any(Project.class), anyString(), anyString(), anyString());
+  }
+
+  @Test
+  void shouldAddAkhqSupport() {
+    Project project = tmpProjectWithPomXml();
+    when(dockerService.getImageNameWithVersion(anyString())).thenReturn(Optional.of("dummy"));
+
+    kafkaDomainService.addAkhqSupport(project);
+
+    verify(dockerService).getImageNameWithVersion(anyString());
+    verify(projectRepository).template(any(Project.class), anyString(), anyString(), anyString(), anyString());
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.infrastructu
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_DOCKER;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,6 +20,8 @@ import tech.jhipster.lite.generator.init.application.InitApplicationService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
 import tech.jhipster.lite.generator.server.springboot.broker.kafka.application.KafkaApplicationService;
+import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq;
+import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka;
 import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
 
 @IntegrationTest
@@ -63,7 +66,7 @@ class KafkaResourceIT {
       .andExpect(status().isOk());
 
     String projectPath = projectDTO.getFolder();
-    assertFileExist(projectPath, "src/main/docker/kafka.yml");
+    assertFileExist(projectPath, MAIN_DOCKER + "/" + Kafka.getKafkaDockerComposeFile());
   }
 
   @Test
@@ -118,6 +121,6 @@ class KafkaResourceIT {
       .andExpect(status().isOk());
 
     String projectPath = projectDTO.getFolder();
-    assertFileExist(projectPath, "src/main/docker/akhq.yml");
+    assertFileExist(projectPath, MAIN_DOCKER + "/" + Akhq.getAkhqDockerImage());
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
@@ -96,4 +96,28 @@ class KafkaResourceIT {
     assertFileExist(projectPath, "src/test/java/tech/jhipster/chips/dummy/infrastructure/secondary/kafka/producer/DummyProducerTest.java");
     assertFileExist(projectPath, "src/main/java/tech/jhipster/chips/technical/infrastructure/secondary/kafka/KafkaConfiguration.java");
   }
+
+  @Test
+  void shouldAkhqSupport() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(FileUtils.tmpDirForTest());
+    if (projectDTO == null) {
+      throw new GeneratorException("Error when reading file");
+    }
+    Project project = ProjectDTO.toProject(projectDTO);
+    initApplicationService.init(project);
+    mavenApplicationService.init(project);
+    springBootApplicationService.init(project);
+    kafkaApplicationService.init(project);
+
+    mockMvc
+      .perform(
+        post("/api/servers/spring-boot/brokers/kafka/akhq-support")
+          .contentType(MediaType.APPLICATION_JSON)
+          .content(TestUtils.convertObjectToJsonBytes(projectDTO))
+      )
+      .andExpect(status().isOk());
+
+    String projectPath = projectDTO.getFolder();
+    assertFileExist(projectPath, "src/main/docker/akhq.yml");
+  }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
@@ -5,6 +5,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.tmpDirForTest;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_DOCKER;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq.AKHQ_DOCKER_COMPOSE_FILE;
+import static tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka.KAFKA_DOCKER_COMPOSE_FILE;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,8 +22,6 @@ import tech.jhipster.lite.generator.init.application.InitApplicationService;
 import tech.jhipster.lite.generator.project.domain.Project;
 import tech.jhipster.lite.generator.project.infrastructure.primary.dto.ProjectDTO;
 import tech.jhipster.lite.generator.server.springboot.broker.kafka.application.KafkaApplicationService;
-import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Akhq;
-import tech.jhipster.lite.generator.server.springboot.broker.kafka.domain.Kafka;
 import tech.jhipster.lite.generator.server.springboot.core.application.SpringBootApplicationService;
 
 @IntegrationTest
@@ -66,7 +66,7 @@ class KafkaResourceIT {
       .andExpect(status().isOk());
 
     String projectPath = projectDTO.getFolder();
-    assertFileExist(projectPath, MAIN_DOCKER + "/" + Kafka.getKafkaDockerComposeFile());
+    assertFileExist(projectPath, MAIN_DOCKER + "/" + KAFKA_DOCKER_COMPOSE_FILE);
   }
 
   @Test
@@ -118,6 +118,6 @@ class KafkaResourceIT {
       .andExpect(status().isOk());
 
     String projectPath = projectDTO.getFolder();
-    assertFileExist(projectPath, MAIN_DOCKER + "/" + Akhq.getAkhqDockerComposeFile());
+    assertFileExist(projectPath, MAIN_DOCKER + "/" + AKHQ_DOCKER_COMPOSE_FILE);
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/rest/KafkaResourceIT.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.broker.kafka.infrastructu
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
+import static tech.jhipster.lite.common.domain.FileUtils.tmpDirForTest;
 import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_DOCKER;
 
 import org.junit.jupiter.api.Test;
@@ -12,7 +13,6 @@ import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import tech.jhipster.lite.IntegrationTest;
 import tech.jhipster.lite.TestUtils;
-import tech.jhipster.lite.common.domain.FileUtils;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.maven.application.MavenApplicationService;
 import tech.jhipster.lite.generator.docker.domain.DockerService;
@@ -48,7 +48,7 @@ class KafkaResourceIT {
 
   @Test
   void shouldInitKafka() throws Exception {
-    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(FileUtils.tmpDirForTest());
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(tmpDirForTest());
     if (projectDTO == null) {
       throw new GeneratorException("Error when reading file");
     }
@@ -71,7 +71,7 @@ class KafkaResourceIT {
 
   @Test
   void shouldAddProducer() throws Exception {
-    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(FileUtils.tmpDirForTest());
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(tmpDirForTest());
     if (projectDTO == null) {
       throw new GeneratorException("Error when reading file");
     }
@@ -101,11 +101,8 @@ class KafkaResourceIT {
   }
 
   @Test
-  void shouldAkhqSupport() throws Exception {
-    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(FileUtils.tmpDirForTest());
-    if (projectDTO == null) {
-      throw new GeneratorException("Error when reading file");
-    }
+  void shouldAkhq() throws Exception {
+    ProjectDTO projectDTO = TestUtils.readFileToObject("json/chips.json", ProjectDTO.class).folder(tmpDirForTest());
     Project project = ProjectDTO.toProject(projectDTO);
     initApplicationService.init(project);
     mavenApplicationService.init(project);
@@ -114,13 +111,13 @@ class KafkaResourceIT {
 
     mockMvc
       .perform(
-        post("/api/servers/spring-boot/brokers/kafka/akhq-support")
+        post("/api/servers/spring-boot/brokers/kafka/akhq")
           .contentType(MediaType.APPLICATION_JSON)
           .content(TestUtils.convertObjectToJsonBytes(projectDTO))
       )
       .andExpect(status().isOk());
 
     String projectPath = projectDTO.getFolder();
-    assertFileExist(projectPath, MAIN_DOCKER + "/" + Akhq.getAkhqDockerImage());
+    assertFileExist(projectPath, MAIN_DOCKER + "/" + Akhq.getAkhqDockerComposeFile());
   }
 }

--- a/src/test/resources/generator/dependencies/Dockerfile
+++ b/src/test/resources/generator/dependencies/Dockerfile
@@ -9,3 +9,4 @@ FROM mysql:8.0.28
 FROM postgres:14.2
 FROM confluentinc/cp-zookeeper:7.0.1
 FROM confluentinc/cp-kafka:7.0.1
+FROM tchiotludo/akhq:0.20.0

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -209,6 +209,7 @@ elif [[ $application == 'kafkaapp' ]]; then
 
   callApi "/api/servers/spring-boot/brokers/kafka"
   callApi "/api/servers/spring-boot/brokers/kafka/dummy-producer"
+  callApi "/api/servers/spring-boot/brokers/kafka/akhq-support"
 
 else
   echo "*** Unknown configuration..."

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -209,7 +209,7 @@ elif [[ $application == 'kafkaapp' ]]; then
 
   callApi "/api/servers/spring-boot/brokers/kafka"
   callApi "/api/servers/spring-boot/brokers/kafka/dummy-producer"
-  callApi "/api/servers/spring-boot/brokers/kafka/akhq-support"
+  callApi "/api/servers/spring-boot/brokers/kafka/akhq"
 
 else
   echo "*** Unknown configuration..."


### PR DESCRIPTION
fix #1098 

How to test:

1. Launch `docker-compose -f src/main/docker/kafka.yml up`
2. Then launch `docker-compose -f src/main/docker/akhq.yml up`
3. Finally, open [http://localhost:11817](http://localhost:11817)
4. Launch `./mvnw spring-boot:run` in generated kafkaapp
5. Produce a message in `queue.kafkaapp.dummy`: `kafka-console-producer.sh --broker-list localhost:9092 --topic queue.kafkaapp.dummy`
6. Topic and message are present in AKHQ