### PR TITLE
Add radius to connectors in landscape

### DIFF
--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -67,11 +67,11 @@
       :style="`width: ${landscapeSize.width}px; height: ${landscapeSize.height}px`"
       data-selector="landscape-connectors"
     >
-      <polyline
+      <path
         v-for="connector in landscapeConnectors"
         class="jhipster-landscape-connectors--line"
         :class="elementFlavor(connector.startingElement)"
-        :points="connector.points"
+        :d="connector.path"
       />
     </svg>
   </div>

--- a/src/main/webapp/app/module/primary/landscape/LandscapeConnector.ts
+++ b/src/main/webapp/app/module/primary/landscape/LandscapeConnector.ts
@@ -1,19 +1,64 @@
 import { LandscapeElementId } from '@/module/domain/landscape/LandscapeElementId';
 
 const SPACER_SIZE = 9;
+const CURVE_RADIUS = 6;
+
+const MOVE_TO_COMMAND = 'M';
+const LINE_TO_COMMAND = 'L';
+const CURVE_TO_COMMAND = 'C';
 
 export class LandscapeConnector {
   public readonly points: string;
+  public readonly path: string;
   constructor(
     public readonly positions: LandscapeConnectorPosition[],
     public readonly startingElement: LandscapeElementId,
     public readonly endingElement: LandscapeElementId
   ) {
     this.points = this.buildPoints();
+    this.path = this.buildCurvedPath();
   }
 
   private buildPoints(): string {
-    return this.positions.map(position => position.x + ',' + position.y).join(' ');
+    return this.positions.map(position => position.x + ' ' + position.y).join(' ');
+  }
+
+  private buildCurvedPath(): string {
+    const commands: string[] = [];
+    commands.push(this.buildCommand(MOVE_TO_COMMAND, [this.positions[0]]));
+
+    const firstControlPoint: LandscapeConnectorPosition = this.positions[1];
+    const secondControlPoint: LandscapeConnectorPosition = this.positions[2];
+
+    const firstCurveStartPosition: LandscapeConnectorPosition = {
+      x: firstControlPoint.x - CURVE_RADIUS,
+      y: firstControlPoint.y,
+    };
+    const firstCurveEndPosition: LandscapeConnectorPosition = {
+      x: firstControlPoint.x,
+      y: firstControlPoint.y > secondControlPoint.y ? firstControlPoint.y - CURVE_RADIUS : firstControlPoint.y + CURVE_RADIUS,
+    };
+    commands.push(this.buildCommand(LINE_TO_COMMAND, [firstCurveStartPosition]));
+    commands.push(this.buildCommand(CURVE_TO_COMMAND, [firstCurveStartPosition, firstControlPoint, firstCurveEndPosition]));
+
+    const secondCurveStartPosition: LandscapeConnectorPosition = {
+      x: secondControlPoint.x,
+      y: firstControlPoint.y > secondControlPoint.y ? secondControlPoint.y + CURVE_RADIUS : secondControlPoint.y - CURVE_RADIUS,
+    };
+    const secondCurveEndPosition: LandscapeConnectorPosition = {
+      x: secondControlPoint.x + CURVE_RADIUS,
+      y: secondControlPoint.y,
+    };
+    commands.push(this.buildCommand(LINE_TO_COMMAND, [secondCurveStartPosition]));
+    commands.push(this.buildCommand(CURVE_TO_COMMAND, [secondCurveStartPosition, secondControlPoint, secondCurveEndPosition]));
+
+    commands.push(this.buildCommand(LINE_TO_COMMAND, [this.positions[this.positions.length - 1]]));
+
+    return commands.join(' ');
+  }
+
+  private buildCommand(command: string, positions: LandscapeConnectorPosition[]): string {
+    return command + ' ' + positions.map(position => position.x + ' ' + position.y).join(' ');
   }
 }
 

--- a/src/test/javascript/spec/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/javascript/spec/module/primary/landscape/LandscapeComponent.spec.ts
@@ -91,7 +91,7 @@ describe('Landscape', () => {
 
       expect(wrapper.find(wrappedElement('landscape-loader')).exists()).toBe(false);
       expect(wrapper.find(wrappedElement('landscape')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('landscape-connectors')).findAll('polyline').length).toBe(17);
+      expect(wrapper.find(wrappedElement('landscape-connectors')).findAll('path').length).toBe(17);
       expect(applicationListener.addEventListener.calledOnce).toBe(true);
 
       const pathField = wrapper.find(wrappedElement('folder-path-field')).element as HTMLInputElement;
@@ -670,7 +670,7 @@ const assertConnectorsCount = (wrapper: VueWrapper, cssClass: string, count: num
   expect(
     wrapper
       .find(wrappedElement('landscape-connectors'))
-      .findAll('polyline')
+      .findAll('path')
       .filter(line => line.classes().includes(cssClass)).length
   ).toBe(count);
 };

--- a/src/test/javascript/spec/module/primary/landscape/LandscapeConnector.spec.ts
+++ b/src/test/javascript/spec/module/primary/landscape/LandscapeConnector.spec.ts
@@ -1,0 +1,54 @@
+import { LandscapeConnector, LandscapeConnectorPosition } from '@/module/primary/landscape/LandscapeConnector';
+import { moduleSlug } from '../../domain/Modules.fixture';
+
+describe('LandscapeConnector', () => {
+  describe('Generate curved path', () => {
+    it('Should generate curved path for bottom-right dependant', () => {
+      const positions: LandscapeConnectorPosition[] = [
+        {
+          x: 0,
+          y: 0,
+        },
+        {
+          x: 10,
+          y: 0,
+        },
+        {
+          x: 10,
+          y: 100,
+        },
+        {
+          x: 100,
+          y: 100,
+        },
+      ];
+      const landscapeConnector: LandscapeConnector = new LandscapeConnector(positions, moduleSlug('moduleA'), moduleSlug('B'));
+      //MoveTo 'startPoint', LineTo, CurveTo(3 points), LineTo, CurveTo(3 points), LineTo 'endPoint'
+      expect(landscapeConnector.path).toEqual('M 0 0 L 4 0 C 4 0 10 0 10 6 L 10 94 C 10 94 10 100 16 100 L 100 100');
+    });
+
+    it('Should generate curved path for top-right dependant', () => {
+      const positions: LandscapeConnectorPosition[] = [
+        {
+          x: 100,
+          y: 100,
+        },
+        {
+          x: 110,
+          y: 100,
+        },
+        {
+          x: 110,
+          y: 0,
+        },
+        {
+          x: 200,
+          y: 0,
+        },
+      ];
+      const landscapeConnector: LandscapeConnector = new LandscapeConnector(positions, moduleSlug('moduleA'), moduleSlug('B'));
+      //MoveTo 'startPoint', LineTo, CurveTo(3 points), LineTo, CurveTo(3 points), LineTo 'endPoint'
+      expect(landscapeConnector.path).toEqual('M 100 100 L 104 100 C 104 100 110 100 110 94 L 110 6 C 110 6 110 0 116 0 L 200 0');
+    });
+  });
+});


### PR DESCRIPTION
Add radius using <path> instead of <polyline> in SVG connectors.

Fix #3967