### PR TITLE
Add compacted mode for landscape

### DIFF
--- a/src/main/webapp/app/assets/global.scss
+++ b/src/main/webapp/app/assets/global.scss
@@ -1,8 +1,8 @@
 $jhipster-lite-primary-color: #0f5b90;
+$jhipster-lite-primary-alternative-color: #3e8abf;
 $jhipster-lite-secondary-color: #0f172a;
 $jhipster-lite-line-color: #ddeffc;
 $jhipster-lite-primary-text-color: #ddeffc;
-$jhipster-lite-primary-button-background-color: #3e8abf;
 $jhipster-lite-disabled-button-background-color: #949494;
 $jhipster-lite-primary-input-color: #fff;
 $jhipster-lite-applied-module-color: #2f7b17;

--- a/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.component.ts
@@ -12,5 +12,9 @@ export default defineComponent({
       type: Object as PropType<Map<string, HTMLElement>>,
       required: true,
     },
+    modeClass: {
+      type: String,
+      required: true,
+    },
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.html
+++ b/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.html
@@ -1,4 +1,4 @@
-<div class="jhipster-landscape-module" :ref="el => landscapeElements.set(module.slug, el)">
-  <div class="jhipster-landscape-module--slug">{{ module.slug }}</div>
-  <div class="jhipster-landscape-module--operation">{{ module.operation }}</div>
+<div class="jhipster-landscape-module" :class="modeClass" :ref="el => landscapeElements.set(module.slug, el)">
+  <div class="jhipster-landscape-module--slug" :class="modeClass">{{ module.slug }}</div>
+  <div class="jhipster-landscape-module--operation" :class="modeClass">{{ module.operation }}</div>
 </div>

--- a/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.vue
+++ b/src/main/webapp/app/module/primary/landscape-module/LandscapeModule.vue
@@ -10,14 +10,33 @@
 
   &--slug {
     text-align: center;
-    padding: 5px 10px;
-    font-weight: bold;
+
+    &.-extended {
+      padding: 5px 10px;
+      font-weight: bold;
+    }
+
+    &.-compacted {
+      padding: 2px 3px;
+    }
   }
 
   &--operation {
     border-top: 1px dotted $jhipster-lite-line-color;
     padding: 5px 10px;
     font-size: 0.8em;
+
+    &.-compacted {
+      display: none;
+    }
+  }
+
+  &.-compacted {
+    margin-bottom: 5px;
+  }
+
+  &.-extended {
+    margin-bottom: 15px;
   }
 }
 </style>

--- a/src/main/webapp/app/module/primary/landscape/DisplayMode.ts
+++ b/src/main/webapp/app/module/primary/landscape/DisplayMode.ts
@@ -1,0 +1,1 @@
+export type DisplayMode = 'EXTENDED' | 'COMPACTED';

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -9,6 +9,7 @@ import { defineComponent, inject, nextTick, onBeforeUnmount, onMounted, ref } fr
 import { LandscapeModuleVue } from '../landscape-module';
 import { buildConnectors, LandscapeConnectorLine } from './LandscapeConnector';
 import { emptyLandscapeSize, LandscapeConnectorsSize } from './LandscapeConnectorsSize';
+import { DisplayMode } from './DisplayMode';
 
 export default defineComponent({
   name: 'LandscapeVue',
@@ -16,6 +17,8 @@ export default defineComponent({
   setup() {
     const modules = inject('modules') as ModulesRepository;
     const applicationListener = inject('applicationListener') as ApplicationListener;
+
+    const selectedMode = ref<DisplayMode>('COMPACTED');
 
     const landscapeContainer = ref<HTMLElement>();
     const landscape = ref(Loader.loading<Landscape>());
@@ -88,6 +91,31 @@ export default defineComponent({
       return element instanceof LandscapeFeature;
     };
 
+    const modeSwitchClass = (mode: DisplayMode): string => {
+      if (selectedMode.value === mode) {
+        return '-selected';
+      }
+
+      return '-not-selected';
+    };
+
+    const selectMode = (mode: DisplayMode): void => {
+      selectedMode.value = mode;
+
+      nextTick(() => {
+        updateConnectors();
+      });
+    };
+
+    const modeClass = (): string => {
+      switch (selectedMode.value) {
+        case 'COMPACTED':
+          return '-compacted';
+        case 'EXTENDED':
+          return '-extended';
+      }
+    };
+
     return {
       landscape,
       isFeature,
@@ -95,6 +123,9 @@ export default defineComponent({
       landscapeElements,
       landscapeSize,
       landscapeContainer,
+      modeSwitchClass,
+      selectMode,
+      modeClass,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -1,18 +1,49 @@
 <div class="jhipster-landscape" v-if="landscape.isLoading()" data-selector="landscape-loader">Loading</div>
 <div class="jhipster-landscape" v-else data-selector="landscape" ref="landscapeContainer">
+  <div class="jhipster-landscape-form">
+    <div class="jhipster-landscape-form--modes">
+      <button
+        class="jhipster-landscape-form--modes-switch"
+        :class="modeSwitchClass('COMPACTED')"
+        @click="selectMode('COMPACTED')"
+        data-selector="compacted-mode-button"
+      >
+        Compacted
+      </button>
+      <button
+        class="jhipster-landscape-form--modes-switch"
+        :class="modeSwitchClass('EXTENDED')"
+        @click="selectMode('EXTENDED')"
+        data-selector="extended-mode-button"
+      >
+        Extended
+      </button>
+    </div>
+  </div>
+
   <div class="jhipster-landscape-levels">
-    <ul class="jhipster-landscape-levels--level" v-for="level in landscape.value().levels">
-      <li class="jhipster-landscape-element" v-for="element in level.elements">
-        <div class="jhipster-landscape-feature" v-if="isFeature(element)" :ref="el => landscapeElements.set(element.slug, el)">
-          <h2 class="jhipster-landscape-feature--title">{{ element.slug }}</h2>
+    <ul class="jhipster-landscape-levels--level" :class="modeClass()" v-for="level in landscape.value().levels">
+      <li
+        class="jhipster-landscape-element"
+        v-for="element in level.elements"
+        :data-selector="`${element.slug}-element`"
+        :class="modeClass()"
+      >
+        <div
+          class="jhipster-landscape-feature"
+          :class="modeClass()"
+          v-if="isFeature(element)"
+          :ref="el => landscapeElements.set(element.slug, el)"
+        >
+          <h2 class="jhipster-landscape-feature--title" :class="modeClass()">{{ element.slug }}</h2>
           <ul class="jhipster-landscape-feature--modules">
-            <li class="jhipster-landscape-element" v-for="module in element.modules">
-              <LandscapeModuleVue :module="module" :landscapeElements="landscapeElements" />
+            <li class="jhipster-landscape-feature--module" v-for="module in element.modules">
+              <LandscapeModuleVue :module="module" :landscapeElements="landscapeElements" :modeClass="modeClass()" />
             </li>
           </ul>
         </div>
 
-        <LandscapeModuleVue :module="element" :landscapeElements="landscapeElements" v-else />
+        <LandscapeModuleVue :module="element" :landscapeElements="landscapeElements" :modeClass="modeClass()" v-else />
       </li>
     </ul>
   </div>

--- a/src/main/webapp/app/module/primary/landscape/Landscape.vue
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.vue
@@ -13,6 +13,33 @@
   position: relative;
 }
 
+.jhipster-landscape-form {
+  left: 15px;
+  position: fixed;
+  z-index: 3;
+  background: rgba($color: $jhipster-lite-secondary-color, $alpha: 0.7);
+  padding: 10px;
+  border: 1px dotted $jhipster-lite-line-color;
+  border-radius: $jhipster-lite-box-radius;
+
+  &--modes {
+    border: 1px solid $jhipster-lite-line-color;
+    border-radius: 1.5em;
+  }
+
+  &--modes-switch {
+    background-color: transparent;
+    border: 0;
+    border-radius: 1.5em;
+    color: $jhipster-lite-primary-input-color;
+    padding: 7px 15px;
+
+    &.-selected {
+      background-color: $jhipster-lite-primary-color;
+    }
+  }
+}
+
 .jhipster-landscape-connectors {
   position: absolute;
   top: -$jhipster-header-height;
@@ -35,31 +62,65 @@
   &--level {
     width: 250px;
     grid-row: 1;
-    margin-right: 70px;
     padding: 0;
+
+    &.-compacted {
+      width: 200px;
+      margin-right: 40px;
+    }
+
+    &.-extended {
+      width: 250px;
+      margin-right: 70px;
+    }
   }
 }
 
 .jhipster-landscape-feature {
   border: 2px dotted $jhipster-lite-line-color;
   border-radius: $jhipster-lite-box-radius;
-  padding: 10px 10px 0 10px;
-  background: rgba($color: $jhipster-lite-secondary-color, $alpha: 0.7);
+  background: rgba($color: $jhipster-lite-primary-alternative-color, $alpha: 0.7);
 
   &--title {
     text-align: center;
-    margin-top: 7px;
     font-size: 1em;
     font-weight: bold;
+
+    &.-extended {
+      margin: 7px;
+    }
+
+    &.-compacted {
+      margin: 1px 3px;
+    }
   }
 
   &--modules {
     padding: 0;
   }
+
+  &--module {
+    list-style-type: none;
+  }
+
+  &.-extended {
+    padding: 10px 10px 0 10px;
+  }
+
+  &.-compacted {
+    padding: 1px 3px 0 3px;
+  }
 }
 
 .jhipster-landscape-element {
   list-style-type: none;
-  margin-bottom: 15px;
+
+  &.-compacted {
+    margin-bottom: 5px;
+  }
+
+  &.-extended {
+    margin-bottom: 15px;
+  }
 }
 </style>

--- a/src/main/webapp/app/module/primary/modules/Modules.vue
+++ b/src/main/webapp/app/module/primary/modules/Modules.vue
@@ -71,7 +71,7 @@
   &--format-project {
     margin-bottom: 15px;
     width: 100%;
-    background-color: $jhipster-lite-primary-button-background-color;
+    background-color: $jhipster-lite-primary-alternative-color;
     border: 1px solid $jhipster-lite-line-color;
     color: $jhipster-lite-primary-input-color;
     border-radius: 6px;

--- a/src/test/javascript/spec/module/primary/Landscape.spec.ts
+++ b/src/test/javascript/spec/module/primary/Landscape.spec.ts
@@ -38,10 +38,12 @@ const wrap = (options?: Partial<WrapperOptions>): VueWrapper => {
   });
 };
 
-const componentWithLandscape = async (applicationListener: ApplicationListener): Promise<VueWrapper> => {
+const componentWithLandscape = async (applicationListener?: ApplicationListener): Promise<VueWrapper> => {
+  const listener = applicationListener || stubApplicationListener();
+
   const modules = repositoryWithLandscape();
 
-  const wrapper = wrap({ modules, applicationListener });
+  const wrapper = wrap({ modules, applicationListener: listener });
 
   await flushPromises();
 
@@ -81,6 +83,30 @@ describe('Landscape', () => {
       wrapper.unmount();
 
       expect(applicationListener.removeEventListener.calledOnce).toBe(true);
+    });
+  });
+
+  describe('Display modes', () => {
+    it('Should switch to compacted mode', async () => {
+      const wrapper = await componentWithLandscape();
+
+      wrapper.find(wrappedElement('compacted-mode-button')).trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(wrappedElement('compacted-mode-button')).classes()).toContain('-selected');
+      expect(wrapper.find(wrappedElement('extended-mode-button')).classes()).toContain('-not-selected');
+      expect(wrapper.find(wrappedElement('infinitest-element')).classes()).toContain('-compacted');
+    });
+
+    it('Should switch to extended mode', async () => {
+      const wrapper = await componentWithLandscape();
+
+      wrapper.find(wrappedElement('extended-mode-button')).trigger('click');
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(wrappedElement('compacted-mode-button')).classes()).toContain('-not-selected');
+      expect(wrapper.find(wrappedElement('extended-mode-button')).classes()).toContain('-selected');
+      expect(wrapper.find(wrappedElement('infinitest-element')).classes()).toContain('-extended');
     });
   });
 });


### PR DESCRIPTION
Close https://github.com/jhipster/jhipster-lite/issues/3032

Add a compacted mode (and a switch) for the landscape, here is the compacted mode look:
![featurebackground](https://user-images.githubusercontent.com/59929679/184328851-26802467-cefa-409c-9204-74b510167d52.png)



