### PR TITLE
feat(SpyLogs): Split LogsSpy into LogSpy and LogSpyExtension to follow single-responsibility principle

### DIFF
--- a/src/test/java/tech/jhipster/lite/Logs.java
+++ b/src/test/java/tech/jhipster/lite/Logs.java
@@ -1,0 +1,13 @@
+package tech.jhipster.lite;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Target({ ElementType.FIELD, ElementType.PARAMETER })
+@Retention(RetentionPolicy.RUNTIME)
+@ExtendWith(LogsSpyExtension.class)
+public @interface Logs {
+}

--- a/src/test/java/tech/jhipster/lite/LogsSpy.java
+++ b/src/test/java/tech/jhipster/lite/LogsSpy.java
@@ -1,28 +1,21 @@
 package tech.jhipster.lite;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.*;
 
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
 import java.util.function.Predicate;
-import org.junit.jupiter.api.extension.AfterEachCallback;
-import org.junit.jupiter.api.extension.BeforeEachCallback;
-import org.junit.jupiter.api.extension.ExtensionContext;
-import org.junit.jupiter.api.extension.ParameterContext;
-import org.junit.jupiter.api.extension.ParameterResolutionException;
-import org.junit.jupiter.api.extension.ParameterResolver;
 import org.slf4j.LoggerFactory;
 
-public final class LogsSpy implements BeforeEachCallback, AfterEachCallback, ParameterResolver {
+public final class LogsSpy {
 
   private Logger logger;
   private ListAppender<ILoggingEvent> appender;
   private Level initialLevel;
 
-  @Override
-  public void beforeEach(ExtensionContext context) {
+  void prepare() {
     appender = new ListAppender<>();
     logger = (Logger) LoggerFactory.getLogger("tech.jhipster.lite");
     logger.addAppender(appender);
@@ -31,8 +24,7 @@ public final class LogsSpy implements BeforeEachCallback, AfterEachCallback, Par
     appender.start();
   }
 
-  @Override
-  public void afterEach(ExtensionContext context) {
+  void reset() {
     logger.setLevel(initialLevel);
     logger.detachAppender(appender);
   }
@@ -57,17 +49,5 @@ public final class LogsSpy implements BeforeEachCallback, AfterEachCallback, Par
 
   private Predicate<ILoggingEvent> withLog(Level level, String content) {
     return event -> level.equals(event.getLevel()) && event.toString().contains(content);
-  }
-
-  @Override
-  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-    throws ParameterResolutionException {
-    return parameterContext.getParameter().getType().equals(LogsSpy.class);
-  }
-
-  @Override
-  public LogsSpy resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
-    throws ParameterResolutionException {
-    return this;
   }
 }

--- a/src/test/java/tech/jhipster/lite/LogsSpyExtension.java
+++ b/src/test/java/tech/jhipster/lite/LogsSpyExtension.java
@@ -1,0 +1,68 @@
+package tech.jhipster.lite;
+
+import static org.junit.platform.commons.util.AnnotationUtils.*;
+
+import java.lang.reflect.Field;
+import java.util.function.Predicate;
+import org.junit.jupiter.api.extension.AfterEachCallback;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.BeforeEachCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+import org.junit.jupiter.api.extension.ParameterContext;
+import org.junit.jupiter.api.extension.ParameterResolutionException;
+import org.junit.jupiter.api.extension.ParameterResolver;
+import org.junit.jupiter.api.extension.TestInstancePostProcessor;
+import org.junit.platform.commons.support.ModifierSupport;
+
+public final class LogsSpyExtension
+  implements BeforeAllCallback, BeforeEachCallback, AfterEachCallback, ParameterResolver, TestInstancePostProcessor {
+
+  private final LogsSpy logsSpy = new LogsSpy();
+
+  @Override
+  public void beforeEach(ExtensionContext context) {
+    logsSpy.prepare();
+  }
+
+  @Override
+  public void afterEach(ExtensionContext context) {
+    logsSpy.reset();
+  }
+
+  @Override
+  public boolean supportsParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+    throws ParameterResolutionException {
+    return parameterContext.getParameter().getType().equals(LogsSpy.class);
+  }
+
+  @Override
+  public LogsSpy resolveParameter(ParameterContext parameterContext, ExtensionContext extensionContext)
+    throws ParameterResolutionException {
+    return logsSpy;
+  }
+
+  @Override
+  public void beforeAll(ExtensionContext context) {
+    Class<?> testClass = context.getRequiredTestClass();
+    injectFields(testClass, null, ModifierSupport::isStatic);
+  }
+
+  @Override
+  public void postProcessTestInstance(Object testInstance, ExtensionContext context) {
+    Class<?> testClass = context.getRequiredTestClass();
+    injectFields(testClass, testInstance, ModifierSupport::isNotStatic);
+  }
+
+  private void injectFields(Class<?> testClass, Object testInstance, Predicate<Field> predicate) {
+    predicate = predicate.and(field -> LogsSpy.class.isAssignableFrom(field.getType()));
+    findAnnotatedFields(testClass, Logs.class, predicate)
+      .forEach(field -> {
+        try {
+          field.setAccessible(true);
+          field.set(testInstance, logsSpy);
+        } catch (Exception ex) {
+          throw new RuntimeException(ex);
+        }
+      });
+  }
+}

--- a/src/test/java/tech/jhipster/lite/module/domain/JHipsterModuleContextTest.java
+++ b/src/test/java/tech/jhipster/lite/module/domain/JHipsterModuleContextTest.java
@@ -7,18 +7,17 @@ import ch.qos.logback.classic.Level;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class JHipsterModuleContextTest {
 
-  private final LogsSpy logs;
-
-  public JHipsterModuleContextTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldGetIndentSizeationFromInvalidIndentation() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModuleFilesTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModuleFilesTest.java
@@ -12,7 +12,9 @@ import java.nio.file.Paths;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
@@ -25,16 +27,13 @@ import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 import tech.jhipster.lite.shared.error.domain.GeneratorException;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class FileSystemJHipsterModuleFilesTest {
 
   private static final FileSystemJHipsterModuleFiles files = new FileSystemJHipsterModuleFiles(new FileSystemProjectFiles());
 
-  private final LogsSpy logs;
-
-  public FileSystemJHipsterModuleFilesTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldNotWriteOnUnwritablePath() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModulesRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModulesRepositoryTest.java
@@ -6,19 +6,18 @@ import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModules
 import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class FileSystemJHipsterModulesRepositoryTest {
 
-  private final LogsSpy logs;
-
-  public FileSystemJHipsterModulesRepositoryTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldApplyModule() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemReplacerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemReplacerTest.java
@@ -8,7 +8,9 @@ import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.
 import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.GeneratedProjectRepository;
@@ -21,16 +23,13 @@ import tech.jhipster.lite.module.domain.replacement.MandatoryReplacementExceptio
 import tech.jhipster.lite.module.domain.replacement.TextReplacer;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class FileSystemReplacerTest {
 
   private static final FileSystemReplacer replacer = new FileSystemReplacer();
 
-  private final LogsSpy logs;
-
-  public FileSystemReplacerTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldHandleMandatoryReplacementError() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/JHipsterModulesResourcesConfigurationTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/JHipsterModulesResourcesConfigurationTest.java
@@ -7,21 +7,20 @@ import ch.qos.logback.classic.Level;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulesResources;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class JHipsterModulesResourcesConfigurationTest {
 
   private static final JHipsterModulesResourcesConfiguration configuration = new JHipsterModulesResourcesConfiguration();
 
-  private final LogsSpy logs;
-
-  public JHipsterModulesResourcesConfigurationTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldGetAllResourcesWithoutHiddenResources() {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
@@ -15,22 +15,21 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class JGitGitRepositoryTest {
 
   private static final JGitGitRepository git = new JGitGitRepository();
 
-  private final LogsSpy logs;
-
-  public JGitGitRepositoryTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Nested
   @DisplayName("init")

--- a/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfigurationTest.java
+++ b/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfigurationTest.java
@@ -8,11 +8,13 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 
 @UnitTest
-@ExtendWith({ MockitoExtension.class, LogsSpy.class })
+@ExtendWith({ MockitoExtension.class, LogsSpyExtension.class })
 class ProjectFormatterConfigurationTest {
 
   private static final ProjectFormatterConfiguration configuration = new ProjectFormatterConfiguration();
@@ -20,11 +22,8 @@ class ProjectFormatterConfigurationTest {
   @Mock
   private NpmInstallationReader npmInstallation;
 
-  private final LogsSpy logs;
-
-  public ProjectFormatterConfigurationTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldGetTraceFormatterWithoutInstalledNpm() {

--- a/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/TraceProjectFormatterTest.java
+++ b/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/TraceProjectFormatterTest.java
@@ -3,21 +3,20 @@ package tech.jhipster.lite.project.infrastructure.secondary;
 import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.project.domain.ProjectPath;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class TraceProjectFormatterTest {
 
   private static final TraceProjectFormatter formatter = new TraceProjectFormatter();
 
-  private final LogsSpy logs;
-
-  public TraceProjectFormatterTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldTraceThatNoNpmIsInstalled() {

--- a/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/AssertionErrorsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/AssertionErrorsHandlerTest.java
@@ -6,23 +6,22 @@ import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.MessageSource;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.shared.error.domain.AssertionErrorType;
 import tech.jhipster.lite.shared.error.domain.AssertionException;
 import tech.jhipster.lite.shared.error_generator.domain.MissingMandatoryValueFactory;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class AssertionErrorsHandlerTest {
 
   private static final AssertionErrorsHandler handler = new AssertionErrorsHandler(mock(MessageSource.class));
 
-  private final LogsSpy logs;
-
-  public AssertionErrorsHandlerTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldLogPrimaryAssertionExceptionInInfo() {

--- a/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/BeanValidationErrorsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/BeanValidationErrorsHandlerTest.java
@@ -11,20 +11,19 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.core.MethodParameter;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class BeanValidationErrorsHandlerTest {
 
   private static final BeanValidationErrorsHandler handler = new BeanValidationErrorsHandler();
 
-  private final LogsSpy logs;
-
-  public BeanValidationErrorsHandlerTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldLogMethodArgumentNotValidInInfo() throws NoSuchMethodException, SecurityException {

--- a/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/GeneratorErrorsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/shared/error/infrastructure/primary/GeneratorErrorsHandlerTest.java
@@ -6,22 +6,21 @@ import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.context.MessageSource;
+import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
+import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.shared.error.domain.GeneratorException;
 import tech.jhipster.lite.shared.error.domain.StandardErrorKey;
 
 @UnitTest
-@ExtendWith(LogsSpy.class)
+@ExtendWith(LogsSpyExtension.class)
 class GeneratorErrorsHandlerTest {
 
   private static final GeneratorErrorsHandler handler = new GeneratorErrorsHandler(mock(MessageSource.class));
 
-  private final LogsSpy logs;
-
-  public GeneratorErrorsHandlerTest(LogsSpy logs) {
-    this.logs = logs;
-  }
+  @Logs
+  private LogsSpy logs;
 
   @Test
   void shouldLogServerErrorAsError() {


### PR DESCRIPTION

This allows not exposing JUnit5 related methods (beforeEach, afterEach, supportsParameter, ...) in actual tests. 
LogSpy could now be injected directly by annotating the field with `@Logs`: this should improve easy of use with other extensions.

I'll also change generated code if we agree on the principle.