### PR TITLE
Improve jest configuration by ignoring some package.json used in tests

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -27,6 +27,11 @@ module.exports = {
     },
   },
   coveragePathIgnorePatterns: ['<rootDir>/src/main/webapp/app/common/primary/applicationlistener/WindowApplicationListener'],
-  modulePathIgnorePatterns: ['<rootDir>/src/main/resources/', '<rootDir>/target/classes/generator/'],
+  modulePathIgnorePatterns: [
+    '<rootDir>/src/main/resources/',
+    '<rootDir>/src/test/resources/',
+    '<rootDir>/target/classes/generator/',
+    '<rootDir>/target/test-classes/',
+  ],
   testResultsProcessor: 'jest-sonar-reporter',
 };


### PR DESCRIPTION
To avoid having:

```
➜ npm test                                 

> jhlite@0.15.4-SNAPSHOT test
> npm run jest --


> jhlite@0.15.4-SNAPSHOT jest
> jest src/test/javascript/spec --logHeapUsage --maxWorkers=2 --no-cache

jest-haste-map: Haste module naming collision: test-jhipster-project
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/src/test/resources/projects/node-template/package.json
    * <rootDir>/src/test/resources/projects/empty-node/package.json

jest-haste-map: Haste module naming collision: test
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/src/test/resources/projects/files/package.json
    * <rootDir>/target/test-classes/projects/files/package.json

jest-haste-map: Haste module naming collision: jhipster
  The following files share their name; please adjust your hasteImpl:
    * <rootDir>/src/test/resources/projects/package-json/package.json
    * <rootDir>/target/test-classes/projects/package-json/package.json

```