### PR TITLE
Add JHipster-lite docker release and instruction to use JHipster lite through docker

### DIFF
--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -30,7 +30,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
@@ -69,7 +69,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v4.0.1
         with:
-          images: ghcr.io/${{ github.repository }}${{ (steps.login-hub.outcome == 'success' && ',jhipster/jhipster') || ''}}
+          images: ghcr.io/${{ github.repository }}${{ (steps.login-hub.outcome == 'success' && ',jhipster/jhipster-lite) || ''}}
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v3.0.0

--- a/.github/workflows/docker-image-publish.yml
+++ b/.github/workflows/docker-image-publish.yml
@@ -1,0 +1,81 @@
+#
+# Copyright 2013-2022 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Publish Docker Image
+
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - main
+    # Publish semver tags as releases.
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2.0.0
+        with:
+          platforms: arm64
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2.0.0
+
+      - name: Login to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2.0.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Login to Docker Registry
+        env:
+          DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        if: ${{env.DOCKERHUB_USERNAME != '' && startsWith(github.ref, 'refs/tags/v')}}
+        uses: docker/login-action@v2.0.0
+        id: login-hub
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract Docker metadata
+        id: meta
+        uses: docker/metadata-action@v4.0.1
+        with:
+          images: ghcr.io/${{ github.repository }}${{ (steps.login-hub.outcome == 'success' && ',jhipster/jhipster') || ''}}
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v3.0.0
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.jhipster/history/history.json
+++ b/.jhipster/history/history.json
@@ -1,6 +1,0 @@
-{
-  "values" : [ {
-    "serviceId" : "dockerfile",
-    "timestamp" : "2022-07-08T13:12:36.287432861Z"
-  } ]
-}

--- a/.jhipster/history/history.json
+++ b/.jhipster/history/history.json
@@ -1,0 +1,6 @@
+{
+  "values" : [ {
+    "serviceId" : "dockerfile",
+    "timestamp" : "2022-07-08T13:12:36.287432861Z"
+  } ]
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,19 @@
 FROM openjdk:17-slim
 COPY . /code/jhipster-app/
 RUN \
+    # configure the "jhipster" user
+    groupadd jhipster && \
+    useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
+    echo 'jhipster:jhipster' |chpasswd && \
     cd /code/jhipster-app/ && \
     rm -Rf target node_modules && \
     chmod +x mvnw && \
-    sleep 1 && \
     ./mvnw package -DskipTests && \
     mv /code/jhipster-app/target/*.jar /code/ && \
     rm -Rf /code/jhipster-app/ /root/.m2 /root/.cache /tmp/* /var/tmp/*
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
-    JHIPSTER_SLEEP=0 \
     JAVA_OPTS=""
-CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
-    sleep ${JHIPSTER_SLEEP} && \
-    java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /code/*.jar
+USER jhipster
+CMD java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /code/*.jar
 EXPOSE 7471

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,18 @@
+FROM openjdk:17-slim
+COPY . /code/jhipster-app/
+RUN \
+    cd /code/jhipster-app/ && \
+    rm -Rf target node_modules && \
+    chmod +x mvnw && \
+    sleep 1 && \
+    ./mvnw package -DskipTests && \
+    mv /code/jhipster-app/target/*.jar /code/ && \
+    rm -Rf /code/jhipster-app/ /root/.m2 /root/.cache /tmp/* /var/tmp/*
+
+ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
+    JHIPSTER_SLEEP=0 \
+    JAVA_OPTS=""
+CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
+    sleep ${JHIPSTER_SLEEP} && \
+    java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /code/*.jar
+EXPOSE 7471

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ JHipster is a development platform to quickly generate, develop & deploy modern 
 To start a local instance of JHipster lite using docker, go to your desired application folder and run:
 
 ```
-docker run --rm --pull=always -p 7471:7471 -v .:/jh:Z -it jhipster/jhlite:latest
+docker run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -it jhipster/jhlite:latest
 ```
 
 Or with podman:

--- a/README.md
+++ b/README.md
@@ -26,18 +26,18 @@ JHipster is a development platform to quickly generate, develop & deploy modern 
 - you will only generate the code you want, no additional unused code
 - best quality as possible: 💯% coverage, 0 code smell, no duplication 😎
 
-## Docker Quickstart
+## Docker/Podman Quickstart
 
-To start a local instance of JHipster lite using docker, go to your desired application folder and run:
+To start a local instance of JHipster Lite, go to your desired application folder and run:
 
 ```
-docker run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -it jhipster/jhlite:latest
+docker run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -it jhipster/jhipster-lite:latest
 ```
 
 Or with podman:
 
 ```
-podman run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -u root -it jhipster/jhlite:latest
+podman run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -u root -it jhipster/jhipster-lite:latest
 ```
 
 Then go to http://localhost:7471, and type `/jh` in the project configuration path.

--- a/README.md
+++ b/README.md
@@ -26,6 +26,22 @@ JHipster is a development platform to quickly generate, develop & deploy modern 
 - you will only generate the code you want, no additional unused code
 - best quality as possible: 💯% coverage, 0 code smell, no duplication 😎
 
+## Docker Quickstart
+
+To start a local instance of JHipster lite using docker, go to your desired application folder and run:
+
+```
+docker run --rm --pull=always -p 7471:7471 -v .:/jh:Z -it jhipster/jhlite:latest
+```
+
+Or with podman:
+
+```
+podman run --rm --pull=always -p 7471:7471 -v $(pwd):/jh:Z -u root -it jhipster/jhlite:latest
+```
+
+Then go to http://localhost:7471, and type `/jh` in the project configuration path.
+
 ## Deploy to Heroku
 
 Click on this button to deploy your own instance of JHipster Lite:


### PR DESCRIPTION
It can be tried out using: `pbesson/jhlite:latest`