### PR TITLE
Svelte: Fix warning (<App> was created with unknown prop 'location')

### DIFF
--- a/src/main/resources/generator/client/svelte/src/main/webapp/routes/+page.svelte.mustache
+++ b/src/main/resources/generator/client/svelte/src/main/webapp/routes/+page.svelte.mustache
@@ -7,6 +7,6 @@
 
 <Router {url}>
   <div>
-    <Route primary={false} path="/" component={App} />
+    <Route primary={false} path="/"><App /></Route>
   </div>
 </Router>


### PR DESCRIPTION
Fix:
![image](https://user-images.githubusercontent.com/9989211/226197092-b0249899-3ff6-4d61-994c-2cd4cdb26bab.png)

Solution:
https://github.com/mefechoel/svelte-navigator
![image](https://user-images.githubusercontent.com/9989211/226197124-7cc0a277-c941-42cb-9cfa-f526e4b69e6f.png)
