### PR TITLE
Bump actions checkout to v4 for templates

### DIFF
--- a/src/main/resources/generator/ci/github/actions/.github/workflows/github-actions-gradle.yml.mustache
+++ b/src/main/resources/generator/ci/github/actions/.github/workflows/github-actions-gradle.yml.mustache
@@ -19,7 +19,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 'Setup: checkout project'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Setup: environment'
         id: setup
         uses: ./.github/actions/setup

--- a/src/main/resources/generator/ci/github/actions/.github/workflows/github-actions-maven.yml.mustache
+++ b/src/main/resources/generator/ci/github/actions/.github/workflows/github-actions-maven.yml.mustache
@@ -16,7 +16,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: 'Setup: checkout project'
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: 'Setup: environment'
         id: setup
         uses: ./.github/actions/setup


### PR DESCRIPTION
Following https://github.com/jhipster/jhipster-lite/pull/7389