### PR TITLE
bump vite from 3.1.8 to 3.2.1 in /src/main/resources/generator/dependencies/vue

### DIFF
--- a/src/main/resources/generator/dependencies/vue/package.json
+++ b/src/main/resources/generator/dependencies/vue/package.json
@@ -25,7 +25,7 @@
     "jsdom": "20.0.1",
     "sinon": "14.0.1",
     "typescript": "4.8.4",
-    "vite": "3.1.8",
+    "vite": "3.2.1",
     "vitest": "0.24.3",
     "vitest-sonar-reporter": "0.3.2",
     "vue-tsc": "1.0.9"


### PR DESCRIPTION
Fix #4140 