### PR TITLE
Add classifier in dependency ID

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
@@ -7,6 +7,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.regex.Pattern;
 import java.util.stream.Stream;
@@ -126,7 +127,7 @@ public class JHipsterModule {
   }
 
   public static DependencyId dependencyId(String groupId, String artifactId) {
-    return new DependencyId(groupId(groupId), artifactId(artifactId));
+    return new DependencyId(groupId(groupId), artifactId(artifactId), Optional.empty());
   }
 
   public static JavaBuildPluginGroupIdBuilder javaBuildPlugin() {

--- a/src/main/java/tech/jhipster/lite/module/domain/javabuildplugin/JavaBuildPlugin.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/javabuildplugin/JavaBuildPlugin.java
@@ -13,7 +13,7 @@ public class JavaBuildPlugin {
   private final Optional<JavaBuildPluginAdditionalElements> additionalElements;
 
   private JavaBuildPlugin(JavaBuildPluginBuilder builder) {
-    dependencyId = new DependencyId(builder.groupId, builder.artifactId);
+    dependencyId = new DependencyId(builder.groupId, builder.artifactId, Optional.empty());
     versionSlug = Optional.ofNullable(builder.versionSlug);
     additionalElements = Optional.ofNullable(builder.additionalElements);
   }

--- a/src/main/java/tech/jhipster/lite/module/domain/javadependency/DependencyId.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/javadependency/DependencyId.java
@@ -1,12 +1,14 @@
 package tech.jhipster.lite.module.domain.javadependency;
 
+import java.util.Optional;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.module.domain.javabuild.ArtifactId;
 import tech.jhipster.lite.module.domain.javabuild.GroupId;
 
-public record DependencyId(GroupId groupId, ArtifactId artifactId) {
+public record DependencyId(GroupId groupId, ArtifactId artifactId, Optional<JavaDependencyClassifier> classifier) {
   public DependencyId {
     Assert.notNull("groupId", groupId);
     Assert.notNull("artifactId", artifactId);
+    Assert.notNull("classifier", classifier);
   }
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/javadependency/JavaDependency.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/javadependency/JavaDependency.java
@@ -21,16 +21,14 @@ public class JavaDependency {
 
   private final DependencyId id;
   private final Optional<VersionSlug> versionSlug;
-  private final Optional<JavaDependencyClassifier> classifier;
   private final JavaDependencyScope scope;
   private final boolean optional;
   private final Optional<JavaDependencyType> type;
   private final Collection<DependencyId> exclusions;
 
   private JavaDependency(JavaDependencyBuilder builder) {
-    id = new DependencyId(builder.groupId, builder.artifactId);
+    id = new DependencyId(builder.groupId, builder.artifactId, Optional.ofNullable(builder.classifier));
     versionSlug = Optional.ofNullable(builder.versionSlug);
-    classifier = Optional.ofNullable(builder.classifier);
     scope = JavaDependencyScope.from(builder.scope);
     optional = builder.optional;
     type = Optional.ofNullable(builder.type);
@@ -90,30 +88,22 @@ public class JavaDependency {
 
   private Collection<JavaDependency> merge(JavaDependency other) {
     Collection<JavaDependency> resultingDependencies = new ArrayList<>();
-    resultingDependencies.add(merge(other, type, classifier));
+    resultingDependencies.add(merge(other, type));
 
     if (!type.equals(other.type)) {
-      resultingDependencies.add(merge(other, other.type, classifier));
-    }
-
-    if (!classifier.equals(other.classifier)) {
-      resultingDependencies.add(merge(other, type, other.classifier));
+      resultingDependencies.add(merge(other, other.type));
     }
 
     return resultingDependencies;
   }
 
-  private JavaDependency merge(
-    JavaDependency other,
-    Optional<JavaDependencyType> resultingType,
-    Optional<JavaDependencyClassifier> resultingClassifier
-  ) {
+  private JavaDependency merge(JavaDependency other, Optional<JavaDependencyType> resultingType) {
     return JavaDependency
       .builder()
       .groupId(groupId())
       .artifactId(artifactId())
       .versionSlug(mergeVersionsSlugs(other))
-      .classifier(resultingClassifier.orElse(null))
+      .classifier(classifier().orElse(null))
       .scope(mergeScopes(other))
       .optional(mergeOptionalFlag(other))
       .type(resultingType.orElse(null))
@@ -141,7 +131,7 @@ public class JavaDependency {
   }
 
   public Optional<JavaDependencyClassifier> classifier() {
-    return classifier;
+    return id.classifier();
   }
 
   public boolean optional() {
@@ -171,7 +161,7 @@ public class JavaDependency {
   @Override
   @Generated
   public int hashCode() {
-    return new HashCodeBuilder().append(id).append(versionSlug).append(classifier).append(scope).append(optional).append(type).hashCode();
+    return new HashCodeBuilder().append(id).append(versionSlug).append(scope).append(optional).append(type).hashCode();
   }
 
   @Override
@@ -190,7 +180,6 @@ public class JavaDependency {
     return new EqualsBuilder()
       .append(id, other.id)
       .append(versionSlug, other.versionSlug)
-      .append(classifier, other.classifier)
       .append(scope, other.scope)
       .append(optional, other.optional)
       .append(type, other.type)
@@ -319,7 +308,7 @@ public class JavaDependency {
     }
 
     default JavaDependencyOptionalValueBuilder addExclusion(GroupId groupId, ArtifactId artifactId) {
-      return addExclusion(new DependencyId(groupId, artifactId));
+      return addExclusion(new DependencyId(groupId, artifactId, Optional.empty()));
     }
   }
 }

--- a/src/test/java/tech/jhipster/lite/module/domain/JHipsterModulesFixture.java
+++ b/src/test/java/tech/jhipster/lite/module/domain/JHipsterModulesFixture.java
@@ -5,6 +5,7 @@ import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import tech.jhipster.lite.TestFileUtils;
@@ -143,7 +144,7 @@ public final class JHipsterModulesFixture {
   }
 
   public static DependencyId springBootDependencyId() {
-    return new DependencyId(groupId("org.springframework.boot"), artifactId("spring-boot-dependencies"));
+    return new DependencyId(groupId("org.springframework.boot"), artifactId("spring-boot-dependencies"), Optional.empty());
   }
 
   public static JavaDependency defaultVersionDependency() {
@@ -157,7 +158,7 @@ public final class JHipsterModulesFixture {
   public static JavaBuildCommands javaDependenciesCommands() {
     SetVersion setVersion = new SetVersion(springBootVersion());
     RemoveDirectJavaDependency remove = new RemoveDirectJavaDependency(
-      new DependencyId(new GroupId("spring-boot"), new ArtifactId("1.2.3"))
+      new DependencyId(new GroupId("spring-boot"), new ArtifactId("1.2.3"), Optional.empty())
     );
     AddDirectJavaDependency add = new AddDirectJavaDependency(optionalTestDependency());
 
@@ -179,7 +180,7 @@ public final class JHipsterModulesFixture {
   }
 
   public static DependencyId jsonWebTokenDependencyId() {
-    return new DependencyId(new GroupId("io.jsonwebtoken"), new ArtifactId("jjwt-api"));
+    return new DependencyId(new GroupId("io.jsonwebtoken"), new ArtifactId("jjwt-api"), Optional.empty());
   }
 
   public static JHipsterModuleContext context() {

--- a/src/test/java/tech/jhipster/lite/module/domain/javadependency/JavaDependencyMangementTest.java
+++ b/src/test/java/tech/jhipster/lite/module/domain/javadependency/JavaDependencyMangementTest.java
@@ -204,12 +204,7 @@ class JavaDependencyMangementTest {
 
     JavaBuildCommands changes = changes().dependency(optionalTestDependency()).projectDependencies(projectDependencies).build();
 
-    assertThat(changes.get())
-      .containsExactly(
-        new RemoveJavaDependencyManagement(differentClassifier.id()),
-        new AddJavaDependencyManagement(optionalTestDependency()),
-        new AddJavaDependencyManagement(differentClassifier)
-      );
+    assertThat(changes.get()).containsExactly(new AddJavaDependencyManagement(optionalTestDependency()));
   }
 
   private JavaDependency junitWithoutVersion() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/FileSystemProjectJavaDependenciesRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/FileSystemProjectJavaDependenciesRepositoryTest.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.module.infrastructure.secondary.javadependency;
 import static org.assertj.core.api.Assertions.*;
 import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.*;
 
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.error.domain.GeneratorException;
@@ -67,11 +68,14 @@ class FileSystemProjectJavaDependenciesRepositoryTest {
 
     assertJJWTDependency(dependencies);
     assertLogstashDependency(dependencies);
-    assertThat(dependencies.get(new DependencyId(new GroupId("org.springdoc"), new ArtifactId("springdoc-openapi-ui")))).isEmpty();
+    assertThat(dependencies.get(new DependencyId(new GroupId("org.springdoc"), new ArtifactId("springdoc-openapi-ui"), Optional.empty())))
+      .isEmpty();
   }
 
   private void assertJJWTDependency(JavaDependencies dependencies) {
-    JavaDependency jjwt = dependencies.get(new DependencyId(new GroupId("io.jsonwebtoken"), new ArtifactId("jjwt-api"))).get();
+    JavaDependency jjwt = dependencies
+      .get(new DependencyId(new GroupId("io.jsonwebtoken"), new ArtifactId("jjwt-api"), JavaDependencyClassifier.of("classif")))
+      .get();
 
     assertThat(jjwt.version()).contains(new VersionSlug("jjwt"));
     assertThat(jjwt.scope()).isEqualTo(JavaDependencyScope.TEST);
@@ -81,7 +85,7 @@ class FileSystemProjectJavaDependenciesRepositoryTest {
 
   private void assertLogstashDependency(JavaDependencies dependencies) {
     JavaDependency jjwt = dependencies
-      .get(new DependencyId(new GroupId("net.logstash.logback"), new ArtifactId("logstash-logback-encoder")))
+      .get(new DependencyId(new GroupId("net.logstash.logback"), new ArtifactId("logstash-logback-encoder"), Optional.empty()))
       .get();
     assertThat(jjwt.version()).isEmpty();
     assertThat(jjwt.scope()).isEqualTo(JavaDependencyScope.COMPILE);


### PR DESCRIPTION
Fix https://github.com/jhipster/jhipster-lite/issues/4149

Tried different things for this but... I really think the classifier should be part of the DependencyID, that totally make sense with my current understanding of maven dependencies (but I may be totally wrong here!)