### PR TITLE
fix playwright test spec

### DIFF
--- a/src/main/resources/generator/client/common/playwright/src/test/javascript/integration/common/primary/app/Home.spec.ts.mustache
+++ b/src/main/resources/generator/client/common/playwright/src/test/javascript/integration/common/primary/app/Home.spec.ts.mustache
@@ -1,11 +1,11 @@
-import { test, Page } from '@playwright/test';
+import { test } from '@playwright/test';
 
-import { HomePage } from './home-page';
+import { HomePage } from './Home-Page';
 
 test.describe('Home', () => {
   test('display home page', async ({ page }) => {
     const homePage = new HomePage(page);
-    await homePage.visit();
+    await homePage.goto();
     await homePage.appLocator.waitFor();
   });
 });


### PR DESCRIPTION
Fixed the specification. Just noticed when you have e.g. already cypress added, and add playwright, the package json becomes invalid as mutiple scripts named e2e are created. Do we have already some means to prevent adding multiple e2e frameworks or multiple server side frameworks?

<img width="1034" alt="image" src="https://user-images.githubusercontent.com/203401/163680185-4c6d0f66-5734-40b9-bc84-2446cd477998.png">


udpates #1296