### PR TITLE
use boot 3 compatible mongock version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
     <joox.version>1.6.2</joox.version>
     <dom4j.version>2.1.3</dom4j.version>
     <testcontainers.version>1.17.5</testcontainers.version>
-    <mongock.version>5.1.6</mongock.version>
+    <mongock.version>5.1.7</mongock.version>
 
     <frontend-maven-plugin.version>1.12.1</frontend-maven-plugin.version>
     <checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
@@ -221,12 +221,12 @@
 
     <dependency>
       <groupId>io.mongock</groupId>
-      <artifactId>mongock-springboot</artifactId>
+      <artifactId>mongock-springboot-v3</artifactId>
     </dependency>
 
     <dependency>
       <groupId>io.mongock</groupId>
-      <artifactId>mongodb-springdata-v3-driver</artifactId>
+      <artifactId>mongodb-springdata-v4-driver</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
This will work when the new artifacts are published. Therefore this PR is in draft mode.

Closes https://github.com/jhipster/jhipster-lite/issues/4067