### PR TITLE
Introduce annotation @ExcludeFromGeneratedCodeCoverage

### DIFF
--- a/src/main/java/tech/jhipster/lite/ApplicationStartupTraces.java
+++ b/src/main/java/tech/jhipster/lite/ApplicationStartupTraces.java
@@ -9,7 +9,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 
 final class ApplicationStartupTraces {
@@ -101,7 +101,7 @@ final class ApplicationStartupTraces {
     return new StringBuilder().append("Profile(s): \t").append(Stream.of(profiles).collect(Collectors.joining(", "))).toString();
   }
 
-  @Generated(reason = "Hard to test implement detail error management")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Hard to test implement detail error management")
   private static String hostAddress() {
     try {
       return InetAddress.getLocalHost().getHostAddress();

--- a/src/main/java/tech/jhipster/lite/JHLiteApp.java
+++ b/src/main/java/tech/jhipster/lite/JHLiteApp.java
@@ -7,9 +7,9 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.data.mongo.MongoDataAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.core.env.Environment;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
-@Generated(reason = "Not testing logs")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing logs")
 @SpringBootApplication(exclude = { MongoAutoConfiguration.class, MongoDataAutoConfiguration.class })
 public class JHLiteApp {
 

--- a/src/main/java/tech/jhipster/lite/common/domain/ExcludeFromGeneratedCodeCoverage.java
+++ b/src/main/java/tech/jhipster/lite/common/domain/ExcludeFromGeneratedCodeCoverage.java
@@ -7,5 +7,6 @@ import java.lang.annotation.Target;
 
 @Retention(RetentionPolicy.RUNTIME)
 @Target({ ElementType.METHOD, ElementType.TYPE, ElementType.CONSTRUCTOR })
-public @interface Generated {
+public @interface ExcludeFromGeneratedCodeCoverage {
+  String reason() default "";
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/landscape/JHipsterLandscape.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/landscape/JHipsterLandscape.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.module.domain.JHipsterFeatureSlug;
 import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
 import tech.jhipster.lite.module.domain.JHipsterSlug;
@@ -60,7 +60,7 @@ public class JHipsterLandscape {
     return level -> new JHipsterLandscapeLevel(level.elements().stream().map(this::toElementWithoutNestedDependencies).toList());
   }
 
-  @Generated(reason = "Jacoco think there is a missing case")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   private JHipsterLandscapeElement toElementWithoutNestedDependencies(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case MODULE -> moduleWithoutNestedDependencies((JHipsterLandscapeModule) element);
@@ -138,7 +138,7 @@ public class JHipsterLandscape {
     return level -> new JHipsterLandscapeLevel(level.elements().stream().sorted(levelComparator).toList());
   }
 
-  @Generated(reason = "Jacoco think there is a missing case")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   private long linksCount(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case FEATURE -> featureLinksCount((JHipsterLandscapeFeature) element);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/primary/NativeHints.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/primary/NativeHints.java
@@ -3,10 +3,10 @@ package tech.jhipster.lite.module.infrastructure.primary;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeElementType;
 
-@Generated(reason = "Not testing native runtime hints")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native runtime hints")
 class NativeHints implements RuntimeHintsRegistrar {
 
   @Override

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/primary/RestJHipsterLandscapeElement.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/primary/RestJHipsterLandscapeElement.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.module.infrastructure.primary;
 
 import io.swagger.v3.oas.annotations.media.Schema;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeElement;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeElementType;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeFeature;
@@ -11,7 +11,7 @@ import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeModule;
 sealed interface RestJHipsterLandscapeElement permits RestJHipsterLandscapeModule, RestJHipsterLandscapeFeature {
   JHipsterLandscapeElementType getType();
 
-  @Generated(reason = "Jacoco think there is a missed case here")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missed case here")
   static RestJHipsterLandscapeElement from(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case MODULE -> RestJHipsterLandscapeModule.fromModule((JHipsterLandscapeModule) element);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModuleFiles.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModuleFiles.java
@@ -12,7 +12,7 @@ import java.util.function.Consumer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.module.domain.JHipsterProjectFilePath;
 import tech.jhipster.lite.module.domain.ProjectFilesReader;
@@ -60,7 +60,7 @@ class FileSystemJHipsterModuleFiles {
     };
   }
 
-  @Generated(reason = "Ensuring posix FS will be a nightmare :)")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Ensuring posix FS will be a nightmare :)")
   private void setExecutable(JHipsterTemplatedFile file, Path filePath) throws IOException {
     if (isNotPosix()) {
       return;
@@ -73,7 +73,7 @@ class FileSystemJHipsterModuleFiles {
     Files.setPosixFilePermissions(filePath, EXECUTABLE_FILE_PERMISSIONS);
   }
 
-  @Generated(reason = "Only tested on POSIX systems")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Only tested on POSIX systems")
   private static boolean isNotPosix() {
     return !FileSystems.getDefault().supportedFileAttributeViews().contains("posix");
   }
@@ -103,7 +103,7 @@ class FileSystemJHipsterModuleFiles {
     };
   }
 
-  @Generated(reason = "Move error case is hard to test and with low value")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Move error case is hard to test and with low value")
   private void move(Path source, Path destination) {
     try {
       Files.move(source, destination);
@@ -128,7 +128,7 @@ class FileSystemJHipsterModuleFiles {
     };
   }
 
-  @Generated(reason = "Deletion error case is hard to test and with low value")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Deletion error case is hard to test and with low value")
   private void delete(Path path) {
     try {
       Files.delete(path);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
@@ -14,7 +14,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import tech.jhipster.lite.common.domain.Enums;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -116,7 +116,7 @@ class FileSystemPackageJsonHandler {
     return npmVersions.get(dependency.packageName().get(), Enums.map(dependency.versionSource(), NpmVersionSource.class)).get();
   }
 
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   private String readContent(Path file) {
     try {
       return Files.readString(file);
@@ -125,7 +125,7 @@ class FileSystemPackageJsonHandler {
     }
   }
 
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   private void write(Path file, String content) {
     try {
       Files.write(file, content.getBytes(StandardCharsets.UTF_8), StandardOpenOption.TRUNCATE_EXISTING);
@@ -203,7 +203,7 @@ class FileSystemPackageJsonHandler {
       return Pattern.compile("(\"" + blocName + "\"\\s*:\\s*\\{)").matcher(result);
     }
 
-    @Generated(reason = "Combiner can't be tested and an implementation detail")
+    @ExcludeFromGeneratedCodeCoverage(reason = "Combiner can't be tested and an implementation detail")
     private String removeExistingEntries() {
       return entries
         .stream()

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemProjectFilesReader.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemProjectFilesReader.java
@@ -5,7 +5,7 @@ import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 import org.apache.commons.io.IOUtils;
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.module.domain.ProjectFilesReader;
@@ -16,7 +16,7 @@ class FileSystemProjectFilesReader implements ProjectFilesReader {
   private static final String SLASH = "/";
 
   @Override
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   public String readString(String path) {
     Assert.notBlank("path", path);
 
@@ -29,7 +29,7 @@ class FileSystemProjectFilesReader implements ProjectFilesReader {
     }
   }
 
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   private static String toString(InputStream input) {
     try {
       return IOUtils.toString(input, StandardCharsets.UTF_8);
@@ -39,7 +39,7 @@ class FileSystemProjectFilesReader implements ProjectFilesReader {
   }
 
   @Override
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   public byte[] readBytes(String path) {
     Assert.notBlank("path", path);
 
@@ -62,7 +62,7 @@ class FileSystemProjectFilesReader implements ProjectFilesReader {
     return FileSystemProjectFilesReader.class.getResourceAsStream(path.replace("\\", SLASH));
   }
 
-  @Generated(reason = "The error handling is an hard to test implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The error handling is an hard to test implementation detail")
   private static byte[] toByteArray(InputStream input) {
     try {
       return IOUtils.toByteArray(input);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringPropertiesCommandsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringPropertiesCommandsHandler.java
@@ -8,7 +8,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.module.domain.javaproperties.SpringProperties;
 import tech.jhipster.lite.module.domain.javaproperties.SpringProperty;
@@ -60,7 +60,7 @@ class FileSystemSpringPropertiesCommandsHandler {
     return folder -> projectFolder.filePath(folder + propertiesFilename(property));
   }
 
-  @Generated(reason = "Jacoco thinks there is a missed branch")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco thinks there is a missed branch")
   private static Supplier<Path> defaultPropertiesFile(JHipsterProjectFolder projectFolder, SpringProperty property) {
     return switch (property.type()) {
       case MAIN_PROPERTIES -> () -> projectFolder.filePath(DEFAULT_MAIN_FOLDER + propertiesFilename(property));

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringPropertiesHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringPropertiesHandler.java
@@ -7,7 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.stream.Collectors;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.module.domain.javaproperties.PropertyKey;
@@ -33,7 +33,7 @@ class PropertiesFileSpringPropertiesHandler {
     updateProperties(key, value);
   }
 
-  @Generated
+  @ExcludeFromGeneratedCodeCoverage
   private void updateProperties(PropertyKey key, PropertyValue value) {
     try {
       String properties = buildProperties(key, value);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/NativeHints.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/NativeHints.java
@@ -7,7 +7,7 @@ import org.eclipse.jgit.util.sha1.SHA1;
 import org.springframework.aot.hint.*;
 import tech.jhipster.lite.common.domain.*;
 
-@Generated(reason = "Not testing native runtime hints")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native runtime hints")
 class NativeHints implements RuntimeHintsRegistrar {
 
   @Override

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/NativeJGitConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/NativeJGitConfiguration.java
@@ -4,6 +4,6 @@ import org.springframework.context.annotation.*;
 import tech.jhipster.lite.common.domain.*;
 
 @ImportRuntimeHints(NativeHints.class)
-@Generated(reason = "Not testing native configuration")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native configuration")
 @Configuration
 class NativeJGitConfiguration {}

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/FileSystemJavaBuildCommandsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/FileSystemJavaBuildCommandsHandler.java
@@ -3,7 +3,7 @@ package tech.jhipster.lite.module.infrastructure.secondary.javadependency;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.module.domain.Indentation;
 import tech.jhipster.lite.module.domain.javabuild.command.AddBuildPluginManagement;
@@ -40,7 +40,7 @@ public class FileSystemJavaBuildCommandsHandler {
     commands.get().forEach(command -> handle(handler, command));
   }
 
-  @Generated(reason = "Jacoco thinks there is a missed branch")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco thinks there is a missed branch")
   private void handle(MavenCommandHandler handler, JavaBuildCommand command) {
     switch (command.type()) {
       case SET_VERSION -> handler.handle((SetVersion) command);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/MavenCommandHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/MavenCommandHandler.java
@@ -26,7 +26,7 @@ import org.joox.Match;
 import org.w3c.dom.Element;
 import org.xml.sax.SAXException;
 import tech.jhipster.lite.common.domain.Enums;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.error.domain.GeneratorException;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -533,7 +533,7 @@ class MavenCommandHandler {
     return format;
   }
 
-  @Generated(reason = "The exception hanlding is hard to test and an implementation detail")
+  @ExcludeFromGeneratedCodeCoverage(reason = "The exception hanlding is hard to test and an implementation detail")
   private void writePom() {
     try (Writer writer = Files.newBufferedWriter(pomPath, StandardCharsets.UTF_8)) {
       writer.write(HEADER);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/NativeHints.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/NativeHints.java
@@ -7,9 +7,9 @@ import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
 import org.springframework.aot.hint.TypeReference;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
-@Generated(reason = "Not testing native runtime hints")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native runtime hints")
 class NativeHints implements RuntimeHintsRegistrar {
 
   @Override

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/NativeJavaDependencyConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/NativeJavaDependencyConfiguration.java
@@ -2,9 +2,9 @@ package tech.jhipster.lite.module.infrastructure.secondary.javadependency;
 
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
 @ImportRuntimeHints(NativeHints.class)
-@Generated(reason = "Not testing native configuration")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native configuration")
 @Configuration
 public class NativeJavaDependencyConfiguration {}

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/FileSystemProjectDownloader.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/FileSystemProjectDownloader.java
@@ -14,7 +14,7 @@ import java.util.regex.Pattern;
 import java.util.stream.Stream;
 import java.util.zip.ZipEntry;
 import java.util.zip.ZipOutputStream;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.project.domain.ProjectPath;
 import tech.jhipster.lite.project.domain.download.Project;
@@ -46,7 +46,7 @@ class FileSystemProjectDownloader {
     return Files.notExists(source) || !Files.isDirectory(source);
   }
 
-  @Generated(reason = "Hard to test exception handling")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Hard to test exception handling")
   private ProjectName readProjectName(Path source) {
     Path packageJsonPath = source.resolve("package.json");
 
@@ -67,7 +67,7 @@ class FileSystemProjectDownloader {
     }
   }
 
-  @Generated(reason = "Hard to test exception handling")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Hard to test exception handling")
   private static Optional<byte[]> zip(Path source) {
     ByteArrayOutputStream result = new ByteArrayOutputStream();
 
@@ -102,7 +102,7 @@ class FileSystemProjectDownloader {
     };
   }
 
-  @Generated(reason = "Hard to test exception handling")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Hard to test exception handling")
   private static void appendToZipEntry(ZipOutputStream zip, Path path, ZipEntry zipEntry) {
     try {
       zip.putNextEntry(zipEntry);

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NativeHints.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NativeHints.java
@@ -3,11 +3,11 @@ package tech.jhipster.lite.project.infrastructure.secondary;
 import org.springframework.aot.hint.MemberCategory;
 import org.springframework.aot.hint.RuntimeHints;
 import org.springframework.aot.hint.RuntimeHintsRegistrar;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.project.domain.history.ProjectAction;
 import tech.jhipster.lite.project.domain.history.ProjectHistory;
 
-@Generated(reason = "Not testing native runtime hints")
+@ExcludeFromGeneratedCodeCoverage(reason = "Not testing native runtime hints")
 class NativeHints implements RuntimeHintsRegistrar {
 
   @Override

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmInstallationReader.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmInstallationReader.java
@@ -5,10 +5,10 @@ import java.util.concurrent.TimeUnit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Service
-@Generated(reason = "Cases can only be tested by using different computers")
+@ExcludeFromGeneratedCodeCoverage(reason = "Cases can only be tested by using different computers")
 class NpmInstallationReader {
 
   private static final Logger log = LoggerFactory.getLogger(NpmInstallationReader.class);

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmProjectFormatter.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmProjectFormatter.java
@@ -10,11 +10,11 @@ import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.Assert;
 import tech.jhipster.lite.project.domain.ProjectPath;
 
-@Generated(reason = "Error cases are hard to test and not worth the efforts")
+@ExcludeFromGeneratedCodeCoverage(reason = "Error cases are hard to test and not worth the efforts")
 record NpmProjectFormatter(String command) implements ProjectFormatter {
   private static final Logger log = LoggerFactory.getLogger(NpmProjectFormatter.class);
 

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
@@ -5,7 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Configuration
 @ImportRuntimeHints(NativeHints.class)
@@ -14,7 +14,7 @@ class ProjectFormatterConfiguration {
   private static final Logger log = LoggerFactory.getLogger(ProjectFormatterConfiguration.class);
 
   @Bean
-  @Generated(reason = "Jacoco think there is a missing case")
+  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   public ProjectFormatter projectFormatter(NpmInstallationReader npmInstallation) {
     return switch (npmInstallation.get()) {
       case UNIX -> unixFormatter();

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormattingException.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormattingException.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.project.infrastructure.secondary;
 
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 import tech.jhipster.lite.error.domain.GeneratorException;
 
-@Generated
+@ExcludeFromGeneratedCodeCoverage
 class ProjectFormattingException extends GeneratorException {
 
   public ProjectFormattingException(String message) {

--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/AppliedModulesChangeUnit.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/AppliedModulesChangeUnit.java
@@ -4,10 +4,10 @@ import io.mongock.api.annotations.ChangeUnit;
 import io.mongock.api.annotations.Execution;
 import io.mongock.api.annotations.RollbackExecution;
 import org.springframework.data.mongodb.core.MongoTemplate;
-import tech.jhipster.lite.common.domain.Generated;
+import tech.jhipster.lite.common.domain.ExcludeFromGeneratedCodeCoverage;
 
 @ChangeUnit(id = "create-applied-modules-collection", order = "002", author = "cdamon")
-@Generated(reason = "Rollback not called in a normal lifecycle and an implementation detail")
+@ExcludeFromGeneratedCodeCoverage(reason = "Rollback not called in a normal lifecycle and an implementation detail")
 public class AppliedModulesChangeUnit {
 
   @Execution


### PR DESCRIPTION
This annotation will also be detected by Jacoco since it contains "Generated". 
Uses this new annotation in replacement of `@Generated` in places where it was explicitly added to skip code coverage check.

Having code annotated with `@Generated(reason = "Hard to test implement detail error management")` is a bit weird and misleading, since the code has not been generated, but written manually. And the reason is not here to explain why the code has (not!) been generated, but why we want to exclude it from code coverage report.