### PR TITLE
configure global jwt bearer auth for swagger documentation

### DIFF
--- a/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
@@ -19,10 +19,8 @@ class SpringdocJWTConfiguration {
 
   @Bean
   GlobalOpenApiCustomizer jwtOpenApi() {
-    return openApi -> openApi
-        .addSecurityItem(new SecurityRequirement()
-            .addList(securitySchemeName))
-        .components(jwtComponents(openApi.getComponents()));
+    return openApi ->
+      openApi.addSecurityItem(new SecurityRequirement().addList(securitySchemeName)).components(jwtComponents(openApi.getComponents()));
   }
 
   private Components jwtComponents(Components existingComponents) {

--- a/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
@@ -14,9 +14,14 @@ import {{packageName}}.common.domain.Generated;
 @Generated(reason = "Not called by integration tests")
 class SpringdocJWTConfiguration {
 
+  private final String securitySchemeName = "bearerAuth";
+
   @Bean
   GlobalOpenApiCustomizer jwtOpenApi() {
-    return openApi -> openApi.components(jwtComponents(openApi.getComponents()));
+    return openApi -> openApi
+        .addSecurityItem(new SecurityRequirement()
+            .addList(securitySchemeName))
+        .components(jwtComponents(openApi.getComponents()));
   }
 
   private Components jwtComponents(Components existingComponents) {
@@ -27,7 +32,7 @@ class SpringdocJWTConfiguration {
         .scheme("Bearer")
         .bearerFormat("JWT")
         .in(SecurityScheme.In.HEADER)
-        .name("bearerAuth")
+        .name(securitySchemeName")
     );
   }
 }

--- a/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/apidocumentation/springdocjwt/SpringdocJWTConfiguration.java.mustache
@@ -2,6 +2,7 @@ package {{packageName}}.technical.infrastructure.primary.springdoc;
 
 import io.swagger.v3.oas.models.Components;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
 import org.springdoc.core.customizers.GlobalOpenApiCustomizer;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +33,7 @@ class SpringdocJWTConfiguration {
         .scheme("Bearer")
         .bearerFormat("JWT")
         .in(SecurityScheme.In.HEADER)
-        .name(securitySchemeName")
+        .name(securitySchemeName)
     );
   }
 }


### PR DESCRIPTION
This configures the swagger/openapi docs to use jwt bearer auth globally/for all endpoints

closes #4273