### PR TITLE
add initial gitlab ci module

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/ci/gitlab/application/GitLabCiApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/gitlab/application/GitLabCiApplicationService.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.ci.gitlab.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.ci.gitlab.domain.GitLabCiModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@Service
+public class GitLabCiApplicationService {
+
+  private final GitLabCiModuleFactory factory;
+
+  public GitLabCiApplicationService() {
+    factory = new GitLabCiModuleFactory();
+  }
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    return factory.buildModule(properties);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/ci/gitlab/domain/GitLabCiModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/gitlab/domain/GitLabCiModuleFactory.java
@@ -1,0 +1,21 @@
+package tech.jhipster.lite.generator.ci.gitlab.domain;
+
+import static tech.jhipster.lite.module.domain.JHipsterModule.from;
+import static tech.jhipster.lite.module.domain.JHipsterModule.moduleBuilder;
+import static tech.jhipster.lite.module.domain.JHipsterModule.to;
+
+import tech.jhipster.lite.error.domain.Assert;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.JHipsterSource;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+public class GitLabCiModuleFactory {
+
+  private static final JHipsterSource SOURCE = from("ci/gitlab");
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    Assert.notNull("properties", properties);
+
+    return moduleBuilder(properties).files().add(SOURCE.template(".gitlab-ci-maven.yml.mustache"), to(".gitlab-ci.yml")).and().build();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/ci/gitlab/infrastructure/primary/GitLabCiModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/gitlab/infrastructure/primary/GitLabCiModuleConfiguration.java
@@ -1,0 +1,23 @@
+package tech.jhipster.lite.generator.ci.gitlab.infrastructure.primary;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.ci.gitlab.application.GitLabCiApplicationService;
+import tech.jhipster.lite.module.infrastructure.primary.JHipsterModuleApiDoc;
+import tech.jhipster.lite.module.infrastructure.primary.JHipsterModuleResource;
+
+@Configuration
+class GitLabCiModuleConfiguration {
+
+  @Bean
+  JHipsterModuleResource gitlabCiModule(GitLabCiApplicationService gitlabCi) {
+    return JHipsterModuleResource
+      .builder()
+      .legacyUrl("/api/developer-tools/gitlab-ci")
+      .slug("gitlab-ci")
+      .withoutProperties()
+      .apiDoc(new JHipsterModuleApiDoc("Continuous Integration", "Add GitLab CI for Maven Build"))
+      .tags("ci", "gitlab")
+      .factory(gitlabCi::buildModule);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/ci/gitlab/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/gitlab/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.ci.gitlab;

--- a/src/main/resources/generator/ci/gitlab/.gitlab-ci-maven.yml.mustache
+++ b/src/main/resources/generator/ci/gitlab/.gitlab-ci-maven.yml.mustache
@@ -1,0 +1,25 @@
+variables:
+  # This will suppress any download for dependencies and plugins or upload messages which would clutter the console log.
+  # `showDateTime` will show the passed time in milliseconds. You need to specify `--batch-mode` to make this work.
+  MAVEN_OPTS: "-Dhttps.protocols=TLSv1.2 -Dmaven.repo.local=$CI_PROJECT_DIR/.m2/repository -Dorg.slf4j.simpleLogger.log.org.apache.maven.cli.transfer.Slf4jMavenTransferListener=WARN -Dorg.slf4j.simpleLogger.showDateTime=true -Djava.awt.headless=true"
+  # As of Maven 3.3.0 instead of this you may define these options in `.mvn/maven.config` so the same config is used
+  # when running from the command line.
+  # `installAtEnd` and `deployAtEnd` are only effective with recent version of the corresponding plugins.
+  MAVEN_CLI_OPTS: "--batch-mode --errors --fail-at-end --show-version -DinstallAtEnd=true -DdeployAtEnd=true"
+
+image: eclipse-temurin:17
+
+# Cache downloaded dependencies and plugins between builds.
+# To keep cache across branches add 'key: "$CI_JOB_NAME"'
+cache:
+  paths:
+    - .m2/repository
+
+stages:
+  - test
+
+Test:run-tests:
+  stage: test
+  script:
+    - ./mvnw $MAVEN_CLI_OPTS clean verify
+  interruptible: true

--- a/src/test/features/gitlab-ci.feature
+++ b/src/test/features/gitlab-ci.feature
@@ -1,0 +1,6 @@
+Feature: GitLab CI module
+
+  Scenario: Should apply gitlab ci module
+    When I apply "gitlab-ci" module to default project without properties
+    Then I should have files in "."
+      | .gitlab-ci.yml |

--- a/src/test/java/tech/jhipster/lite/generator/ci/gitlab/domain/GitLabCiModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/ci/gitlab/domain/GitLabCiModuleFactoryTest.java
@@ -1,0 +1,25 @@
+package tech.jhipster.lite.generator.ci.gitlab.domain;
+
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModule;
+
+import org.junit.jupiter.api.Test;
+import tech.jhipster.lite.TestFileUtils;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@UnitTest
+class GitLabCiModuleFactoryTest {
+
+  private static final GitLabCiModuleFactory factory = new GitLabCiModuleFactory();
+
+  @Test
+  void shouldBuildModule() {
+    JHipsterModuleProperties properties = JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest()).build();
+
+    JHipsterModule module = factory.buildModule(properties);
+
+    assertThatModule(module).createFiles(".gitlab-ci.yml");
+  }
+}


### PR DESCRIPTION
A very simple initial gitlab ci configuration. Example run/project can be [found here on gitlab](https://gitlab.com/atomfrede/jh-lite-sample-ci/-/jobs/2789026169).

The build file must not be a mustache template, but I guess it needs to be in future iterations maybe.
closes #423