### PR TITLE
Make jest-sonar optional in Vue

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
@@ -62,7 +62,7 @@ public class VueModulesFactory {
         .addScript(scriptKey("test"), scriptCommand("npm run jest --"))
         .addScript(scriptKey("test:watch"), scriptCommand("npm run jest -- --watch"))
         .and()
-      .mandatoryReplacements()
+      .optionalReplacements()
         .in("package.json")
           .add(justLineBefore(text(CACHE_NEEDLE)), jestSonar(properties.indentation()))
           .and()


### PR DESCRIPTION
The jest-sonar replacement in `package.json` shouldn't be mandatory IMO, as it won't stop an app from starting.
Btw maybe we can put the `jestSonar` method in a "Common" package as I think it will be the same for each client...
But I don't know where to put it, if you have any advice :) 

Ping @DamnClin 