### PR TITLE
Fix failing PR labelling

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -2,7 +2,7 @@ name: Triage pull requests and issues
 on:
   issues:
     types: opened
-  pull_request:
+  pull_request_target:
     types: opened
 jobs:
   apply-label:


### PR DESCRIPTION
Currently PRs are not being labelled for triage (due to missing write permission in actions)

pull_request_target as event type gives permissions required to label PR

Following issue #3281 and PR #3754