### PR TITLE
ci: use environment file to manage outputs without warnings

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -176,7 +176,7 @@ jobs:
           ls -al /tmp/jhlite/${{ matrix.app }}
           MD5SUM_POM_XML=$(md5sum /tmp/jhlite/${{ matrix.app }}/pom.xml | cut -d ' ' -f 1)
           echo $MD5SUM_POM_XML
-          echo ::set-output name=md5sum_pom_xml::${MD5SUM_POM_XML}
+          echo "md5sum_pom_xml=${MD5SUM_POM_XML}" >> $GITHUB_OUTPUT
       - name: 'Init: cache local Maven repository'
         uses: actions/cache@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,9 +61,9 @@ jobs:
           ARTIFACT_PATHNAME=$(ls target/*.jar | head -n 1)
           ARTIFACT_NAME=$(basename $ARTIFACT_PATHNAME)
           ARTIFACT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
-          echo ::set-output name=artifact_asset_name::${ARTIFACT_NAME}
-          echo ::set-output name=artifact_asset_path::${ARTIFACT_PATHNAME}
-          echo ::set-output name=artifact_version::${ARTIFACT_VERSION}
+          echo "artifact_asset_name=${ARTIFACT_NAME}" >> $GITHUB_OUTPUT
+          echo "artifact_asset_path=${ARTIFACT_PATHNAME}" >> $GITHUB_OUTPUT
+          echo "artifact_version=${ARTIFACT_VERSION}" >> $GITHUB_OUTPUT
       - name: 'Release: publish release drafter'
         uses: release-drafter/release-drafter@v5
         id: release-drafter-final


### PR DESCRIPTION

GitHub Actions have depreciated the `set-output` command to avoid vulnerabilities

See changelog https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/