### PR TITLE
Prevent external librairies in domain classes

### DIFF
--- a/src/main/java/tech/jhipster/lite/common/domain/Base64Utils.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/Base64Utils.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.common.domain;
 
 import java.security.SecureRandom;
-import org.apache.tomcat.util.codec.binary.Base64;
+import java.util.Base64;
 
 public class Base64Utils {
 
@@ -18,7 +18,7 @@ public class Base64Utils {
   }
 
   public static String getBase64Secret(String value, int length) {
-    return Base64.encodeBase64String(value != null ? value.getBytes() : getRandomHexString(length).getBytes());
+    return Base64.getEncoder().encodeToString(value != null ? value.getBytes() : getRandomHexString(length).getBytes());
   }
 
   public static String getRandomHexString(int length) {

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -175,6 +175,18 @@ class HexagonalArchTest {
   }
 
   @Test
+  void shouldNotHaveExternalDependenciesFromDomain() {
+    classes()
+      .that()
+      .resideInAnyPackage("..domain..")
+      .should()
+      .onlyDependOnClassesThat()
+      .resideInAnyPackage("tech.jhipster.lite..", "java..", ""/* primitives */, "org.slf4j", "org.apache.commons..")
+      .because("Domain should not depend on external dependencies")
+      .check(classes);
+  }
+
+  @Test
   void shouldNotHaveContextDependenciesForSharedKernels() {
     sharedKernelsPackages.forEach(kernel ->
       noClasses()


### PR DESCRIPTION
Closes #3039  

Adding an ArchUnit test to prevent the adding of new external dependencies into domain classes.
Switching a Base64 encoder to `java.util` implementation.