### PR TITLE
fix: build crash on svelte cause using beta version

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -145,7 +145,7 @@ jobs:
           - angularapp
           - reactapp
           - vueapp
-          # - svelteapp
+          - svelteapp
           - kafkaapp
           - pulsarapp
           - reactiveapp

--- a/src/main/resources/generator/dependencies/svelte/package.json
+++ b/src/main/resources/generator/dependencies/svelte/package.json
@@ -8,7 +8,7 @@
   "devDependencies": {
     "@babel/preset-env": "7.18.6",
     "@sveltejs/adapter-static": "1.0.0-next.34",
-    "@sveltejs/kit": "next",
+    "@sveltejs/kit": "1.0.0-next.357",
     "@testing-library/jest-dom": "5.16.4",
     "@testing-library/svelte": "3.1.3",
     "@types/jest": "28.1.4",


### PR DESCRIPTION
Related to #2409 

I don't know why but sveltekit was using beta version by default. Sveltekit will releasing a breaking point soon, but there isn't any update guide. We will have to make this update once the release will be stable.