### PR TITLE
Support multi lines spring properties comments

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandler.java
@@ -6,6 +6,8 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
 import tech.jhipster.lite.module.domain.javaproperties.Comment;
 import tech.jhipster.lite.module.domain.javaproperties.PropertyKey;
 import tech.jhipster.lite.shared.error.domain.Assert;
@@ -102,7 +104,13 @@ class PropertiesFileSpringCommentsHandler {
   }
 
   private String commentLine(Comment comment) {
-    return new StringBuilder().append(HASH).append(BLANK_SPACE).append(comment.get()).append(LINE_BREAK).toString();
+    StringBuilder stringBuilder = new StringBuilder();
+    splitLines(comment).forEach(line -> stringBuilder.append(HASH).append(BLANK_SPACE).append(line).append(LINE_BREAK));
+    return stringBuilder.toString();
+  }
+
+  private static Collection<String> splitLines(Comment comment) {
+    return List.of(comment.get().split("\\r?\\n"));
   }
 
   private String propertyId(PropertyKey key) {

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandler.java
@@ -33,7 +33,7 @@ class PropertiesFileSpringCommentsHandler {
     updateComments(key, comment);
   }
 
-  @ExcludeFromGeneratedCodeCoverage
+  @ExcludeFromGeneratedCodeCoverage(reason = "Hard to cover IOException")
   private void updateComments(PropertyKey key, Comment comment) {
     try {
       String properties = buildComments(key, comment);

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
@@ -43,4 +43,48 @@ class PropertiesFileSpringCommentsHandlerTest {
 
     assertThat(content(propertiesFile)).doesNotContain("This is a comment");
   }
+
+  @Test
+  void shouldAddSingleLineCommentForExistingProperty() {
+    Path propertiesFile = Paths.get(TestFileUtils.tmpDirForTest(), "src/main/resources/application.properties");
+    loadDefaultProperties(EXISTING_SPRING_PROPERTIES, propertiesFile);
+
+    new PropertiesFileSpringCommentsHandler(propertiesFile).set(propertyKey("spring.application.name"), comment("This is a comment"));
+
+    assertThat(content(propertiesFile))
+      .contains(
+        """
+        # This is a comment
+        spring.application.name=JHLite
+        """
+      );
+  }
+
+  @Test
+  void shouldAddMultilineCommentForExistingProperty() {
+    Path propertiesFile = Paths.get(TestFileUtils.tmpDirForTest(), "src/main/resources/application.properties");
+    loadDefaultProperties(EXISTING_SPRING_PROPERTIES, propertiesFile);
+
+    new PropertiesFileSpringCommentsHandler(propertiesFile)
+      .set(
+        propertyKey("spring.application.name"),
+        comment(
+          """
+          This is a
+          multiline
+          comment
+          """
+        )
+      );
+
+    assertThat(content(propertiesFile))
+      .contains(
+        """
+        # This is a
+        # multiline
+        # comment
+        spring.application.name=JHLite
+        """
+      );
+  }
 }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
@@ -2,8 +2,7 @@ package tech.jhipster.lite.module.infrastructure.secondary;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
-import static tech.jhipster.lite.TestFileUtils.content;
-import static tech.jhipster.lite.TestFileUtils.loadDefaultProperties;
+import static tech.jhipster.lite.TestFileUtils.*;
 import static tech.jhipster.lite.module.domain.JHipsterModule.comment;
 import static tech.jhipster.lite.module.domain.JHipsterModule.propertyKey;
 
@@ -51,7 +50,7 @@ class PropertiesFileSpringCommentsHandlerTest {
 
     new PropertiesFileSpringCommentsHandler(propertiesFile).set(propertyKey("spring.application.name"), comment("This is a comment"));
 
-    assertThat(content(propertiesFile))
+    assertThat(contentNormalizingNewLines(propertiesFile))
       .contains(
         """
         # This is a comment
@@ -77,7 +76,7 @@ class PropertiesFileSpringCommentsHandlerTest {
         )
       );
 
-    assertThat(content(propertiesFile))
+    assertThat(contentNormalizingNewLines(propertiesFile))
       .contains(
         """
         # This is a

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/PropertiesFileSpringCommentsHandlerTest.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.module.infrastructure.secondary;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.catchThrowable;
 import static tech.jhipster.lite.TestFileUtils.content;
+import static tech.jhipster.lite.TestFileUtils.loadDefaultProperties;
 import static tech.jhipster.lite.module.domain.JHipsterModule.comment;
 import static tech.jhipster.lite.module.domain.JHipsterModule.propertyKey;
 
@@ -16,8 +17,12 @@ import tech.jhipster.lite.UnitTest;
 @UnitTest
 class PropertiesFileSpringCommentsHandlerTest {
 
+  public static final Path EXISTING_SPRING_PROPERTIES = Paths.get(
+    "src/test/resources/projects/project-with-spring-application-properties/application.properties"
+  );
+
   @Test
-  void shouldNotCommentWhenFileNotExists() {
+  void shouldNotCommentWhenFileDoesNotExist() {
     String path = TestFileUtils.tmpDirForTest();
     Path propertiesFile = Paths.get(path, "src/main/resources/config/application.properties");
 
@@ -27,5 +32,15 @@ class PropertiesFileSpringCommentsHandlerTest {
       content(Paths.get(path, "src/main/resources/config/application.properties"));
     });
     assertThat(thrown).hasCauseInstanceOf(NoSuchFileException.class);
+  }
+
+  @Test
+  void shouldNotCommentWhenKeyDoesNotExist() {
+    Path propertiesFile = Paths.get(TestFileUtils.tmpDirForTest(), "src/main/resources/application.properties");
+    loadDefaultProperties(EXISTING_SPRING_PROPERTIES, propertiesFile);
+
+    new PropertiesFileSpringCommentsHandler(propertiesFile).set(propertyKey("foo.bar"), comment("This is a comment"));
+
+    assertThat(content(propertiesFile)).doesNotContain("This is a comment");
   }
 }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
@@ -1,22 +1,28 @@
 package tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.params.provider.EnumSource.Mode.EXCLUDE;
 import static tech.jhipster.lite.TestFileUtils.*;
 import static tech.jhipster.lite.module.domain.JHipsterModule.javaDependency;
 import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.*;
 
-import java.nio.file.*;
-
-import org.junit.jupiter.api.*;
-import org.junit.jupiter.params.*;
-import org.junit.jupiter.params.provider.*;
-
-import tech.jhipster.lite.*;
-import tech.jhipster.lite.module.domain.*;
-import tech.jhipster.lite.module.domain.javabuild.command.*;
-import tech.jhipster.lite.module.domain.javadependency.*;
-import tech.jhipster.lite.module.domain.properties.*;
+import java.nio.file.Paths;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.module.domain.Indentation;
+import tech.jhipster.lite.module.domain.javabuild.command.AddDirectJavaDependency;
+import tech.jhipster.lite.module.domain.javabuild.command.AddJavaDependencyManagement;
+import tech.jhipster.lite.module.domain.javabuild.command.RemoveDirectJavaDependency;
+import tech.jhipster.lite.module.domain.javabuild.command.RemoveJavaDependencyManagement;
+import tech.jhipster.lite.module.domain.javabuild.command.SetVersion;
+import tech.jhipster.lite.module.domain.javadependency.JavaDependency;
+import tech.jhipster.lite.module.domain.javadependency.JavaDependencyScope;
+import tech.jhipster.lite.module.domain.javadependency.JavaDependencyVersion;
+import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 
 @UnitTest
 class GradleCommandHandlerTest {
@@ -325,7 +331,7 @@ class GradleCommandHandlerTest {
   }
 
   private static String versionCatalogContent(JHipsterProjectFolder projectFolder) {
-    return content(Paths.get(projectFolder.get()).resolve("gradle/libs.versions.toml")).replace("\r\n", "\n");
+    return contentNormalizingNewLines(Paths.get(projectFolder.get()).resolve("gradle/libs.versions.toml"));
   }
 
 }


### PR DESCRIPTION
Support for adding such comment:
```properties
# This is a
# multiline
# comment
spring.application.name=JHLite
```