### PR TITLE
Generator: Executes integration tests with a configuration derived from application configuration

### DIFF
--- a/src/test/java/tech/jhipster/lite/IntegrationTest.java
+++ b/src/test/java/tech/jhipster/lite/IntegrationTest.java
@@ -7,7 +7,9 @@ import java.lang.annotation.Target;
 import org.junit.jupiter.api.DisplayNameGeneration;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.annotation.AliasFor;
+import org.springframework.test.context.ActiveProfiles;
 
+@ActiveProfiles("test")
 @Target(ElementType.TYPE)
 @Retention(RetentionPolicy.RUNTIME)
 @DisplayNameGeneration(ReplaceCamelCase.class)

--- a/src/test/java/tech/jhipster/lite/cucumber/CucumberConfiguration.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/CucumberConfiguration.java
@@ -14,10 +14,12 @@ import org.springframework.http.client.ClientHttpRequestInterceptor;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
+import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 import tech.jhipster.lite.JHLiteApp;
 import tech.jhipster.lite.project.infrastructure.secondary.MockedProjectFormatterConfiguration;
 
+@ActiveProfiles("test")
 @CucumberContextConfiguration
 @SpringBootTest(classes = { JHLiteApp.class, MockedProjectFormatterConfiguration.class }, webEnvironment = WebEnvironment.RANDOM_PORT)
 public class CucumberConfiguration {

--- a/src/test/resources/config/application-test.properties
+++ b/src/test/resources/config/application-test.properties
@@ -4,21 +4,15 @@
 # http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
 #====================================================================
 
-spring.application.name=jhlite
 spring.main.banner-mode=off
 
 server.port=0
 application.exception.package=org.,java.
 
-spring.jackson.default-property-inclusion=non_null
-
 # Cors configuration
 application.cors.allowed-origins=http://localhost:8100,http://localhost:9000
-application.cors.allowed-methods=*
-application.cors.allowed-headers=*
-application.cors.exposed-headers=Authorization,Link,X-Total-Count,X-jhlite-alert,X-jhlite-error,X-jhlite-params
-application.cors.allow-credentials=true
-application.cors.max-age=1800
-application.cors.allowed-origin-patterns=https://*.githubpreview.dev
 
 spring.main.allow-bean-definition-overriding=true
+
+jhlite-hidden-resources.tags=
+jhlite-hidden-resources.slugs=


### PR DESCRIPTION
This makes tests more reliable since they use a configuration that is more real (since it's derived from main configuration).
Indeed it's currently possible to have passing tests because of wrong/outdated test configuration, whereas main application fails.

Also this decreases maintenance burden of test configuration (application-test.properties) since it only contains overridden parameters configuration.