### PR TITLE
make annotation attribute override explicit

### DIFF
--- a/src/test/java/tech/jhipster/lite/IntegrationTest.java
+++ b/src/test/java/tech/jhipster/lite/IntegrationTest.java
@@ -6,11 +6,13 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.core.annotation.AliasFor;
 
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @DisplayNameGeneration(ReplaceCamelCase.class)
 @SpringBootTest(classes = { JHLiteApp.class })
 public @interface IntegrationTest {
+  @AliasFor(annotation = SpringBootTest.class)
   String[] properties() default {};
 }


### PR DESCRIPTION
This fixes the warning
> AnnotationTypeMapping   : Support for convention-based annotation attribute overrides is deprecated and will be removed in Spring Framework 6.1. Please annotate the following attributes in @tech.jhipster.lite.IntegrationTest with appropriate @AliasFor declarations: [properties]