### PR TITLE
Angular: Inject the PRECONNECT_CHECK_BLOCKLIST token to disable warning during Jest tests

### DIFF
--- a/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.component.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.component.spec.ts.mustache
@@ -1,3 +1,4 @@
+import { PRECONNECT_CHECK_BLOCKLIST } from '@angular/common';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -11,6 +12,9 @@ describe('App Component', () => {
     waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [RouterTestingModule.withRoutes([])],
+        providers: [
+          { provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'https://jestjs.io' }
+        ],
       }).compileComponents();
     })
   );

--- a/src/test/resources/projects/angular/app.component.spec.ts
+++ b/src/test/resources/projects/angular/app.component.spec.ts
@@ -1,3 +1,4 @@
+import { PRECONNECT_CHECK_BLOCKLIST } from '@angular/common';
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 
@@ -10,6 +11,9 @@ describe('App Component', () => {
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
       imports: [RouterTestingModule.withRoutes([])],
+      providers: [
+        { provide: PRECONNECT_CHECK_BLOCKLIST, useValue: 'https://jestjs.io' }
+      ],
       declarations: [AppComponent],
     }).compileComponents();
   }));


### PR DESCRIPTION
Remove this warning during tests execution:
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/58a3977e-b9e2-49cd-8390-208c26e3f338)

Doc to resolve this: [here](https://angular.io/guide/image-directive#performance-features)