### PR TITLE
Module 'angular-health' depends on 'spring-boot-actuator'

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/angular/admin/health/infrastructure/primary/AngularhealthModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/admin/health/infrastructure/primary/AngularhealthModuleConfiguration.java
@@ -18,7 +18,7 @@ class AngularhealthModuleConfiguration {
       .slug(ANGULAR_HEALTH)
       .withoutProperties()
       .apiDoc("Angular", "Angular Health")
-      .organization(JHipsterModuleOrganization.builder().addDependency(ANGULAR_CORE).build())
+      .organization(JHipsterModuleOrganization.builder().addDependency(ANGULAR_CORE).addDependency(SPRING_BOOT_ACTUATOR).build())
       .tags("client", "angular", "health")
       .factory(angularHealth::buildModule);
   }


### PR DESCRIPTION
Fix #4852 