### PR TITLE
Feature/issue 5324 cassandra dummy

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/JHLiteModuleSlug.java
+++ b/src/main/java/tech/jhipster/lite/generator/JHLiteModuleSlug.java
@@ -20,6 +20,7 @@ public enum JHLiteModuleSlug implements JHipsterModuleSlugFactory {
   CUSTOM_JHLITE("custom-jhlite"),
   CYPRESS("cypress"),
   DOCKERFILE("dockerfile"),
+  DUMMY_CASSANDRA_PERSISTENCE("dummy-cassandra-persistence"),
   DUMMY_FEATURE("dummy-feature"),
   DUMMY_JPA_PERSISTENCE("dummy-jpa-persistence"),
   DUMMY_LIQUIBASE_CHANGELOG("dummy-liquibase-changelog"),

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/application/DummyCassandraPersistenceApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/application/DummyCassandraPersistenceApplicationService.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.domain.DummyCassandraPersistenceModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@Service
+public class DummyCassandraPersistenceApplicationService {
+
+  private final DummyCassandraPersistenceModuleFactory factory;
+
+  public DummyCassandraPersistenceApplicationService() {
+    factory = new DummyCassandraPersistenceModuleFactory();
+  }
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    return factory.buildModule(properties);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactory.java
@@ -1,0 +1,66 @@
+package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.domain;
+
+import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+
+import java.util.regex.Pattern;
+import tech.jhipster.lite.error.domain.Assert;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.file.JHipsterDestination;
+import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+import tech.jhipster.lite.module.domain.replacement.ElementReplacer;
+import tech.jhipster.lite.module.domain.replacement.RegexReplacer;
+import tech.jhipster.lite.module.domain.replacement.ReplacementCondition;
+
+public class DummyCassandraPersistenceModuleFactory {
+
+  private static final Pattern KEYSPACE_PATTERN = Pattern.compile(".*spring\\.cassandra\\.keyspace-name=.*");
+  private static final ElementReplacer EXISTING_KEYSPACE_NEEDLE = new RegexReplacer(ReplacementCondition.always(), KEYSPACE_PATTERN);
+  private static final JHipsterSource SOURCE = from("server/springboot/mvc/dummy/cassandrapersistence");
+  private static final String SECONDARY = "infrastructure/secondary";
+  private static final String SECONDARY_DESTINATION = "dummy/" + SECONDARY;
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    Assert.notNull("properties", properties);
+
+    String packagePath = properties.packagePath();
+    String baseName = properties.projectBaseName().get();
+
+    //@formatter:off
+    return moduleBuilder(properties)
+      .files()
+        .batch(SOURCE.append("main").append(SECONDARY), toSrcMainJava().append(packagePath).append(SECONDARY_DESTINATION))
+          .addTemplate("BeerCatalogTable.java")
+          .addTemplate("BeerTable.java")
+          .addTemplate("CassandraBeerCatalogRepository.java")
+          .addTemplate("CassandraBeerRepository.java")
+          .addTemplate("SpringDataBeersRepository.java")
+          .and()
+        .batch(SOURCE.append("test").append(SECONDARY), toSrcTestJava().append(packagePath).append(SECONDARY_DESTINATION))
+          .addTemplate("BeerCatalogTableTest.java")
+          .addTemplate("BeerTableTest.java")
+          .addTemplate("CassandraBeerCatalogRepositoryIntTest.java")
+          .addTemplate("CassandraBeerRepositoryIntTest.java")
+          .addTemplate("CassandraBeersResetter.java")
+          .addTemplate("SpringDataRepositoryIntTest.java")
+          .and()
+        .batch(SOURCE.append("cql"), toSrcMainResourcesCql().append("changelog"))
+          .addTemplate("00000000000000_create-keyspace.cql")
+          .addTemplate("00000000000001_create-tables.cql")
+          .and()
+        .delete(path("src/main/java").append(packagePath).append(SECONDARY_DESTINATION).append("InMemoryBeersRepository.java"))
+        .delete(path("src/test/java").append(packagePath).append(SECONDARY_DESTINATION).append("InMemoryBeersReseter.java"))
+        .and()
+      .mandatoryReplacements()
+        .in(path("src/main/resources/config/application.properties"))
+          .add(EXISTING_KEYSPACE_NEEDLE, "spring.cassandra.keyspace-name=" + baseName)
+          .and()
+        .and()
+      .build();
+    //@formatter:on
+  }
+
+  private JHipsterDestination toSrcMainResourcesCql() {
+    return toSrcMainResources().append("config").append("cql");
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactory.java
@@ -24,7 +24,7 @@ public class DummyCassandraPersistenceModuleFactory {
     Assert.notNull("properties", properties);
 
     String packagePath = properties.packagePath();
-    String baseName = properties.projectBaseName().get();
+    String pakageName = properties.projectBaseName().get();
 
     //@formatter:off
     return moduleBuilder(properties)
@@ -53,7 +53,7 @@ public class DummyCassandraPersistenceModuleFactory {
         .and()
       .mandatoryReplacements()
         .in(path("src/main/resources/config/application.properties"))
-          .add(EXISTING_KEYSPACE_NEEDLE, "spring.cassandra.keyspace-name=" + baseName)
+          .add(EXISTING_KEYSPACE_NEEDLE, "spring.cassandra.keyspace-name=" + pakageName)
           .and()
         .and()
       .build();

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/infrastructure/primary/DummyCassandraPersistenceModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/infrastructure/primary/DummyCassandraPersistenceModuleConfiguration.java
@@ -1,0 +1,36 @@
+package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.infrastructure.primary;
+
+import static tech.jhipster.lite.generator.JHLiteFeatureSlug.DUMMY_PERSISTENCE;
+import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.application.DummyCassandraPersistenceApplicationService;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
+import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
+
+@Configuration
+class DummyCassandraPersistenceModuleConfiguration {
+
+  @Bean
+  JHipsterModuleResource dummyCassandraPersistenceModule(
+    DummyCassandraPersistenceApplicationService dummyCassandraPersistenceApplicationService
+  ) {
+    return JHipsterModuleResource
+      .builder()
+      .slug(DUMMY_CASSANDRA_PERSISTENCE)
+      .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addBasePackage().build())
+      .apiDoc("Spring Boot - MVC", "Add Cassandra persistence for dummy feature")
+      .organization(
+        JHipsterModuleOrganization
+          .builder()
+          .feature(DUMMY_PERSISTENCE)
+          .addDependency(DUMMY_FEATURE)
+          .addDependency(CASSANDRA_MIGRATION)
+          .build()
+      )
+      .tags("server")
+      .factory(dummyCassandraPersistenceApplicationService::buildModule);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence;

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/cql/00000000000000_create-keyspace.cql.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/cql/00000000000000_create-keyspace.cql.mustache
@@ -1,0 +1,3 @@
+CREATE KEYSPACE IF NOT EXISTS {{ baseName }}
+  WITH REPLICATION = { 'class' : 'SimpleStrategy', 'replication_factor' : 1 }
+   AND DURABLE_WRITES = true;

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/cql/00000000000001_create-tables.cql.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/cql/00000000000001_create-tables.cql.mustache
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS {{ baseName }}.beer (
+    id uuid,
+    name text,
+    unit_price decimal,
+    selling_state text,
+    PRIMARY KEY(id)
+);
+
+CREATE TABLE IF NOT EXISTS {{ baseName }}.beer_catalog (
+    id uuid,
+    name text,
+    unit_price decimal,
+    PRIMARY KEY(id)
+);

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerCatalogTable.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerCatalogTable.java.mustache
@@ -1,0 +1,82 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.common.domain.Generated;
+import {{ packageName }}.dummy.domain.BeerId;
+import {{ packageName }}.dummy.domain.beer.Beer;
+import {{ packageName }}.dummy.domain.beer.BeerSellingState;
+import {{ packageName }}.error.domain.Assert;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Table("beer_catalog")
+class BeerCatalogTable {
+
+  @PrimaryKey("id")
+  private UUID id;
+
+  @Column("name")
+  private String name;
+
+  @Column("unit_price")
+  private BigDecimal unitPrice;
+
+  public static BeerCatalogTable from(Beer beer) {
+    Assert.notNull("beer", beer);
+
+    return new BeerCatalogTable()
+      .id(beer.id().get())
+      .name(beer.name().get())
+      .unitPrice(beer.unitPrice().get());
+  }
+
+  private BeerCatalogTable id(UUID id) {
+    this.id = id;
+
+    return this;
+  }
+
+  private BeerCatalogTable name(String name) {
+    this.name = name;
+
+    return this;
+  }
+
+  private BeerCatalogTable unitPrice(BigDecimal unitPrice) {
+    this.unitPrice = unitPrice;
+
+    return this;
+  }
+
+
+  public Beer toDomain() {
+    return Beer.builder().id(new BeerId(id)).name(name).unitPrice(unitPrice).sellingState(BeerSellingState.SOLD).build();
+  }
+
+  @Override
+  @Generated
+  public int hashCode() {
+    return new HashCodeBuilder().append(id).hashCode();
+  }
+
+  @Override
+  @Generated
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    BeerCatalogTable other = (BeerCatalogTable) obj;
+
+    return new EqualsBuilder().append(id, other.id).isEquals();
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerTable.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerTable.java.mustache
@@ -1,0 +1,91 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.common.domain.Generated;
+import {{ packageName }}.dummy.domain.BeerId;
+import {{ packageName }}.dummy.domain.beer.Beer;
+import {{ packageName }}.dummy.domain.beer.BeerSellingState;
+import {{ packageName }}.error.domain.Assert;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.springframework.data.cassandra.core.mapping.Column;
+import org.springframework.data.cassandra.core.mapping.PrimaryKey;
+import org.springframework.data.cassandra.core.mapping.Table;
+
+import java.math.BigDecimal;
+import java.util.UUID;
+
+@Table("beer")
+class BeerTable {
+
+  @PrimaryKey("id")
+  private UUID id;
+
+  @Column("name")
+  private String name;
+
+  @Column("unit_price")
+  private BigDecimal unitPrice;
+
+  @Column("selling_state")
+  private BeerSellingState sellingState;
+
+  public static BeerTable from(Beer beer) {
+    Assert.notNull("beer", beer);
+
+    return new BeerTable()
+      .id(beer.id().get())
+      .name(beer.name().get())
+      .unitPrice(beer.unitPrice().get())
+      .sellingState(beer.sellingState());
+  }
+
+  private BeerTable id(UUID id) {
+    this.id = id;
+
+    return this;
+  }
+
+  private BeerTable name(String name) {
+    this.name = name;
+
+    return this;
+  }
+
+  private BeerTable unitPrice(BigDecimal unitPrice) {
+    this.unitPrice = unitPrice;
+
+    return this;
+  }
+
+  private BeerTable sellingState(BeerSellingState sellingState) {
+    this.sellingState = sellingState;
+
+    return this;
+  }
+
+  public Beer toDomain() {
+    return Beer.builder().id(new BeerId(id)).name(name).unitPrice(unitPrice).sellingState(sellingState).build();
+  }
+
+  @Override
+  @Generated
+  public int hashCode() {
+    return new HashCodeBuilder().append(id).hashCode();
+  }
+
+  @Override
+  @Generated
+  public boolean equals(Object obj) {
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null || getClass() != obj.getClass()) {
+      return false;
+    }
+
+    BeerTable other = (BeerTable) obj;
+
+    return new EqualsBuilder().append(id, other.id).isEquals();
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerTable.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/BeerTable.java.mustache
@@ -75,16 +75,16 @@ class BeerTable {
 
   @Override
   @Generated
-  public boolean equals(Object obj) {
-    if (this == obj) {
+  public boolean equals(Object o) {
+    if (this == o) {
       return true;
     }
 
-    if (obj == null || getClass() != obj.getClass()) {
+    if (o == null || getClass() != o.getClass()) {
       return false;
     }
 
-    BeerTable other = (BeerTable) obj;
+    BeerTable other = (BeerTable) o;
 
     return new EqualsBuilder().append(id, other.id).isEquals();
   }

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerCatalogRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerCatalogRepository.java.mustache
@@ -1,0 +1,10 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+interface CassandraBeerCatalogRepository extends CassandraRepository<BeerCatalogTable, UUID> {
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerCatalogRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerCatalogRepository.java.mustache
@@ -1,10 +1,14 @@
 package {{ packageName }}.dummy.infrastructure.secondary;
 
-import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
 import java.util.UUID;
 
 @Repository
-interface CassandraBeerCatalogRepository extends CassandraRepository<BeerCatalogTable, UUID> {
+interface CassandraBeerCatalogRepository extends CrudRepository<BeerCatalogTable, UUID> {
+
+  @Override
+  List<BeerCatalogTable> findAll();
 }

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerRepository.java.mustache
@@ -1,0 +1,10 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.UUID;
+
+@Repository
+interface CassandraBeerRepository extends CassandraRepository<BeerTable, UUID> {
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/CassandraBeerRepository.java.mustache
@@ -1,10 +1,10 @@
 package {{ packageName }}.dummy.infrastructure.secondary;
 
-import org.springframework.data.cassandra.repository.CassandraRepository;
+import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
 
 import java.util.UUID;
 
 @Repository
-interface CassandraBeerRepository extends CassandraRepository<BeerTable, UUID> {
+interface CassandraBeerRepository extends CrudRepository<BeerTable, UUID> {
 }

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/SpringDataBeersRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/SpringDataBeersRepository.java.mustache
@@ -1,0 +1,52 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.dummy.domain.BeerId;
+import {{ packageName }}.dummy.domain.beer.Beer;
+import {{ packageName }}.dummy.domain.beer.Beers;
+import {{ packageName }}.dummy.domain.beer.BeersRepository;
+import {{ packageName }}.error.domain.Assert;
+import org.springframework.data.cassandra.core.CassandraBatchOperations;
+import org.springframework.data.cassandra.core.CassandraOperations;
+import org.springframework.stereotype.Repository;
+
+import java.util.Optional;
+
+@Repository
+class SpringDataBeersRepository implements BeersRepository {
+
+  private final CassandraOperations cassandraTemplate;
+  private final CassandraBeerRepository beers;
+  private final CassandraBeerCatalogRepository beersCatalog;
+
+  public SpringDataBeersRepository(CassandraOperations cassandraTemplate, CassandraBeerRepository beers, CassandraBeerCatalogRepository beersCatalog) {
+    this.cassandraTemplate = cassandraTemplate;
+    this.beers = beers;
+    this.beersCatalog = beersCatalog;
+  }
+
+  @Override
+  public void save(Beer beer) {
+    Assert.notNull("beer", beer);
+    CassandraBatchOperations batchOps = cassandraTemplate.batchOps();
+
+    batchOps.insert(BeerTable.from(beer));
+    switch (beer.sellingState()){
+      case NOT_SOLD -> batchOps.delete(BeerCatalogTable.from(beer));
+      case SOLD -> batchOps.insert(BeerCatalogTable.from(beer));
+    }
+
+    batchOps.execute();
+  }
+
+  @Override
+  public Beers catalog() {
+    return new Beers(beersCatalog.findAll().stream().map(BeerCatalogTable::toDomain).toList());
+  }
+
+  @Override
+  public Optional<Beer> get(BeerId beer) {
+    Assert.notNull("beer", beer);
+
+    return beers.findById(beer.get()).map(BeerTable::toDomain);
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/SpringDataBeersRepository.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/main/infrastructure/secondary/SpringDataBeersRepository.java.mustache
@@ -11,6 +11,8 @@ import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
 
+import static {{ packageName }}.dummy.domain.beer.BeerSellingState.NOT_SOLD;
+
 @Repository
 class SpringDataBeersRepository implements BeersRepository {
 
@@ -30,9 +32,11 @@ class SpringDataBeersRepository implements BeersRepository {
     CassandraBatchOperations batchOps = cassandraTemplate.batchOps();
 
     batchOps.insert(BeerTable.from(beer));
-    switch (beer.sellingState()){
-      case NOT_SOLD -> batchOps.delete(BeerCatalogTable.from(beer));
-      case SOLD -> batchOps.insert(BeerCatalogTable.from(beer));
+
+    if (beer.sellingState() == NOT_SOLD) {
+      batchOps.delete(BeerCatalogTable.from(beer));
+    } else {
+      batchOps.insert(BeerCatalogTable.from(beer));
     }
 
     batchOps.execute();

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/BeerCatalogTableTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/BeerCatalogTableTest.java.mustache
@@ -1,0 +1,16 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@UnitTest
+class BeerCatalogTableTest {
+
+  @Test
+  void shouldConvertFromAndToDomain() {
+    assertThat(BeerCatalogTable.from(beer()).toDomain()).usingRecursiveComparison().isEqualTo(beer());
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/BeerTableTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/BeerTableTest.java.mustache
@@ -1,0 +1,16 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.UnitTest;
+import org.junit.jupiter.api.Test;
+
+import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@UnitTest
+class BeerTableTest {
+
+  @Test
+  void shouldConvertFromAndToDomain() {
+    assertThat(BeerTable.from(beer()).toDomain()).usingRecursiveComparison().isEqualTo(beer());
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeerCatalogRepositoryIntTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeerCatalogRepositoryIntTest.java.mustache
@@ -1,0 +1,23 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static {{ packageName }}.dummy.domain.BeersIdentityFixture.cloackOfFeathersId;
+import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class CassandraBeerCatalogRepositoryIntTest {
+
+  @Autowired
+  private CassandraBeerCatalogRepository beerCatalog;
+
+  @Test
+  void shouldSaveAndGetBeer() {
+    beerCatalog.save(BeerCatalogTable.from(beer()));
+
+    assertThat(beerCatalog.findById(cloackOfFeathersId().get()).get().toDomain()).usingRecursiveComparison().isEqualTo(beer());
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeerRepositoryIntTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeerRepositoryIntTest.java.mustache
@@ -1,0 +1,23 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.IntegrationTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static {{ packageName }}.dummy.domain.BeersIdentityFixture.cloackOfFeathersId;
+import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class CassandraBeerRepositoryIntTest {
+
+  @Autowired
+  private CassandraBeerRepository beers;
+
+  @Test
+  void shouldSaveAndGetBeer() {
+    beers.save(BeerTable.from(beer()));
+
+    assertThat(beers.findById(cloackOfFeathersId().get()).get().toDomain()).usingRecursiveComparison().isEqualTo(beer());
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeersResetter.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/CassandraBeersResetter.java.mustache
@@ -1,0 +1,19 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import io.cucumber.java.Before;
+import org.springframework.beans.factory.annotation.Autowired;
+
+public class CassandraBeersResetter {
+
+  @Autowired
+  private CassandraBeerRepository beers;
+
+  @Autowired
+  private CassandraBeerCatalogRepository beerCatalog;
+
+  @Before
+  public void resetBeers() {
+    beers.deleteAll();
+    beerCatalog.deleteAll();
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/SpringDataRepositoryIntTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/SpringDataRepositoryIntTest.java.mustache
@@ -1,0 +1,37 @@
+package {{ packageName }}.dummy.infrastructure.secondary;
+
+import {{ packageName }}.IntegrationTest;
+import com.datastax.oss.driver.api.core.CqlSession;
+import com.datastax.oss.driver.api.core.cql.BoundStatement;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import static {{ packageName }}.dummy.domain.BeersIdentityFixture.cloackOfFeathersId;
+import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
+import static org.assertj.core.api.Assertions.assertThat;
+
+@IntegrationTest
+class SpringDataRepositoryIntTest {
+
+  @Autowired
+  private SpringDataBeersRepository repository;
+
+  @Autowired
+  private CqlSession cqlSession;
+
+  private static final String FIND_BEER = "select writetime(name) from beer where id=:id";
+  private static final String FIND_CATALOG = "select writetime(name) from beer_catalog where id=:id";
+
+  @Test
+  void shouldSaveInBatch() {
+    repository.save(beer());
+
+    BoundStatement findBeerStmt = cqlSession.prepare(FIND_BEER).bind().setUuid("id", cloackOfFeathersId().get());
+    BoundStatement findCatalogStmt = cqlSession.prepare(FIND_CATALOG).bind().setUuid("id", cloackOfFeathersId().get());
+
+    long beerInsertionTime = cqlSession.execute(findBeerStmt).one().getLong("writetime(name)");
+    long catalogInsertionTime = cqlSession.execute(findCatalogStmt).one().getLong("writetime(name)");
+
+    assertThat(beerInsertionTime).isEqualTo(catalogInsertionTime);
+  }
+}

--- a/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/SpringDataRepositoryIntTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/cassandrapersistence/test/infrastructure/secondary/SpringDataRepositoryIntTest.java.mustache
@@ -2,9 +2,10 @@ package {{ packageName }}.dummy.infrastructure.secondary;
 
 import {{ packageName }}.IntegrationTest;
 import com.datastax.oss.driver.api.core.CqlSession;
-import com.datastax.oss.driver.api.core.cql.BoundStatement;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.cassandra.core.cql.CqlTemplate;
+import org.springframework.data.cassandra.core.cql.session.DefaultSessionFactory;
 
 import static {{ packageName }}.dummy.domain.BeersIdentityFixture.cloackOfFeathersId;
 import static {{ packageName }}.dummy.domain.beer.BeersFixture.beer;
@@ -19,18 +20,18 @@ class SpringDataRepositoryIntTest {
   @Autowired
   private CqlSession cqlSession;
 
-  private static final String FIND_BEER = "select writetime(name) from beer where id=:id";
-  private static final String FIND_CATALOG = "select writetime(name) from beer_catalog where id=:id";
+  private static final String FIND_BEER = "select writetime(name) from beer where id = ?";
+  private static final String FIND_CATALOG = "select writetime(name) from beer_catalog where id = ?";
 
   @Test
   void shouldSaveInBatch() {
     repository.save(beer());
 
-    BoundStatement findBeerStmt = cqlSession.prepare(FIND_BEER).bind().setUuid("id", cloackOfFeathersId().get());
-    BoundStatement findCatalogStmt = cqlSession.prepare(FIND_CATALOG).bind().setUuid("id", cloackOfFeathersId().get());
+    CqlTemplate cqlTemplate = new CqlTemplate();
+    cqlTemplate.setSessionFactory(new DefaultSessionFactory(cqlSession));
 
-    long beerInsertionTime = cqlSession.execute(findBeerStmt).one().getLong("writetime(name)");
-    long catalogInsertionTime = cqlSession.execute(findCatalogStmt).one().getLong("writetime(name)");
+    long beerInsertionTime = cqlTemplate.queryForObject(FIND_BEER, Long.class, cloackOfFeathersId().get());
+    long catalogInsertionTime = cqlTemplate.queryForObject(FIND_CATALOG, Long.class, cloackOfFeathersId().get());
 
     assertThat(beerInsertionTime).isEqualTo(catalogInsertionTime);
   }

--- a/src/test/features/dummy.feature
+++ b/src/test/features/dummy.feature
@@ -13,7 +13,7 @@ Feature: Dummy feature module
       | dummy-jpa-persistence |
     Then I should have files in "src/main/java/tech/jhipster/chips/dummy/infrastructure/secondary"
       | BeerEntity.java |
-      
+
   Scenario: Should Apply dummy mongodb module
     When I apply modules to default project
       | maven-java                |
@@ -21,14 +21,23 @@ Feature: Dummy feature module
       | dummy-mongodb-persistence |
     Then I should have files in "src/main/java/tech/jhipster/chips/dummy/infrastructure/secondary"
       | BeerDocument.java |
-      
+
+  Scenario: Should Apply dummy cassandra module
+    When I apply modules to default project
+      | maven-java                  |
+      | cassandra                   |
+      | dummy-feature               |
+      | dummy-cassandra-persistence |
+    Then I should have files in "src/main/java/tech/jhipster/chips/dummy/infrastructure/secondary"
+      | BeerTable.java |
+
   Scenario: Should Apply dummy liquibase module
     When I apply modules to default project
       | maven-java                |
       | liquibase                 |
       | dummy-liquibase-changelog |
     Then  I should have 2 files in "src/main/resources/config/liquibase/changelog"
-    
+
   Scenario: Should Apply dummy postgresql flyway module
     When I apply "dummy-postgresql-flyway-changelog" module to default project without parameters
     Then I should have 1 file in "src/main/resources/db/migration"

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactoryTest.java
@@ -5,7 +5,6 @@ import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModules
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
-import tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.domain.DummyCassandraPersistenceModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/domain/DummyCassandraPersistenceModuleFactoryTest.java
@@ -1,0 +1,74 @@
+package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.domain;
+
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+
+import org.junit.jupiter.api.Test;
+import tech.jhipster.lite.TestFileUtils;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.domain.DummyCassandraPersistenceModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@UnitTest
+class DummyCassandraPersistenceModuleFactoryTest {
+
+  private static final String BASE_NAME = "jhipster";
+  private static final DummyCassandraPersistenceModuleFactory factory = new DummyCassandraPersistenceModuleFactory();
+
+  @Test
+  void shouldBuildModule() {
+    JHipsterModuleProperties properties = JHipsterModulesFixture
+      .propertiesBuilder(TestFileUtils.tmpDirForTest())
+      .basePackage("com.jhipster.test")
+      .projectBaseName(BASE_NAME)
+      .build();
+
+    JHipsterModule module = factory.buildModule(properties);
+
+    assertThatModuleWithFiles(module, dummyInMemoryRepository(), inMemoryBeersReseter(), customPropertiesFile())
+      .hasPrefixedFiles(
+        "src/main/java/com/jhipster/test/dummy/infrastructure/secondary",
+        "BeerCatalogTable.java",
+        "BeerTable.java",
+        "CassandraBeerCatalogRepository.java",
+        "CassandraBeerRepository.java",
+        "SpringDataBeersRepository.java"
+      )
+      .hasPrefixedFiles(
+        "src/test/java/com/jhipster/test/dummy/infrastructure/secondary",
+        "BeerCatalogTableTest.java",
+        "BeerTableTest.java",
+        "CassandraBeerCatalogRepositoryIntTest.java",
+        "CassandraBeerRepositoryIntTest.java",
+        "CassandraBeersResetter.java",
+        "SpringDataRepositoryIntTest.java"
+      )
+      .hasPrefixedFiles("src/main/resources/config/cql/changelog", "00000000000000_create-keyspace.cql", "00000000000001_create-tables.cql")
+      .hasFile("src/main/resources/config/application.properties")
+      .containing("spring.cassandra.keyspace-name=" + BASE_NAME)
+      .and()
+      .doNotHaveFiles(
+        "src/main/java/com/jhipster/test/dummy/infrastructure/secondary/InMemoryBeersRepository.java",
+        "src/test/java/com/jhipster/test/dummy/infrastructure/secondary/InMemoryBeersReseter.java"
+      );
+  }
+
+  private ModuleFile customPropertiesFile() {
+    return file("src/test/resources/projects/cassandra/application.properties", "src/main/resources/config/application.properties");
+  }
+
+  private ModuleFile dummyInMemoryRepository() {
+    return file(
+      "src/test/resources/projects/dummy-feature/InMemoryBeersRepository.java",
+      "src/main/java/com/jhipster/test/dummy/infrastructure/secondary/InMemoryBeersRepository.java"
+    );
+  }
+
+  private ModuleFile inMemoryBeersReseter() {
+    return file(
+      "src/test/resources/projects/dummy-feature/InMemoryBeersReseter.java",
+      "src/test/java/com/jhipster/test/dummy/infrastructure/secondary/InMemoryBeersReseter.java"
+    );
+  }
+}

--- a/src/test/resources/projects/cassandra/application.properties
+++ b/src/test/resources/projects/cassandra/application.properties
@@ -1,0 +1,16 @@
+#====================================================================
+# Standard Spring Boot properties.
+# Full reference is available at:
+# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+#====================================================================
+
+spring.application.name=myapp
+logging.level.tech.jhipster.lite=INFO
+
+spring.cassandra.schema-action=none
+spring.cassandra.local-datacenter=datacenter1
+spring.cassandra.contact-points=127.0.0.1
+#spring.cassandra.keyspace-name=yourKeyspace
+spring.cassandra.port=9042
+
+# jhipster-needle-application-properties

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -274,7 +274,7 @@ elif [[ $application == 'cassandraapp' ]]; then
   spring_boot_mvc
   sonar_back
 
-  applyModules "cassandra" "cassandra-migration"
+  applyModules "cassandra" "cassandra-migration" "dummy-cassandra-persistence"
 
 elif [[ $application == 'neo4japp' ]]; then
   spring_boot_mvc

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -274,7 +274,11 @@ elif [[ $application == 'cassandraapp' ]]; then
   spring_boot_mvc
   sonar_back
 
-  applyModules "cassandra" "cassandra-migration" "dummy-cassandra-persistence"
+  applyModules "cassandra" "cassandra-migration"
+
+  cucumber_with_jwt
+
+  applyModules "dummy-feature" "dummy-cassandra-persistence"
 
 elif [[ $application == 'neo4japp' ]]; then
   spring_boot_mvc


### PR DESCRIPTION
Fixes #5324


Notes:
- When launching tests in generated project, these WARN are displayed : `You have too many session instances: 6 active, expected less than 4 (see 'advanced.session-leak.threshold' in the configuration)`. This is "normal", Spring creates and caches an ApplicationContext everytime a new one is needed. In this project, 6 different ApplicationsContexts are created and cached, and their cassandra sessions remain active; throwing this message when more than 4 are detected.
