### PR TITLE
Remove jhipster-needle-exception-translator from templates

### DIFF
--- a/src/main/resources/generator/server/springboot/mvc/zalandoproblem/main/ExceptionTranslator.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/zalandoproblem/main/ExceptionTranslator.java.mustache
@@ -110,8 +110,6 @@ public class ExceptionTranslator implements ProblemHandling {
     return create(ex, request, HeaderUtil.createFailureAlert(applicationName, ex.getEntityName(), ex.getErrorKey()));
   }
 
-  // jhipster-needle-exception-translator
-
   @Override
   public ProblemBuilder prepare(final Throwable throwable, final StatusType status, final URI type) {
     if (!exceptionWithDetails) {

--- a/src/main/resources/generator/server/springboot/mvc/zalandoproblem/test/ExceptionTranslatorIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/zalandoproblem/test/ExceptionTranslatorIT.java.mustache
@@ -215,5 +215,4 @@ class ExceptionTranslatorIT {
       .andExpect(jsonPath("$.title").value("Internal Server Error"));
   }
 
-  // jhipster-needle-exception-translator-it
 }

--- a/src/main/resources/generator/server/springboot/mvc/zalandoproblem/test/ExceptionTranslatorTestController.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/zalandoproblem/test/ExceptionTranslatorTestController.java.mustache
@@ -44,8 +44,6 @@ public class ExceptionTranslatorTestController {
     throw new HttpMessageConversionException("beer");
   }
 
-  // jhipster-needle-exception-translator-test-controller
-
   public static class TestDTO {
 
     @NotNull

--- a/src/main/resources/generator/server/springboot/webflux/web/test/ExceptionTranslatorIT.java.mustache
+++ b/src/main/resources/generator/server/springboot/webflux/web/test/ExceptionTranslatorIT.java.mustache
@@ -291,5 +291,4 @@ class ExceptionTranslatorIT {
     ));
   }
 
-  // jhipster-needle-exception-translator-it
 }

--- a/src/main/resources/generator/server/springboot/webflux/web/test/ExceptionTranslatorTestController.java.mustache
+++ b/src/main/resources/generator/server/springboot/webflux/web/test/ExceptionTranslatorTestController.java.mustache
@@ -59,8 +59,6 @@ class ExceptionTranslatorTestController {
     throw new HttpMessageConversionException("beer");
   }
 
-  // jhipster-needle-exception-translator-test-controller
-
   @SuppressWarnings("unused")
   public static class TestDataDTO {
 


### PR DESCRIPTION
jhipster-needle-exception-translator and jhipster-needle-exception-translator-it are not used and can be deleted

Fix #3974