### PR TITLE
React - Sonar: Literals should not be used for promise rejection

### DIFF
--- a/src/main/resources/generator/client/react/src/test/javascript/spec/login/services/login.test.ts.mustache
+++ b/src/main/resources/generator/client/react/src/test/javascript/spec/login/services/login.test.ts.mustache
@@ -14,7 +14,7 @@ const idToken = 123;
 describe('login function', () => {
   it('should return a promise', () => {
     const spy = vi.spyOn(axios, 'post');
-    spy.mockImplementationOnce(() => Promise.reject('error'));
+    spy.mockImplementationOnce(() => Promise.reject(new Error('error')));
     const setUsername = vi.fn();
     const setToken = vi.fn();
     expect(login({...data, setToken, setUsername})).toBeInstanceOf(Promise);


### PR DESCRIPTION
<img width="1112" alt="image" src="https://github.com/jhipster/jhipster-lite/assets/9989211/e924445e-ee00-4b3d-8785-09930ed4e361">
