### PR TITLE
CI: Disable interactive mode in maven settings.xml

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -24,6 +24,10 @@ runs:
       with:
         distribution: 'zulu'
         java-version: '${{ inputs.java-version }}'
+    - name: 'Disable maven interactive mode'
+      shell: bash
+      run: |
+        sed -i 's/<servers>/<interactiveMode>false\<\/interactiveMode>\n  <servers>/g' ~/.m2/settings.xml
     - name: 'Setup: check tools'
       shell: bash
       run: |


### PR DESCRIPTION
It disables download progress indication globally, rather than specifying it in each maven invocation

This is a quick workaround, I've submitted a feature request for `actions/setup-java`: https://github.com/actions/setup-java/issues/547