### PR TITLE
Logback enhancements

### DIFF
--- a/src/main/resources/generator/server/springboot/core/main/logback-spring.xml.mustache
+++ b/src/main/resources/generator/server/springboot/core/main/logback-spring.xml.mustache
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration>
 <configuration scan="true">
-  <include resource="org/springframework/boot/logging/logback/base.xml" />
+  <springProperty name="log.level" source="logging.level.root" defaultValue="INFO" />
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
   <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 
   <!-- The FILE and ASYNC appenders are here as examples for a production configuration -->
@@ -21,10 +22,6 @@
     <queueSize>512</queueSize>
     <appender-ref ref="FILE"/>
   </appender>
-
-  <root level="${logging.level.root}">
-    <appender-ref ref="ASYNC"/>
-  </root>
   -->
 
   <logger name="{{packageName}}" level="INFO" />
@@ -34,8 +31,15 @@
   <logger name="org.springframework" level="WARN" />
   <!-- jhipster-needle-logback-add-log -->
 
-  <!-- https://logback.qos.ch/manual/configuration.html#shutdownHook and https://jira.qos.ch/browse/LOGBACK-1090 -->
-  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook" />
+  <root level="${log.level}">
+    <appender-ref ref="CONSOLE" />
+
+    <!-- The FILE and ASYNC appenders are here as examples for a production configuration -->
+    <!--
+    <appender-ref ref="FILE" />
+    <appender-ref ref="ASYNC"/>
+    -->
+  </root>
 
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>

--- a/src/main/resources/generator/server/springboot/core/test/logback.xml.mustache
+++ b/src/main/resources/generator/server/springboot/core/test/logback.xml.mustache
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration>
 <configuration scan="true">
-  <include resource="org/springframework/boot/logging/logback/base.xml" />
+  <springProperty name="log.level" source="logging.level.root" defaultValue="INFO" />
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
+  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
 
   <logger name="{{packageName}}" level="OFF" />
 
@@ -9,4 +11,8 @@
   <logger name="com.sun" level="WARN" />
   <logger name="org.springframework" level="WARN" />
   <!-- jhipster-needle-logback-add-log -->
+
+  <root level="${log.level}">
+    <appender-ref ref="CONSOLE" />
+  </root>
 </configuration>

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,31 +1,9 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration>
 <configuration scan="true">
-  <include resource="org/springframework/boot/logging/logback/base.xml" />
+  <springProperty name="log.level" source="logging.level.root" defaultValue="INFO" />
+  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
   <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
-
-  <!-- The FILE and ASYNC appenders are here as examples for a production configuration -->
-  <!--
-  <appender name="FILE" class="ch.qos.logback.core.rolling.RollingFileAppender">
-    <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-      <fileNamePattern>logFile.%d{yyyy-MM-dd}.log</fileNamePattern>
-      <maxHistory>90</maxHistory>
-    </rollingPolicy>
-    <encoder>
-      <charset>utf-8</charset>
-      <Pattern>%d %-5level [%thread] %logger{0}: %msg%n</Pattern>
-    </encoder>
-  </appender>
-
-  <appender name="ASYNC" class="ch.qos.logback.classic.AsyncAppender">
-    <queueSize>512</queueSize>
-    <appender-ref ref="FILE"/>
-  </appender>
-
-  <root level="${logging.level.root}">
-    <appender-ref ref="ASYNC"/>
-  </root>
-  -->
 
   <logger name="tech.jhipster.lite" level="INFO" />
 
@@ -36,8 +14,9 @@
   <logger name="com.jackson" level="WARN" />
   <!-- jhipster-needle-logback-add-log -->
 
-  <!-- https://logback.qos.ch/manual/configuration.html#shutdownHook and https://jira.qos.ch/browse/LOGBACK-1090 -->
-  <shutdownHook class="ch.qos.logback.core.hook.DefaultShutdownHook" />
+  <root level="${log.level}">
+    <appender-ref ref="CONSOLE" />
+  </root>
 
   <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
     <resetJUL>true</resetJUL>


### PR DESCRIPTION
Note:
It is not needed to define the shutdown hook explicitly since version 1.1.10 of logback. Version 1.1.10 onwards, logback takes care of stopping the current logback-classic context (and all the appenders) when the web-app is stopped or reloaded. Here's the updated doc: https://logback.qos.ch/manual/configuration.html#webShutdownHook

Related with https://github.com/jhipster/jhipster-lite/pull/6941