### PR TITLE
Fix style scoped for modules page

### DIFF
--- a/src/main/webapp/app/module/primary/modules-list/ModulesList.vue
+++ b/src/main/webapp/app/module/primary/modules-list/ModulesList.vue
@@ -2,7 +2,7 @@
 
 <script lang="ts" src="./ModulesList.component.ts"></script>
 
-<style>
+<style scoped>
 * {
   color: #29293b;
 }


### PR DESCRIPTION
Following https://github.com/jhipster/jhipster-lite/pull/2055

For fixing:

![image](https://user-images.githubusercontent.com/9156882/173625101-76bdf539-995e-4737-854a-88b461381382.png)
