### PR TITLE
Caffeine JCache

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/JHLiteFeatureSlug.java
+++ b/src/main/java/tech/jhipster/lite/generator/JHLiteFeatureSlug.java
@@ -6,7 +6,7 @@ public enum JHLiteFeatureSlug implements JHipsterFeatureSlugFactory {
   ANGULAR_AUTHENTICATION("angular-authentication"),
   AUTHENTICATION("authentication"),
   BANNER("banner"),
-  CACHE("cache"),
+  JCACHE("jcache"),
   CLIENT_CORE("client-core"),
   CUCUMBER_AUTHENTICATION("cucumber-authentication"),
   DATABASE_MIGRATION("database-migration"),

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/domain/CaffeineCacheModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/domain/CaffeineCacheModuleFactory.java
@@ -18,7 +18,8 @@ public class CaffeineCacheModuleFactory {
     return moduleBuilder(properties)
       .documentation(documentationTitle("Caffeine"), SOURCE.template("caffeine.md"))
       .javaDependencies()
-        .addDependency(groupId("com.github.ben-manes.caffeine"), artifactId("caffeine"))
+        .addDependency(groupId("com.github.ben-manes.caffeine"), artifactId("jcache"))
+        .addDependency(groupId("javax.cache"), artifactId("cache-api"))
         .and()
       .build();
     //@formatter:on

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/infrastructure/primary/CaffeineCacheModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/infrastructure/primary/CaffeineCacheModuleConfiguration.java
@@ -1,5 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cache.caffeine.infrastructure.primary;
 
+import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JCACHE;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import tech.jhipster.lite.generator.JHLiteModuleSlug;
@@ -18,7 +20,7 @@ class CaffeineCacheModuleConfiguration {
       .slug(JHLiteModuleSlug.CAFFEINE_CACHE)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().addIndentation().build())
       .apiDoc("Spring Boot - Cache", "Add caffeine cache")
-      .organization(JHipsterModuleOrganization.builder().addDependency(JHLiteModuleSlug.SPRING_BOOT_CACHE).build())
+      .organization(JHipsterModuleOrganization.builder().feature(JCACHE).addDependency(JHLiteModuleSlug.SPRING_BOOT_CACHE).build())
       .tags("server", "spring", "spring-boot", "cache")
       .factory(caffeineCaches::buildModule);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/EHCacheModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/EHCacheModulesConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JCACHE;
 import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
@@ -45,6 +45,6 @@ class EHCacheModulesConfiguration {
   }
 
   private JHipsterModuleOrganization organization() {
-    return JHipsterModuleOrganization.builder().feature(CACHE).addDependency(SPRING_BOOT).build();
+    return JHipsterModuleOrganization.builder().feature(JCACHE).addDependency(SPRING_BOOT).build();
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/domain/CaffeineCacheModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/domain/CaffeineCacheModuleFactoryTest.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cache.caffeine.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.pomFile;
 
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
@@ -29,7 +30,15 @@ class CaffeineCacheModuleFactoryTest {
         """
             <dependency>
               <groupId>com.github.ben-manes.caffeine</groupId>
-              <artifactId>caffeine</artifactId>
+              <artifactId>jcache</artifactId>
+            </dependency>
+        """
+      )
+      .containing(
+        """
+            <dependency>
+              <groupId>javax.cache</groupId>
+              <artifactId>cache-api</artifactId>
             </dependency>
         """
       )


### PR DESCRIPTION
- [x] switch to [Caffeine JCache](https://github.com/ben-manes/caffeine/wiki/JCache)
- [x] provides feature `jcache` instead of `cache` (also updated ehcache), so that JCache-based modules can depend on it
- [ ] be consistent with ehcache: do not depent on "simple" cache and provide a specific configuration class (or depend on a new jcache module as it was done in the past but too heavy)

This PR makes the caffeine module compatible with PR #4269.

If we don't want that, we could also say that Caffeine is not an option for Hibernate 2nd-level caching.