### PR TITLE
put not emphasized landscape elements in background

### DIFF
--- a/src/main/style/atom/chip/_chip.scss
+++ b/src/main/style/atom/chip/_chip.scss
@@ -56,3 +56,23 @@
     margin-bottom: 15px;
   }
 }
+
+.has-emphasized-module {
+  .jhlite-chip {
+    &--title,
+    &--description {
+      opacity: 0.5;
+    }
+  }
+
+  .-selectable-highlighted,
+  .-not-selectable-highlighted,
+  .-selected {
+    .jhlite-chip {
+      &--title,
+      &--description {
+        opacity: 1;
+      }
+    }
+  }
+}

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -149,6 +149,11 @@ export default defineComponent({
       return element instanceof LandscapeFeature;
     };
 
+    const landscapeClass = (): string => {
+      const hasEmphasizedModule = emphasizedModule.value !== undefined;
+      return `jhipster-landscape-map jhlite-menu-content-template--content${hasEmphasizedModule ? ' has-emphasized-module' : ''}`;
+    };
+
     const modeSwitchClass = (mode: DisplayMode): string => {
       if (selectedMode.value === mode) {
         return '-selected';
@@ -422,6 +427,7 @@ export default defineComponent({
       landscapeSize,
       landscapeElements,
       landscapeContainer,
+      landscapeClass,
       modeSwitchClass,
       selectMode,
       modeClass,

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -24,7 +24,7 @@
   </div>
 
   <div
-    class="jhipster-landscape-map jhlite-menu-content-template--content"
+    :class="landscapeClass()"
     ref="landscapeContainer"
     data-selector="landscape-container"
     @mousedown="startGrabbing"

--- a/src/test/javascript/spec/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/javascript/spec/module/primary/landscape/LandscapeComponent.spec.ts
@@ -262,6 +262,18 @@ describe('Landscape', () => {
       expect(wrapper.find(wrappedElement('spring-boot-module')).classes()).toContain('-highlighted-unselection');
       assertUnSelectionHighlightedConnectorsCount(wrapper, 2);
     });
+
+    it('Should put not emphasized in background', async () => {
+      const wrapper = await componentWithLandscape();
+
+      wrapper.find(wrappedElement('infinitest-module')).trigger('mouseover');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(wrappedElement('landscape-container')).classes()).toContain('has-emphasized-module');
+
+      wrapper.find(wrappedElement('infinitest-module')).trigger('mouseleave');
+      await wrapper.vm.$nextTick();
+      expect(wrapper.find(wrappedElement('landscape-container')).classes()).not.toContain('has-emphasized-module');
+    });
   });
 
   describe('Selectable module', () => {


### PR DESCRIPTION
Fix #3968


**Compacted view mode**

When no emphasized element => Other elements in foreground with full visibility
![image](https://user-images.githubusercontent.com/5896391/229544454-9454974a-cbe9-47f9-9740-a4107c8b9d41.png)

When mouseover an spring-boot-actuator element to emphasize it => Other elements put to background with reduced opacity
![image](https://user-images.githubusercontent.com/5896391/229544622-2daf0fa7-81f8-45f9-8715-328e5983fdd7.png)

**Extended view mode**
When no emphasized element => Other elements in foreground with full visibility
![image](https://user-images.githubusercontent.com/5896391/229545228-ba72857f-a430-4e68-aa50-4ee2e35adb42.png)

When mouseover an spring-boot-actuator element to emphasize it => Other elements put to background with reduced opacity
![image](https://user-images.githubusercontent.com/5896391/229545286-38f24f90-c442-4958-a0c5-aae5301d4cba.png)
