### PR TITLE
React: Use createRoot instead of ReactDOM.render

### DIFF
--- a/src/main/resources/generator/client/react/src/main/webapp/app/index.tsx.mustache
+++ b/src/main/resources/generator/client/react/src/main/webapp/app/index.tsx.mustache
@@ -1,11 +1,12 @@
 import React from 'react';
-import ReactDOM from 'react-dom';
+import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from '@/common/primary/app/App';
 
-ReactDOM.render(
+const container = document.getElementById('root');
+const root = createRoot(container!);
+root.render(
   <React.StrictMode>
     <App />
-  </React.StrictMode>,
-  document.getElementById('root')
+  </React.StrictMode>
 );


### PR DESCRIPTION
Fix #2621 