### PR TITLE
Reorganize JHLite steps

### DIFF
--- a/src/test/java/tech/jhipster/lite/TestProjects.java
+++ b/src/test/java/tech/jhipster/lite/TestProjects.java
@@ -1,0 +1,16 @@
+package tech.jhipster.lite;
+
+public final class TestProjects {
+
+  private static String lastProjectFolder;
+
+  private TestProjects() {}
+
+  public static String newTestFolder() {
+    return lastProjectFolder = TestFileUtils.tmpDirForTest();
+  }
+
+  public static String lastProjectFolder() {
+    return lastProjectFolder;
+  }
+}

--- a/src/test/java/tech/jhipster/lite/project/infrastructure/primary/ProjectsSteps.java
+++ b/src/test/java/tech/jhipster/lite/project/infrastructure/primary/ProjectsSteps.java
@@ -1,6 +1,7 @@
-package tech.jhipster.lite;
+package tech.jhipster.lite.project.infrastructure.primary;
 
 import static org.assertj.core.api.Assertions.*;
+import static tech.jhipster.lite.TestProjects.*;
 import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
 
 import io.cucumber.java.en.Then;
@@ -11,10 +12,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
-import java.util.function.Consumer;
-import java.util.function.Supplier;
-import java.util.stream.Collectors;
-import org.assertj.core.api.SoftAssertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.http.HttpEntity;
@@ -25,22 +22,12 @@ import tech.jhipster.lite.module.infrastructure.secondary.git.GitTestUtil;
 
 public class ProjectsSteps {
 
-  private static String lastProjectFolder;
-
   @Autowired
   private TestRestTemplate rest;
 
-  public static String newTestFolder() {
-    return lastProjectFolder = TestFileUtils.tmpDirForTest();
-  }
-
-  public static String lastProjectFolder() {
-    return lastProjectFolder;
-  }
-
   @When("I download the created project")
   public void downloadCreatedProject() {
-    rest.exchange("/api/projects?path=" + lastProjectFolder, HttpMethod.GET, new HttpEntity<>(octetsHeaders()), Void.class);
+    rest.exchange("/api/projects?path=" + lastProjectFolder(), HttpMethod.GET, new HttpEntity<>(octetsHeaders()), Void.class);
   }
 
   private HttpHeaders octetsHeaders() {
@@ -54,12 +41,12 @@ public class ProjectsSteps {
 
   @When("I format the created project")
   public void formatCreatedProject() {
-    rest.postForEntity("/api/format-project?path=" + lastProjectFolder, null, Void.class);
+    rest.postForEntity("/api/format-project?path=" + lastProjectFolder(), null, Void.class);
   }
 
   @When("I get the created project information")
   public void getCreatedProjectInformation() {
-    rest.exchange("/api/projects?path=" + lastProjectFolder, HttpMethod.GET, new HttpEntity<>(jsonHeaders()), Void.class);
+    rest.exchange("/api/projects?path=" + lastProjectFolder(), HttpMethod.GET, new HttpEntity<>(jsonHeaders()), Void.class);
   }
 
   private HttpHeaders jsonHeaders() {
@@ -71,70 +58,24 @@ public class ProjectsSteps {
     return headers;
   }
 
-  @Then("I should have files in {string}")
-  public void shouldHaveFiles(String basePath, List<String> files) {
-    assertThatLastResponse().hasOkStatus();
-
-    SoftAssertions assertions = new SoftAssertions();
-
-    files.stream().map(file -> Paths.get(lastProjectFolder, basePath, file)).forEach(assertFileExist(assertions));
-
-    assertions.assertAll();
-  }
-
-  private Consumer<Path> assertFileExist(SoftAssertions assertions) {
-    return path -> assertions.assertThat(Files.exists(path)).as(fileNotFoundMessage(path)).isTrue();
-  }
-
-  private Supplier<String> fileNotFoundMessage(Path path) {
-    return () -> "Can't find file " + path + " in project folder, found " + projectFiles();
-  }
-
-  @Then("I should not have files in {string}")
-  public void shouldNotHaveFiles(String basePath, List<String> files) {
-    assertThatLastResponse().hasHttpStatusIn(200, 201);
-
-    SoftAssertions assertions = new SoftAssertions();
-
-    files.stream().map(file -> Paths.get(lastProjectFolder, basePath, file)).forEach(assertFileNotExist(assertions));
-
-    assertions.assertAll();
-  }
-
-  private Consumer<Path> assertFileNotExist(SoftAssertions assertions) {
-    return path -> assertions.assertThat(!Files.exists(path)).as(fileFoundMessage(path)).isTrue();
-  }
-
-  private Supplier<String> fileFoundMessage(Path path) {
-    return () -> "Can find file " + path + " in project folder, found " + projectFiles();
-  }
-
-  private String projectFiles() {
-    try {
-      return Files.walk(Paths.get(lastProjectFolder)).filter(Files::isRegularFile).map(Path::toString).collect(Collectors.joining(", "));
-    } catch (IOException e) {
-      return "unreadable folder";
-    }
-  }
-
   @Then("I should have {string} in {string}")
   public void shouldHaveFileContent(String content, String file) throws IOException {
     assertThatLastResponse().hasHttpStatusIn(200, 201);
 
-    assertThat(Files.readString(Paths.get(lastProjectFolder, file))).contains(content);
+    assertThat(Files.readString(Paths.get(lastProjectFolder(), file))).contains(content);
   }
 
   @Then("I should not have {string} in {string}")
   public void shouldNotHaveFileContent(String content, String file) throws IOException {
     assertThatLastResponse().hasHttpStatusIn(200, 201);
 
-    assertThat(Files.readString(Paths.get(lastProjectFolder, file))).doesNotContain(content);
+    assertThat(Files.readString(Paths.get(lastProjectFolder(), file))).doesNotContain(content);
   }
 
   @Then("I should have entries in {string}")
   public void shouldHaveStringsInFile(String file, List<String> values) throws IOException {
     assertThatLastResponse().hasHttpStatusIn(200, 201);
-    assertThat(Files.readString(Paths.get(lastProjectFolder, file))).contains(values);
+    assertThat(Files.readString(Paths.get(lastProjectFolder(), file))).contains(values);
   }
 
   @Then("I should have {string} project")
@@ -162,20 +103,17 @@ public class ProjectsSteps {
   public void shouldHaveCommit(String commitMessage) throws IOException {
     assertThatLastResponse().hasOkStatus();
 
-    assertThat(GitTestUtil.getCommits(Paths.get(lastProjectFolder))).contains(commitMessage);
+    assertThat(GitTestUtil.getCommits(lastProjectPath())).contains(commitMessage);
   }
 
   @Then("I should not have any commit")
   public void shouldNotHaveCommits() throws IOException {
     assertThatLastResponse().hasOkStatus();
 
-    assertThat(GitTestUtil.getCommits(Paths.get(lastProjectFolder))).isEmpty();
+    assertThat(GitTestUtil.getCommits(lastProjectPath())).isEmpty();
   }
 
-  @Then("I should have {int} file in {string}")
-  public void shouldHaveFilesCountInDirectory(int filesCount, String directory) throws IOException {
-    assertThatLastResponse().hasOkStatus();
-
-    assertThat(Files.list(Paths.get(lastProjectFolder, directory)).count()).isEqualTo(filesCount);
+  private Path lastProjectPath() {
+    return Paths.get(lastProjectFolder());
   }
 }


### PR DESCRIPTION
Related to https://github.com/jhipster/jhipster-lite/issues/3650 because we need to be able to add JHLite steps in custom JHLite instances, that mean we need all module steps in a given package