### PR TITLE
Remove href in header section and add loader css

### DIFF
--- a/src/main/webapp/app/assets/loader.scss
+++ b/src/main/webapp/app/assets/loader.scss
@@ -1,0 +1,25 @@
+.jhipster-loader-container {
+  height: 100%;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.jhipster-loader {
+  width: 48px;
+  height: 48px;
+  border: 5px solid #fff;
+  border-bottom-color: transparent;
+  border-radius: 50%;
+  display: inline-block;
+  box-sizing: border-box;
+  animation: rotation 1s linear infinite;
+}
+
+@keyframes rotation {
+  0% {
+    transform: rotate(0deg);
+  }
+  100% {
+    transform: rotate(360deg);
+  }
+}

--- a/src/main/webapp/app/common/primary/header/Header.vue
+++ b/src/main/webapp/app/common/primary/header/Header.vue
@@ -1,34 +1,34 @@
 <template>
   <header class="jhlite-header">
     <div class="jhlite-header--slot">
-      <a class="jhlite-logo" href="/">
+      <router-link class="jhlite-logo" to="/">
         <img class="jhlite-logo--icon" src="../../../../content/JHipster-Lite-neon-blue.png" alt="JHipster bow tie" width="48" />
         <span class="jhlite-logo--text">JHipster lite</span>
-      </a>
+      </router-link>
     </div>
     <div class="jhlite-header--slot -expand"></div>
     <div class="jhlite-header--slot">
       <nav aria-label="Main navigation">
         <ul class="jhlite-nav">
           <li class="jhlite-nav--item">
-            <a class="jhlite-nav-item" href="landscape">
+            <router-link class="jhlite-nav-item" to="/landscape">
               <span class="jhlite-icon-text">
                 <span class="jhlite-icon-text--icon">
                   <IconVue name="map" aria-label="Icon map" title="Module landscape" />
                 </span>
                 <span class="jhlite-icon-text--text">Landscape</span>
               </span>
-            </a>
+            </router-link>
           </li>
           <li class="jhlite-nav--item">
-            <a class="jhlite-nav-item" href="patches">
+            <router-link class="jhlite-nav-item" to="/patches">
               <span class="jhlite-icon-text">
                 <span class="jhlite-icon-text--icon">
                   <IconVue name="puzzle" aria-label="Icon puzzle" title="Patch list" />
                 </span>
                 <span class="jhlite-icon-text--text">Patches</span>
               </span>
-            </a>
+            </router-link>
           </li>
           <li class="jhlite-nav--item">
             <a

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -1,4 +1,6 @@
-<div class="jhipster-landscape" v-if="levels.isLoading()" data-selector="landscape-loader">Loading</div>
+<div class="jhipster-landscape jhipster-loader-container" v-if="levels.isLoading()" data-selector="landscape-loader">
+  <div class="jhipster-loader"></div>
+</div>
 <div class="jhipster-landscape jhlite-menu-content-template" v-else data-selector="landscape">
   <div class="jhipster-landscape-modes-selection">
     <div class="jhipster-landscape-modes-selection--modes">

--- a/src/main/webapp/app/module/primary/modules-patch/ModulesPatch.html
+++ b/src/main/webapp/app/module/primary/modules-patch/ModulesPatch.html
@@ -1,4 +1,6 @@
-<div class="jhipster-modules" v-if="content.isLoading()" data-selector="modules-loader">Loading</div>
+<div class="jhipster-modules jhipster-loader-container" v-if="content.isLoading()" data-selector="modules-loader">
+  <div class="jhipster-loader"></div>
+</div>
 <div class="jhipster-modules jhlite-menu-content-template" v-else data-selector="modules-list">
   <div class="jhipster-modules-list jhlite-menu-content-template--content">
     <div class="jhipster-modules-filters">

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -40,7 +40,7 @@ export default defineConfig({
   css: {
     preprocessorOptions: {
       scss: {
-        additionalData: '@import "@/assets/global.scss"; @import "@/assets/side-form.scss";',
+        additionalData: '@import "@/assets/global.scss"; @import "@/assets/side-form.scss"; @import "@/assets/loader.scss";',
       },
     },
   },


### PR DESCRIPTION
The header has href which causes full page reloads, this is refactored to router-link and a css loader added instead of text.

Related to #3005 (which is larger issue for adding placeholder loading)