### PR TITLE
Liquibase changelog version

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mariadb/domain/MariaDBModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mariadb/domain/MariaDBModuleFactory.java
@@ -52,7 +52,7 @@ public class MariaDBModuleFactory {
       .packageName(properties.basePackage())
       .put("applicationName", properties.projectBaseName().capitalized())
       .put("srcMainDocker", "src/main/docker") // Used in mariadb.md
-      .put("dockerImageWithVersion", dockerImage.fullName()); // Used in mariadb.yml
+      .put("mariaDBDockerImageWithVersion", dockerImage.fullName()); // Used in mariadb.yml
   }
 
   private void appendDocumentation(JHipsterModuleBuilder builder) {

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainService.java
@@ -8,6 +8,7 @@ import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquiba
 
 import java.time.Clock;
 import tech.jhipster.lite.common.domain.TimeUtils;
+import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
 import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
 import tech.jhipster.lite.generator.project.domain.Project;
@@ -51,7 +52,20 @@ public class LiquibaseDomainService implements LiquibaseService {
 
   @Override
   public void addLiquibase(Project project) {
-    Dependency liquibaseDependency = Dependency.builder().groupId("org.liquibase").artifactId("liquibase-core").build();
+    buildToolService
+      .getVersion(project, "liquibase")
+      .ifPresentOrElse(
+        version -> buildToolService.addProperty(project, "liquibase.version", version),
+        () -> {
+          throw new GeneratorException("Version not found: liquibase");
+        }
+      );
+    Dependency liquibaseDependency = Dependency
+      .builder()
+      .groupId("org.liquibase")
+      .artifactId("liquibase-core")
+      .version("\\${liquibase.version}")
+      .build();
     buildToolService.addDependency(project, liquibaseDependency);
 
     Dependency h2dependency = Dependency.builder().groupId("com.h2database").artifactId("h2").scope("test").build();

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -35,6 +35,7 @@
     <cucumber.version>7.3.4</cucumber.version>
     <testng.version>7.6.0</testng.version>
     <pulsar.version>2.10.0</pulsar.version>
+    <liquibase.version>4.12.0</liquibase.version>
   </properties>
 
   <dependencyManagement>
@@ -153,6 +154,11 @@
         <groupId>org.awaitility</groupId>
         <artifactId>awaitility</artifactId>
         <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.liquibase</groupId>
+        <artifactId>liquibase-core</artifactId>
+        <version>${liquibase.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/master.xml
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/master.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
 >
   <property name="now" value="now()" dbms="h2" />
   <property name="now" value="current_timestamp" dbms="postgresql" />

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/authority.xml.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/authority.xml.mustache
@@ -3,7 +3,7 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
 >
   <changeSet id="create_table_jhi_authority" author="jhipster">

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/sequence_user.xml.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/sequence_user.xml.mustache
@@ -3,7 +3,7 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
 >
   <changeSet id="create_sequence_jhi_user" author="jhipster">

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/user.xml.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/user.xml.mustache
@@ -3,7 +3,7 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
 >
   <changeSet id="create_table_jhi_user" author="jhipster">

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/user_with_autoincrement.xml.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/resources/user/user_with_autoincrement.xml.mustache
@@ -3,7 +3,7 @@
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd"
 >
   <changeSet id="create_table_jhi_user" author="jhipster">

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseApplicationServiceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseApplicationServiceIT.java
@@ -75,16 +75,7 @@ class LiquibaseApplicationServiceIT {
 
     liquibaseApplicationService.init(project);
 
-    assertFileContent(
-      project,
-      POM_XML,
-      List.of("<dependency>", "<groupId>org.liquibase</groupId>", "<artifactId>liquibase-core</artifactId>", "</dependency>")
-    );
-    assertFileContent(
-      project,
-      POM_XML,
-      List.of("<dependency>", "<groupId>com.h2database</groupId>", "<artifactId>h2</artifactId>", "<scope>test</scope>", "</dependency>")
-    );
+    assertDependencies(project);
     assertFilesLiquibaseChangelogMasterXml(project);
     assertFilesLiquibaseJava(project);
     assertLoggerInConfig(project);
@@ -97,11 +88,7 @@ class LiquibaseApplicationServiceIT {
 
     liquibaseApplicationService.addLiquibase(project);
 
-    assertFileContent(
-      project,
-      POM_XML,
-      List.of("<dependency>", "<groupId>org.liquibase</groupId>", "<artifactId>liquibase-core</artifactId>", "</dependency>")
-    );
+    assertDependencies(project);
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
@@ -5,7 +5,6 @@ import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
 import static tech.jhipster.lite.generator.project.domain.Constants.*;
-import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
 

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/application/LiquibaseAssertFiles.java
@@ -4,10 +4,8 @@ import static org.mockito.Mockito.when;
 import static tech.jhipster.lite.TestUtils.assertFileContent;
 import static tech.jhipster.lite.TestUtils.assertFileExist;
 import static tech.jhipster.lite.common.domain.FileUtils.getPath;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.MAIN_RESOURCES;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_JAVA;
-import static tech.jhipster.lite.generator.project.domain.Constants.TEST_RESOURCES;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
+import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_CONFIGURATION;
 import static tech.jhipster.lite.generator.server.springboot.core.domain.SpringBoot.LOGGING_TEST_CONFIGURATION;
 
@@ -15,6 +13,7 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.util.List;
+import tech.jhipster.lite.TestUtils;
 import tech.jhipster.lite.generator.project.domain.DefaultConfig;
 import tech.jhipster.lite.generator.project.domain.Project;
 
@@ -22,6 +21,27 @@ public class LiquibaseAssertFiles {
 
   public static final String CURRENT_DATE = "2022-01-28T17:30:26.0Z";
   public static final ZoneId DEFAULT_TIMEZONE = ZoneId.of("UTC");
+
+  public static void assertDependencies(Project project) {
+    TestUtils.assertFileContent(project, POM_XML, "<liquibase.version>");
+    TestUtils.assertFileContent(project, POM_XML, "</liquibase.version>");
+    assertFileContent(
+      project,
+      POM_XML,
+      List.of(
+        "<dependency>",
+        "<groupId>org.liquibase</groupId>",
+        "<artifactId>liquibase-core</artifactId>",
+        "<version>${liquibase.version}</version>",
+        "</dependency>"
+      )
+    );
+    assertFileContent(
+      project,
+      POM_XML,
+      List.of("<dependency>", "<groupId>com.h2database</groupId>", "<artifactId>h2</artifactId>", "<scope>test</scope>", "</dependency>")
+    );
+  }
 
   public static void assertFilesLiquibaseJava(Project project) {
     String liquibasePackage =

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainServiceTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/domain/LiquibaseDomainServiceTest.java
@@ -1,0 +1,139 @@
+package tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.domain;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static tech.jhipster.lite.TestUtils.*;
+import static tech.jhipster.lite.common.domain.FileUtils.getPath;
+import static tech.jhipster.lite.generator.project.domain.Constants.*;
+import static tech.jhipster.lite.generator.project.domain.ProjectFilesAsserter.*;
+import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.domain.LiquibaseDomainService.CONFIG_LIQUIBASE;
+import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.domain.LiquibaseDomainService.LIQUIBASE_PATH;
+
+import java.time.Clock;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.Optional;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.*;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.error.domain.GeneratorException;
+import tech.jhipster.lite.generator.buildtool.generic.domain.BuildToolService;
+import tech.jhipster.lite.generator.buildtool.generic.domain.Dependency;
+import tech.jhipster.lite.generator.project.domain.FilePath;
+import tech.jhipster.lite.generator.project.domain.Project;
+import tech.jhipster.lite.generator.project.domain.ProjectFile;
+import tech.jhipster.lite.generator.project.domain.ProjectRepository;
+import tech.jhipster.lite.generator.server.springboot.common.domain.Level;
+import tech.jhipster.lite.generator.server.springboot.common.domain.SpringBootCommonService;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+class LiquibaseDomainServiceTest {
+
+  @Mock
+  ProjectRepository projectRepository;
+
+  @Mock
+  BuildToolService buildToolService;
+
+  @Mock
+  SpringBootCommonService springBootCommonService;
+
+  @Spy
+  Clock clock = Clock.fixed(Instant.parse("2022-01-22T14:01:54.954396664Z"), ZoneId.of("Europe/Paris"));
+
+  @InjectMocks
+  LiquibaseDomainService liquibaseDomainService;
+
+  @Test
+  void shouldInit() {
+    // Given
+    Project project = tmpProject();
+
+    when(buildToolService.getVersion(any(Project.class), anyString())).thenReturn(Optional.of("0.0.0"));
+
+    // When
+    liquibaseDomainService.init(project);
+
+    // Then
+    ArgumentCaptor<Dependency> dependencyArgCaptor = ArgumentCaptor.forClass(Dependency.class);
+    verify(buildToolService, times(2)).addDependency(eq(project), dependencyArgCaptor.capture());
+    List<Dependency> dependencies = dependencyArgCaptor.getAllValues();
+
+    Dependency expectedDependency = Dependency
+      .builder()
+      .groupId("org.liquibase")
+      .artifactId("liquibase-core")
+      .version("\\${liquibase.version}")
+      .build();
+    assertThat(dependencies.get(0)).usingRecursiveComparison().isEqualTo(expectedDependency);
+
+    expectedDependency = Dependency.builder().groupId("com.h2database").artifactId("h2").scope("test").build();
+    assertThat(dependencies.get(1)).usingRecursiveComparison().isEqualTo(expectedDependency);
+
+    verify(projectRepository)
+      .add(
+        projectFileArgument(
+          project,
+          new FilePath("server/springboot/dbmigration/liquibase/resources", LIQUIBASE_MASTER_XML),
+          new FilePath("src/main/resources/" + CONFIG_LIQUIBASE, LIQUIBASE_MASTER_XML)
+        )
+      );
+
+    ArgumentCaptor<ProjectFile> projectFileArgCaptor = ArgumentCaptor.forClass(ProjectFile.class);
+    verify(projectRepository, times(6)).template(projectFileArgCaptor.capture());
+    List<ProjectFile> projectFiles = projectFileArgCaptor.getAllValues();
+
+    ProjectFile projectFile = ProjectFile
+      .forProject(project)
+      .withSource("server/springboot/dbmigration/liquibase/src", "AsyncSpringLiquibase.java")
+      .withDestinationFolder(MAIN_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(0)).usingRecursiveComparison().isEqualTo(projectFile);
+    projectFile =
+      ProjectFile
+        .forProject(project)
+        .withSource("server/springboot/dbmigration/liquibase/src", "LiquibaseConfiguration.java")
+        .withDestinationFolder(MAIN_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(1)).usingRecursiveComparison().isEqualTo(projectFile);
+    projectFile =
+      ProjectFile
+        .forProject(project)
+        .withSource("server/springboot/dbmigration/liquibase/src", "SpringLiquibaseUtil.java")
+        .withDestinationFolder(MAIN_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(2)).usingRecursiveComparison().isEqualTo(projectFile);
+    projectFile =
+      ProjectFile
+        .forProject(project)
+        .withSource("server/springboot/dbmigration/liquibase/test", "AsyncSpringLiquibaseTest.java")
+        .withDestinationFolder(TEST_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(3)).usingRecursiveComparison().isEqualTo(projectFile);
+    projectFile =
+      ProjectFile
+        .forProject(project)
+        .withSource("server/springboot/dbmigration/liquibase/test", "LiquibaseConfigurationIT.java")
+        .withDestinationFolder(TEST_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(4)).usingRecursiveComparison().isEqualTo(projectFile);
+    projectFile =
+      ProjectFile
+        .forProject(project)
+        .withSource("server/springboot/dbmigration/liquibase/test", "SpringLiquibaseUtilTest.java")
+        .withDestinationFolder(TEST_JAVA + "/com/mycompany/myapp/" + LIQUIBASE_PATH);
+    assertThat(projectFiles.get(5)).usingRecursiveComparison().isEqualTo(projectFile);
+
+    verify(springBootCommonService).addTestLogbackRecorder(any(Project.class));
+    verify(springBootCommonService, times(3)).addLogger(any(Project.class), anyString(), any(Level.class));
+    verify(springBootCommonService, times(3)).addLoggerTest(any(Project.class), anyString(), any(Level.class));
+  }
+
+  @Test
+  void shouldNotAddLiquibaseDependency() {
+    Project project = tmpProject();
+
+    Assertions.assertThatThrownBy(() -> liquibaseDomainService.addLiquibase(project)).isExactlyInstanceOf(GeneratorException.class);
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/infrastructure/primary/rest/LiquibaseResourceIT.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/infrastructure/primary/rest/LiquibaseResourceIT.java
@@ -2,13 +2,7 @@ package tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.inf
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-import static tech.jhipster.lite.TestUtils.assertFileContent;
-import static tech.jhipster.lite.generator.project.domain.Constants.POM_XML;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseChangelogMasterXml;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseJava;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseSqlUser;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.assertFilesLiquibaseSqlUserAuthority;
-import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.initClock;
+import static tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.application.LiquibaseAssertFiles.*;
 
 import java.time.Clock;
 import java.util.List;
@@ -90,16 +84,7 @@ class LiquibaseResourceIT {
       )
       .andExpect(status().isOk());
 
-    assertFileContent(
-      project,
-      POM_XML,
-      List.of("<dependency>", "<groupId>org.liquibase</groupId>", "<artifactId>liquibase-core</artifactId>", "</dependency>")
-    );
-    assertFileContent(
-      project,
-      POM_XML,
-      List.of("<dependency>", "<groupId>com.h2database</groupId>", "<artifactId>h2</artifactId>", "<scope>test</scope>", "</dependency>")
-    );
+    assertDependencies(project);
     assertFilesLiquibaseChangelogMasterXml(project);
     assertFilesLiquibaseJava(project);
   }

--- a/src/test/resources/generator/server/springboot/liquibase/master.test.xml
+++ b/src/test/resources/generator/server/springboot/liquibase/master.test.xml
@@ -2,7 +2,7 @@
 <databaseChangeLog
   xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.5.xsd"
+  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog https://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-latest.xsd"
 >
   <property name="now" value="now()" dbms="h2" />
   <property name="now" value="current_timestamp" dbms="postgresql" />


### PR DESCRIPTION
Fix https://github.com/jhipster/jhipster-lite/issues/1430

Starting on liquibase version [4.12.0](https://github.com/liquibase/liquibase/releases/tag/v4.12.0), _it has been introduced "latest" xsd file path. By using "latest", Liquibase will use the bundled XSD for it's version. The uploaded "latest" XSD will always be the most recent Liquibase release, so note how they can be different and locally cached IDE versions may be different yet._