### PR TITLE
Add start-class property in pom

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -60,7 +60,7 @@ public class SpringBootCoreModuleFactory {
         .addDependency(springBootTest())
         .and()
       .javaBuildPlugins()
-        .pluginManagement(springBootPluginManagement())
+        .pluginManagement(springBootPluginManagement(fullyQualifiedMainClass))
         .plugin(springBootMavenPlugin())
         .and()
       .files()
@@ -75,11 +75,6 @@ public class SpringBootCoreModuleFactory {
         .add(SOURCE.template("LogsSpy.java"), toSrcTestJava().append(properties.packagePath()).append("LogsSpy.java"))
         .add(SOURCE.template("ApplicationStartupTracesTest.java"), toSrcTestJava().append(packagePath).append("ApplicationStartupTracesTest.java"))
         .and()
-      .mandatoryReplacements()
-        .in("pom.xml")
-          .add(lineBeforeText("</properties>"),properties.indentation().times(2) + "<start-class>"+ fullyQualifiedMainClass +"</start-class>")
-          .and()
-      .and()
       .optionalReplacements()
         .in("pom.xml")
           .add(DEFAULT_GOAL_REPLACER, properties.indentation().times(2) + "<defaultGoal>spring-boot:run</defaultGoal>")
@@ -113,7 +108,7 @@ public class SpringBootCoreModuleFactory {
       .build();
   }
 
-  private JavaBuildPlugin springBootPluginManagement() {
+  private JavaBuildPlugin springBootPluginManagement(String fullyQualifiedMainClass) {
     return JavaBuildPlugin
       .builder()
       .groupId(SRPING_BOOT_GROUP)
@@ -129,9 +124,11 @@ public class SpringBootCoreModuleFactory {
           </execution>
         </executions>
         <configuration>
-          <mainClass>${start-class}</mainClass>
+          <mainClass>%s</mainClass>
         </configuration>
-        """
+        """.formatted(
+            fullyQualifiedMainClass
+          )
       )
       .build();
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -40,6 +40,7 @@ public class SpringBootCoreModuleFactory {
     String mainClassName = properties.projectBaseName().capitalized();
     String packagePath = properties.packagePath();
     JHipsterDestination testDestination = toSrcTestJava().append(packagePath);
+    String fullyQualifiedMainClass = properties.basePackage().get() + "." + mainClassName + "App";
 
     //@formatter:off
     return moduleBuilder(properties)
@@ -74,6 +75,11 @@ public class SpringBootCoreModuleFactory {
         .add(SOURCE.template("LogsSpy.java"), toSrcTestJava().append(properties.packagePath()).append("LogsSpy.java"))
         .add(SOURCE.template("ApplicationStartupTracesTest.java"), toSrcTestJava().append(packagePath).append("ApplicationStartupTracesTest.java"))
         .and()
+      .mandatoryReplacements()
+        .in("pom.xml")
+          .add(lineBeforeText("</properties>"),properties.indentation().times(2) + "<start-class>"+ fullyQualifiedMainClass +"</start-class>")
+          .and()
+      .and()
       .optionalReplacements()
         .in("pom.xml")
           .add(DEFAULT_GOAL_REPLACER, properties.indentation().times(2) + "<defaultGoal>spring-boot:run</defaultGoal>")

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
@@ -22,6 +22,7 @@ class SpringBootCoreModuleFactoryTest {
 
     assertThatModuleWithFiles(module, pomFile())
       .hasFile("pom.xml")
+      .containing("<start-class>com.jhipster.test.MyappApp</start-class")
       .containing(
         """
               <dependency>

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
@@ -22,7 +22,6 @@ class SpringBootCoreModuleFactoryTest {
 
     assertThatModuleWithFiles(module, pomFile())
       .hasFile("pom.xml")
-      .containing("<start-class>com.jhipster.test.MyappApp</start-class")
       .containing(
         """
               <dependency>
@@ -82,7 +81,7 @@ class SpringBootCoreModuleFactoryTest {
                     </execution>
                   </executions>
                   <configuration>
-                    <mainClass>${start-class}</mainClass>
+                    <mainClass>com.jhipster.test.MyappApp</mainClass>
                   </configuration>
                 </plugin>
         """


### PR DESCRIPTION
I have added the `<start-class>` property using replacement, as currently the module system has the methods to add versions but not an independent property easily. I feel not a lot of modules have need to add maven pom properties, hence not adding a new builder method, anyone please let me know if you think it can be used and should be made generic, would be happy to look into that with some help 

Fix #3748