### PR TITLE
Add triage label

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -1,0 +1,15 @@
+name: Triage pull requests and issues
+on:
+  issues:
+    types: opened
+  pull_request:
+    types: opened
+jobs:
+  apply-label:
+    runs-on: ubuntu-latest
+    steps:
+      - name: initial labeling
+        uses: andymckay/labeler@master
+        with:
+          add-labels: "area: triage"
+          ignore-if-labeled: true


### PR DESCRIPTION
Add 'area: triage' label to unlabelled PRs and issues

Uses https://github.com/marketplace/actions/simple-issue-labeler for simple issue labeling for unlabelled issues and PRs

Fix #3281