### PR TITLE
Cleanup: remove unneeded ${jacoco.version} in pom.xml

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactory.java
@@ -147,7 +147,7 @@ public class MavenModuleFactory {
   }
 
   private JavaBuildPlugin jacocoPlugin() {
-    return javaBuildPlugin().groupId(JACOCO_GROUP).artifactId(JACOCO_ARTIFACT_ID).versionSlug(JACOCO_VERSION).build();
+    return javaBuildPlugin().groupId(JACOCO_GROUP).artifactId(JACOCO_ARTIFACT_ID).build();
   }
 
   private JavaBuildPlugin failsafePlugin() {

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactoryTest.java
@@ -69,7 +69,6 @@ class MavenModuleFactoryTest {
               <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco.version}</version>
               </plugin>
         """
       )


### PR DESCRIPTION
No need to re-declare jacoco plugin version in build section, since it's already declared in pluginManagement section