### PR TITLE
group springdoc auth modules under same features

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/JHLiteFeatureSlug.java
+++ b/src/main/java/tech/jhipster/lite/generator/JHLiteFeatureSlug.java
@@ -5,6 +5,7 @@ import tech.jhipster.lite.module.domain.resource.JHipsterFeatureSlugFactory;
 public enum JHLiteFeatureSlug implements JHipsterFeatureSlugFactory {
   ANGULAR_AUTHENTICATION("angular-authentication"),
   AUTHENTICATION("authentication"),
+  AUTHENTICATION_SPRINGDOC("authentication-springdoc"),
   BANNER("banner"),
   CACHE("cache"),
   CLIENT_CORE("client-core"),
@@ -16,6 +17,7 @@ public enum JHLiteFeatureSlug implements JHipsterFeatureSlugFactory {
   JAVA_BUILD_TOOL("java-build-tool"),
   JPA_PERSISTENCE("jpa-persistence"),
   OAUTH_PROVIDER("oauth-provider"),
+  OAUTH_PROVIDER_SPRINGDOC("oauth-provider-springdoc"),
   SERVICE_DISCOVERY("service-discovery"),
   SPRING_SERVER("spring-server"),
   SPRINGDOC("springdoc"),

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocauth0/infrastructure/primary/SpringDocAuth0ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocauth0/infrastructure/primary/SpringDocAuth0ModuleConfiguration.java
@@ -20,7 +20,14 @@ class SpringDocAuth0ModuleConfiguration {
       .slug(SPRINGDOC_OAUTH_2_AUTH_0)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().addIndentation().build())
       .apiDoc("Spring Boot - API Documentation", "Add Auth0 authentication for springdoc")
-      .organization(JHipsterModuleOrganization.builder().addDependency(SPRINGDOC).addDependency(SPRING_BOOT_OAUTH_2_AUTH_0).build())
+      .organization(
+        JHipsterModuleOrganization
+          .builder()
+          .feature(OAUTH_PROVIDER_SPRINGDOC)
+          .addDependency(SPRINGDOC)
+          .addDependency(SPRING_BOOT_OAUTH_2_AUTH_0)
+          .build()
+      )
       .tags("server", "swagger", "springdoc", "auth0")
       .factory(springdocAuth0::buildModule);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocjwt/infrastructure/primary/SpringdocJwtModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocjwt/infrastructure/primary/SpringdocJwtModuleConfiguration.java
@@ -20,7 +20,14 @@ class SpringdocJwtModuleConfiguration {
       .slug(SPRINGDOC_JWT)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().addIndentation().build())
       .apiDoc("Spring Boot - API Documentation", "Add JWT authentication for springdoc")
-      .organization(JHipsterModuleOrganization.builder().addDependency(SPRINGDOC).addDependency(SPRING_BOOT_JWT).build())
+      .organization(
+        JHipsterModuleOrganization
+          .builder()
+          .feature(AUTHENTICATION_SPRINGDOC)
+          .addDependency(SPRINGDOC)
+          .addDependency(SPRING_BOOT_JWT)
+          .build()
+      )
       .tags("server", "swagger", "springdoc")
       .factory(springdocJwt::buildModule);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocoauth/infrastructure/primary/SpringdocOauth2ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocoauth/infrastructure/primary/SpringdocOauth2ModuleConfiguration.java
@@ -20,7 +20,14 @@ class SpringdocOauth2ModuleConfiguration {
       .slug(SPRINGDOC_OAUTH_2)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().addIndentation().build())
       .apiDoc("Spring Boot - API Documentation", "Add OAuth2 authentication for springdoc")
-      .organization(JHipsterModuleOrganization.builder().addDependency(SPRINGDOC).addDependency(SPRING_BOOT_OAUTH_2).build())
+      .organization(
+        JHipsterModuleOrganization
+          .builder()
+          .feature(AUTHENTICATION_SPRINGDOC)
+          .addDependency(SPRINGDOC)
+          .addDependency(SPRING_BOOT_OAUTH_2)
+          .build()
+      )
       .tags("server", "swagger", "springdoc")
       .factory(springdocOauth2::buildModule);
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocokta/infrastructure/primary/SpringDocOktaModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocokta/infrastructure/primary/SpringDocOktaModuleConfiguration.java
@@ -20,7 +20,14 @@ class SpringDocOktaModuleConfiguration {
       .slug(SPRINGDOC_OAUTH_2_OKTA)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().addIndentation().build())
       .apiDoc("Spring Boot - API Documentation", "Add Okta authentication for springdoc")
-      .organization(JHipsterModuleOrganization.builder().addDependency(SPRINGDOC).addDependency(SPRING_BOOT_OAUTH_2_OKTA).build())
+      .organization(
+        JHipsterModuleOrganization
+          .builder()
+          .feature(OAUTH_PROVIDER_SPRINGDOC)
+          .addDependency(SPRINGDOC)
+          .addDependency(SPRING_BOOT_OAUTH_2_OKTA)
+          .build()
+      )
       .tags("server", "swagger", "springdoc", "okta")
       .factory(springdocOkta::buildModule);
   }


### PR DESCRIPTION
Fixes #4313

In the continuation of PR #4481 (merged too quickly, RIP), this one creates the feature `oauth-springdoc`.

I also added the feature `authentication-springdoc`, I find it more logic and homogeneous this way. 