### PR TITLE
Remove obsolete @ExcludeFromGeneratedCodeCoverage after jacoco upgrade 

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/domain/landscape/JHipsterLandscape.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/landscape/JHipsterLandscape.java
@@ -12,7 +12,6 @@ import tech.jhipster.lite.module.domain.JHipsterFeatureSlug;
 import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
 import tech.jhipster.lite.module.domain.JHipsterSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulesResources;
-import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 public class JHipsterLandscape {
 
@@ -60,7 +59,6 @@ public class JHipsterLandscape {
     return level -> new JHipsterLandscapeLevel(level.elements().stream().map(this::toElementWithoutNestedDependencies).toList());
   }
 
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   private JHipsterLandscapeElement toElementWithoutNestedDependencies(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case MODULE -> moduleWithoutNestedDependencies((JHipsterLandscapeModule) element);
@@ -138,7 +136,6 @@ public class JHipsterLandscape {
     return level -> new JHipsterLandscapeLevel(level.elements().stream().sorted(levelComparator).toList());
   }
 
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   private long linksCount(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case FEATURE -> featureLinksCount((JHipsterLandscapeFeature) element);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/primary/RestJHipsterLandscapeElement.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/primary/RestJHipsterLandscapeElement.java
@@ -5,13 +5,11 @@ import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeElement;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeElementType;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeFeature;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeModule;
-import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Schema(name = "JHipsterLandscapeElement", description = "An element in a landscape, can be either a module or a feature")
 sealed interface RestJHipsterLandscapeElement permits RestJHipsterLandscapeModule, RestJHipsterLandscapeFeature {
   JHipsterLandscapeElementType getType();
 
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missed case here")
   static RestJHipsterLandscapeElement from(JHipsterLandscapeElement element) {
     return switch (element.type()) {
       case MODULE -> RestJHipsterLandscapeModule.fromModule((JHipsterLandscapeModule) element);

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
@@ -184,7 +184,6 @@ class FileSystemPackageJsonHandler {
       return new JsonActionBuilder(JsonActionType.REMOVE);
     }
 
-    @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco thinks there is a missed branch")
     public String handle() {
       Assert.notNull("action", action);
 

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringFactoriesCommandsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringFactoriesCommandsHandler.java
@@ -5,10 +5,10 @@ import static tech.jhipster.lite.module.infrastructure.secondary.FileSystemJHips
 import java.nio.file.Path;
 import java.util.function.Consumer;
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.module.domain.javaproperties.*;
+import tech.jhipster.lite.module.domain.javaproperties.SpringFactories;
+import tech.jhipster.lite.module.domain.javaproperties.SpringFactory;
 import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 import tech.jhipster.lite.shared.error.domain.Assert;
-import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Service
 class FileSystemSpringFactoriesCommandsHandler {
@@ -24,7 +24,6 @@ class FileSystemSpringFactoriesCommandsHandler {
     return property -> new PropertiesFileSpringFactoriesHandler(getPath(projectFolder, property)).append(property.key(), property.value());
   }
 
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco thinks there is a missed branch")
   private static Path getPath(JHipsterProjectFolder projectFolder, SpringFactory factory) {
     return switch (factory.type()) {
       case TEST_FACTORIES -> projectFolder.filePath(TEST_META_INF_FOLDER + "spring.factories");

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringPropertiesCommandsHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemSpringPropertiesCommandsHandler.java
@@ -13,7 +13,6 @@ import tech.jhipster.lite.module.domain.javaproperties.SpringProperty;
 import tech.jhipster.lite.module.domain.javaproperties.SpringPropertyType;
 import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 import tech.jhipster.lite.shared.error.domain.Assert;
-import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Service
 class FileSystemSpringPropertiesCommandsHandler {
@@ -45,7 +44,6 @@ class FileSystemSpringPropertiesCommandsHandler {
     return folder -> projectFolder.filePath(folder + propertiesFilename(property));
   }
 
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco thinks there is a missed branch")
   private static Supplier<Path> defaultPropertiesFile(JHipsterProjectFolder projectFolder, SpringProperty property) {
     return switch (property.type()) {
       case MAIN_PROPERTIES, MAIN_BOOTSTRAP_PROPERTIES -> () ->

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
@@ -5,7 +5,6 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
-import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 @Configuration
 @ImportRuntimeHints(NativeHints.class)
@@ -14,7 +13,6 @@ class ProjectFormatterConfiguration {
   private static final Logger log = LoggerFactory.getLogger(ProjectFormatterConfiguration.class);
 
   @Bean
-  @ExcludeFromGeneratedCodeCoverage(reason = "Jacoco think there is a missing case")
   public ProjectFormatter projectFormatter(NpmInstallationReader npmInstallation) {
     return switch (npmInstallation.get()) {
       case UNIX -> unixFormatter();


### PR DESCRIPTION
Remove obsolete @ExcludeFromGeneratedCodeCoverage annotations associated to erroneous missing switch branch - the jacoco bug has been fixed.