### PR TITLE
Dockerfile: Skip build of javadoc and sources jar during maven build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ RUN \
     cd /code/jhipster-app/ && \
     rm -Rf target node_modules && \
     chmod +x mvnw && \
-    ./mvnw package -DskipTests && \
+    ./mvnw package -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip && \
     mv /code/jhipster-app/target/*.jar /code/ && \
     rm -Rf /code/jhipster-app/ /root/.m2 /root/.cache /tmp/* /var/tmp/*
 


### PR DESCRIPTION
to prevent having multiple jars in execution folder

Fixes #3986