### PR TITLE
Svelte: Anchor with target=_blank should have rel attribute containing the value noreferrer

### DIFF
--- a/src/main/resources/generator/client/svelte/src/main/webapp/app/common/primary/app/App.svelte.mustache
+++ b/src/main/resources/generator/client/svelte/src/main/webapp/app/common/primary/app/App.svelte.mustache
@@ -6,11 +6,11 @@
 		<img alt="JHipster logo" src="JHipster-Lite-neon-orange.png" />
 	</div>
 	<h1>svelteapp: SvelteKit + Typescript</h1>
-	<p>Recommend IDE setup: <a href="https://code.visualstudio.com/" target="_blank">VSCode</a></p>
+	<p>Recommend IDE setup: <a href="https://code.visualstudio.com/" target="_blank" rel="noreferrer">VSCode</a></p>
 	<p class="link-container">
-		<a href="https://kit.svelte.dev" target="_blank">Visit kit.svelte.dev</a>
+		<a href="https://kit.svelte.dev" target="_blank" rel="noreferrer">Visit kit.svelte.dev</a>
 		|
-		<a href="https://github.com/jhipster/jhipster-lite" target="_blank">Visit jhipster-lite</a>
+		<a href="https://github.com/jhipster/jhipster-lite" target="_blank" rel="noreferrer">Visit jhipster-lite</a>
 	</p>
 	<p>
 		Edit


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/9989211/210180184-5f121009-c9db-421d-be5f-92e2e45e703b.png)
