### PR TITLE
bump to sonarqube:9.8.0-community

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,5 +1,8 @@
 sonar.projectKey=jhlite
 sonar.projectName=JHipster Lite
+# used for local sonarqube Docker image
+sonar.login=admin
+sonar.password=admin
 
 sonar.sources=src/main/
 sonar.tests=src/test/

--- a/src/main/docker/sonar.yml
+++ b/src/main/docker/sonar.yml
@@ -2,7 +2,7 @@
 version: '3.8'
 services:
   sonar:
-    image: sonarqube:9.7.1-community
+    image: sonarqube:9.8.0-community
     container_name: sonar
     platform: linux/x86_64
     # Authentication is turned off for out of the box experience while trying out SonarQube

--- a/src/main/resources/generator/client/react/src/main/webapp/app/login/primary/loginForm/index.tsx.mustache
+++ b/src/main/resources/generator/client/react/src/main/webapp/app/login/primary/loginForm/index.tsx.mustache
@@ -1,4 +1,4 @@
-import { createContext, useState } from 'react';
+import { createContext, useState, useMemo, useCallback } from 'react';
 import { Button } from '@nextui-org/react';
 
 import LoginModal from '@/login/primary/loginModal';
@@ -10,14 +10,17 @@ const LoginForm = () => {
   const [username, setUsername] = useState<any>('');
   const [token, setToken] = useState<any>('');
 
-  const userInfoContextValues = {
-    setUsername,
-    setToken,
-  };
+  const userInfoContextValues = useMemo(
+    () => ({
+      setUsername,
+      setToken,
+    }),
+    []
+  );
 
-  const onClickLoginButton = () => setOpen(true);
+  const onClickLoginButton = useCallback(() => setOpen(true), []);
 
-  const onCloseModal = () => setOpen(false);
+  const onCloseModal = useCallback(() => setOpen(false), []);
 
   return (
     <div>

--- a/src/main/resources/generator/client/react/src/main/webapp/app/login/primary/loginModal/index.tsx.mustache
+++ b/src/main/resources/generator/client/react/src/main/webapp/app/login/primary/loginModal/index.tsx.mustache
@@ -1,4 +1,4 @@
-import { useContext, useState } from 'react';
+import { useCallback, useContext, useState } from 'react';
 import { useForm } from 'react-hook-form';
 import { Button, Input, Modal, Spacer, Text } from '@nextui-org/react';
 
@@ -20,10 +20,10 @@ const LoginModal = ({ open, onClose }: LoginModalType) => {
     } else setError(true);
   };
 
-  const handleClose = () => {
+  const handleClose = useCallback(() => {
     setError(false);
     onClose();
-  };
+  }, []);
 
   return (
     <Modal blur open={open} onClose={handleClose} aria-labelledby="modal-login">

--- a/src/main/resources/generator/dependencies/Dockerfile
+++ b/src/main/resources/generator/dependencies/Dockerfile
@@ -1,4 +1,4 @@
-FROM sonarqube:9.7.1-community
+FROM sonarqube:9.8.0-community
 FROM consul:1.14.3
 FROM jhipster/consul-config-loader:v0.4.1
 FROM jhipster/jhipster-registry:v7.4.0

--- a/src/main/resources/generator/server/sonar/sonar-fullstack-project.properties.mustache
+++ b/src/main/resources/generator/server/sonar/sonar-fullstack-project.properties.mustache
@@ -1,5 +1,8 @@
 sonar.projectKey={{baseName}}
 sonar.projectName={{projectName}}
+# used for local sonarqube Docker image
+sonar.login=admin
+sonar.password=admin
 
 sonar.sources=src/main/
 sonar.tests=src/test/

--- a/src/main/resources/generator/server/sonar/sonar-project.properties.mustache
+++ b/src/main/resources/generator/server/sonar/sonar-project.properties.mustache
@@ -1,5 +1,8 @@
 sonar.projectKey={{baseName}}
 sonar.projectName={{projectName}}
+# used for local sonarqube Docker image
+sonar.login=admin
+sonar.password=admin
 
 sonar.sources=src/main/
 sonar.tests=src/test/


### PR DESCRIPTION
- following https://github.com/jhipster/jhipster-lite/pull/4799
- see https://github.com/jhipster/jhipster-lite/pull/4799#issuecomment-1374420847

it seems the following property `sonar.forceAuthentication=false` doesn't work any more

Without these changes, we have:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.875 s
[INFO] Finished at: 2023-01-07T10:08:43+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.sonarsource.scanner.maven:sonar-maven-plugin:3.9.1.2184:sonar (default-cli) on project jhlite: You're not authorized to run analysis. Please contact the project administrator. -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```