### PR TITLE
fix(angular): angular's common package dependencies about jest not ma…

### DIFF
--- a/src/main/resources/generator/dependencies/common/package.json
+++ b/src/main/resources/generator/dependencies/common/package.json
@@ -18,14 +18,14 @@
     "eslint-plugin-prettier": "4.2.1",
     "husky": "8.0.3",
     "jasmine-core": "4.6.0",
-    "jest": "28.1.3",
+    "jest": "29.5.0",
     "lint-staged": "13.2.1",
     "node": "18.15.0",
     "npm": "9.6.4",
     "prettier": "2.8.7",
     "prettier-plugin-java": "2.1.0",
     "prettier-plugin-packagejson": "2.4.3",
-    "ts-jest": "28.0.8",
+    "ts-jest": "29.1.0",
     "typescript": "5.0.4"
   }
 }


### PR DESCRIPTION
…tching

upgdae common jest version same with jhipster-lite

to resolve the issue when npm install

npm ERR! code ERESOLVE
npm ERR! ERESOLVE unable to resolve dependency tree
npm ERR!
npm ERR! While resolving: xx@0.0.0
npm ERR! Found: jest@29.5.0
npm ERR! node_modules/jest
npm ERR!   dev jest@"29.5.0" from the root project
npm ERR!
npm ERR! Could not resolve dependency:
npm ERR! peer jest@"^28.0.0" from ts-jest@28.0.8
npm ERR! node_modules/ts-jest
npm ERR!   dev ts-jest@"28.0.8" from the root project
npm ERR!
npm ERR! Fix the upstream dependency conflict, or retry
npm ERR! this command with --force or --legacy-peer-deps
npm ERR! to accept an incorrect (and potentially broken) dependency resolution.
npm ERR!
