### PR TITLE
Vue+Vitest: Remove useless logs

### DIFF
--- a/src/main/resources/generator/client/vue/vitest.config.ts
+++ b/src/main/resources/generator/client/vue/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
     alias: [{ find: '@', replacement: path.resolve(__dirname, 'src/main/webapp/app') }],
   },
   test: {
-    reporters: ['json', 'verbose', 'vitest-sonar-reporter'],
+    reporters: ['verbose', 'vitest-sonar-reporter'],
     outputFile: {
       'vitest-sonar-reporter': 'target/test-results/TESTS-results-sonar.xml',
     },


### PR DESCRIPTION
Remove useless logs on command `npm t`:
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/c44ee9f5-10b9-4a76-8f14-f2c203f9e4b7)
Now we have:
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/eb965f6b-6a97-4e72-9982-2eab5d1ed736)
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/2bd9e4e9-5073-45c7-9b8d-bc781f869e2e)
Already done on React https://github.com/jhipster/jhipster-lite/blob/83a4a9786147823d8634e5f4e81312fa6665196c/src/main/resources/generator/client/react/vitest.config.ts#L14