### PR TITLE
Fix hexa arch test

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/gradle/infrastructure/primary/GradleModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/gradle/infrastructure/primary/GradleModuleConfiguration.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.generator.buildtool.gradle.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JAVA_BUILD_TOOL;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.GRADLE_JAVA;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.GRADLE_WRAPPER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.INIT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JAVA_BUILD_TOOL;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.GRADLE_JAVA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.GRADLE_WRAPPER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.INIT;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/infrastructure/primary/MavenModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/infrastructure/primary/MavenModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.buildtool.maven.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/ci/github/actions/infrastructure/primary/GitHubActionsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/github/actions/infrastructure/primary/GitHubActionsModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.ci.github.actions.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/ci/gitlab/infrastructure/primary/GitLabCiModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/ci/gitlab/infrastructure/primary/GitLabCiModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.ci.gitlab.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/admin/health/infrastructure/primary/AngularHealthModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/admin/health/infrastructure/primary/AngularHealthModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.client.angular.admin.health.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/infrastructure/primary/AngularCoreModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/infrastructure/primary/AngularCoreModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.angular.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/security/jwt/infrastructure/primary/AngularJwtModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/security/jwt/infrastructure/primary/AngularJwtModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.angular.security.jwt.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/security/oauth2/infrastructure/primary/AngularOAuth2ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/security/oauth2/infrastructure/primary/AngularOAuth2ModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.angular.security.oauth2.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/infrastructure/primary/ReactCoreModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/infrastructure/primary/ReactCoreModulesConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.react.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/react/security/jwt/infrastructure/primary/ReactJwtModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/security/jwt/infrastructure/primary/ReactJwtModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.client.react.security.jwt.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/svelte/core/infrastructure/primary/SvelteModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/svelte/core/infrastructure/primary/SvelteModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.svelte.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/tools/cypress/infrastructure/primary/CypressModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/tools/cypress/infrastructure/primary/CypressModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.tools.cypress.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/tools/playwright/infrastructure/primary/PlaywrightModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/tools/playwright/infrastructure/primary/PlaywrightModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.tools.playwright.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/infrastructure/primary/VueModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/infrastructure/primary/VueModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.vue.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/init/infrastructure/primary/InitModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/init/infrastructure/primary/InitModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.init.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/prettier/infrastructure/primary/PrettierModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/prettier/infrastructure/primary/PrettierModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.prettier.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/hexagonaldocumentation/infrastructure/primary/HexagonalArchitectureDocumentationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/hexagonaldocumentation/infrastructure/primary/HexagonalArchitectureDocumentationModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.hexagonaldocumentation.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/arch/infrastructure/primary/ArchUnitModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/arch/infrastructure/primary/ArchUnitModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.javatool.arch.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/base/infrastructure/primary/JavaBaseModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/base/infrastructure/primary/JavaBaseModuleConfiguration.java
@@ -1,11 +1,11 @@
 package tech.jhipster.lite.generator.server.javatool.base.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.javatool.base.application.JavaBaseApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/checkstyle/infrastructure/primary/CheckstyleModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/checkstyle/infrastructure/primary/CheckstyleModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.javatool.checkstyle.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/infrastructure/primary/FrontendMavenModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/infrastructure/primary/FrontendMavenModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.javatool.frontendmaven.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/jacoco/infrastructure/primary/JacocoThresholdModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/jacoco/infrastructure/primary/JacocoThresholdModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.javatool.jacoco.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/java_enum/infrastructure/primary/JavaEnumsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/java_enum/infrastructure/primary/JavaEnumsModuleConfiguration.java
@@ -2,8 +2,8 @@ package tech.jhipster.lite.generator.server.javatool.java_enum.infrastructure.pr
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.javatool.java_enum.application.JavaEnumsApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/memoizer/infrastructure/primary/JavaMemoizersModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/memoizer/infrastructure/primary/JavaMemoizersModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.javatool.memoizer.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/pagination/domainmodel/infrastructure/primary/PaginationDomainModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/pagination/domainmodel/infrastructure/primary/PaginationDomainModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.pagination.domainmodel.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/pagination/jpa/infrastructure/primary/JpaPaginationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/pagination/jpa/infrastructure/primary/JpaPaginationModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.pagination.jpa.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/pagination/rest/infrastructure/primary/RestPaginationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/pagination/rest/infrastructure/primary/RestPaginationModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.pagination.rest.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/sonarqube/infrastructure/primary/SonarQubeModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonarqube/infrastructure/primary/SonarQubeModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.sonarqube.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocauth0/infrastructure/primary/SpringDocAuth0ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocauth0/infrastructure/primary/SpringDocAuth0ModuleConfiguration.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.generator.server.springboot.apidocumentation.springdocauth0.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.OAUTH_PROVIDER_SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRINGDOC_OAUTH_2_AUTH_0;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_AUTH_0;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.OAUTH_PROVIDER_SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRINGDOC_OAUTH_2_AUTH_0;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_AUTH_0;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdoccore/infrastructure/primary/SpringdocModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdoccore/infrastructure/primary/SpringdocModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.apidocumentation.springdoccore.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_MVC_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_MVC_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocjwt/infrastructure/primary/SpringdocJwtModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocjwt/infrastructure/primary/SpringdocJwtModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.apidocumentation.springdocjwt.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocoauth/infrastructure/primary/SpringdocOauth2ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocoauth/infrastructure/primary/SpringdocOauth2ModuleConfiguration.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.generator.server.springboot.apidocumentation.springdocoauth.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.AUTHENTICATION_SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRINGDOC_OAUTH_2;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.AUTHENTICATION_SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRINGDOC_OAUTH_2;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocokta/infrastructure/primary/SpringDocOktaModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/apidocumentation/springdocokta/infrastructure/primary/SpringDocOktaModuleConfiguration.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.generator.server.springboot.apidocumentation.springdocokta.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.OAUTH_PROVIDER_SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRINGDOC;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRINGDOC_OAUTH_2_OKTA;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_OKTA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.OAUTH_PROVIDER_SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRINGDOC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRINGDOC_OAUTH_2_OKTA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_OKTA;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/async/infrastructure/primary/SpringBootAsyncModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/async/infrastructure/primary/SpringBootAsyncModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.async.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_ASYNC;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_ASYNC;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/banner/infrastructure/primary/BannerModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/banner/infrastructure/primary/BannerModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.banner.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/KafkaModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/kafka/infrastructure/primary/KafkaModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.broker.kafka.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/pulsar/infrastructure/primary/PulsarModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/broker/pulsar/infrastructure/primary/PulsarModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.broker.pulsar.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_PULSAR;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_PULSAR;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/infrastructure/primary/CaffeineCacheModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/caffeine/infrastructure/primary/CaffeineCacheModuleConfiguration.java
@@ -2,8 +2,8 @@ package tech.jhipster.lite.generator.server.springboot.cache.caffeine.infrastruc
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.springboot.cache.caffeine.application.CaffeineCacheApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/EHCacheModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/ehcache/infrastructure/primary/EHCacheModulesConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cache.ehcache.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JCACHE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JCACHE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/CacheModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cache/simple/infrastructure/primary/CacheModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cache.simple.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_CACHE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_CACHE;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/infrastructure/primary/SpringBootCoreModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/infrastructure/primary/SpringBootCoreModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/infrastructure/primary/CucumberModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/infrastructure/primary/CucumberModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cucumber.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/infrastructure/primary/CucumberAuthenticationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/infrastructure/primary/CucumberAuthenticationModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cucumberauthentication.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/customjhlite/infrastructure/primary/CustomJHLiteModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/customjhlite/infrastructure/primary/CustomJHLiteModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.customjhlite.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.CUSTOM_JHLITE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.CUSTOM_JHLITE;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/cassandra/infrastructure/primary/CassandraModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/cassandra/infrastructure/primary/CassandraModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.database.cassandra.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.CASSANDRA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.CASSANDRA;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/hibernate2ndlevelcache/infrastructure/primary/Hibernate2ndLevelCacheModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/hibernate2ndlevelcache/infrastructure/primary/Hibernate2ndLevelCacheModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.database.hibernate2ndlevelcache.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JCACHE;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.HIBERNATE_2ND_LEVEL_CACHE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JCACHE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.HIBERNATE_2ND_LEVEL_CACHE;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mariadb/infrastructure/primary/MariaDBModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mariadb/infrastructure/primary/MariaDBModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.database.mariadb.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MARIADB;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MARIADB;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/MongoDbModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mongodb/infrastructure/primary/MongoDbModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.database.mongodb.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MONGODB;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MONGODB;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mssql/infrastructure/primary/MsSQLModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mssql/infrastructure/primary/MsSQLModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.database.mssql.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MSSQL;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MSSQL;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/infrastructure/primary/MySQLModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/mysql/infrastructure/primary/MySQLModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.database.mysql.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MYSQL;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MYSQL;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/neo4j/infrastructure/primary/Neo4jModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/neo4j/infrastructure/primary/Neo4jModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.database.neo4j.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.NEO4J;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.NEO4J;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/infrastructure/primary/PostgresqlModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/postgresql/infrastructure/primary/PostgresqlModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.database.postgresql.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.POSTGRESQL;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.POSTGRESQL;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/database/redis/infrastructure/primary/RedisModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/database/redis/infrastructure/primary/RedisModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.database.redis.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.REDIS;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.REDIS;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/cassandra/infrastructure/primary/CassandraMigrationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/cassandra/infrastructure/primary/CassandraMigrationModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.dbmigration.cassandra.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.CASSANDRA;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.CASSANDRA_MIGRATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.CASSANDRA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.CASSANDRA_MIGRATION;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/flyway/infrastructure/primary/FlywayModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/flyway/infrastructure/primary/FlywayModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.dbmigration.flyway.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.DATABASE_MIGRATION;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.DATABASE_MIGRATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/infrastructure/primary/LiquibaseModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/liquibase/infrastructure/primary/LiquibaseModuleConfiguration.java
@@ -1,9 +1,9 @@
 package tech.jhipster.lite.generator.server.springboot.dbmigration.liquibase.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.DATABASE_MIGRATION;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.JPA_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.LIQUIBASE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.LOGS_SPY;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.DATABASE_MIGRATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.JPA_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.LIQUIBASE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.LOGS_SPY;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/mongock/infrastructure/primary/MongockModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/mongock/infrastructure/primary/MongockModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.dbmigration.mongock.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MONGOCK;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.MONGODB;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MONGOCK;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.MONGODB;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/neo4jmigrations/infrastructure/primary/Neo4jMigrationsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/dbmigration/neo4jmigrations/infrastructure/primary/Neo4jMigrationsModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.dbmigration.neo4jmigrations.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.NEO4J;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.NEO4J_MIGRATIONS;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.NEO4J;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.NEO4J_MIGRATIONS;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/primary/DevToolsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/devtools/infrastructure/primary/DevToolsModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.devtools.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_DEVTOOLS;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_DEVTOOLS;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/docker/infrastructure/primary/SpringBootDockerModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/docker/infrastructure/primary/SpringBootDockerModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.docker.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/infrastructure/primary/LogstashModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logging/logstash/infrastructure/primary/LogstashModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.logging.logstash.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.LOGSTASH;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.LOGSTASH;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/logsspy/infrastructure/primary/LogsSpyModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/logsspy/infrastructure/primary/LogsSpyModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.logsspy.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/infrastructure/primary/DummyCassandraPersistenceModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/cassandrapersistence/infrastructure/primary/DummyCassandraPersistenceModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.cassandrapersistence.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.DUMMY_PERSISTENCE;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.DUMMY_PERSISTENCE;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/feature/infrastructure/primary/DummyFeatureModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/feature/infrastructure/primary/DummyFeatureModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.feature.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/flyway/infrastructure/primary/DummyFlywayModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/flyway/infrastructure/primary/DummyFlywayModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.flyway.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/jpapersistence/infrastructure/primary/DummyJpaPersistenceModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/jpapersistence/infrastructure/primary/DummyJpaPersistenceModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.jpapersistence.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/liquibase/infrastructure/primary/DummyLiquibaseModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/liquibase/infrastructure/primary/DummyLiquibaseModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.liquibase.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/mongopersistence/infrastructure/primary/DummyMongoDBPersistenceModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/dummy/mongopersistence/infrastructure/primary/DummyMongoDBPersistenceModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.dummy.mongopersistence.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/internationalized_errors/infrastructure/primary/InternationalizedErrorsModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/internationalized_errors/infrastructure/primary/InternationalizedErrorsModuleConfiguration.java
@@ -2,9 +2,9 @@ package tech.jhipster.lite.generator.server.springboot.mvc.internationalized_err
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteFeatureSlug;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.springboot.mvc.internationalized_errors.application.InternationalizedErrorsApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/infrastructure/primary/JwtAuthenticationModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/jwt/infrastructure/primary/JwtAuthenticationModulesConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.jwt.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.AUTHENTICATION;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_MVC_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.AUTHENTICATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_MVC_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/kipe/infrastructure/primary/KipeAuthorizationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/kipe/infrastructure/primary/KipeAuthorizationModuleConfiguration.java
@@ -2,9 +2,9 @@ package tech.jhipster.lite.generator.server.springboot.mvc.security.kipe.infrast
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteFeatureSlug;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.springboot.mvc.security.kipe.application.KipeApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/kipe/infrastructure/primary/KipeExpressionModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/kipe/infrastructure/primary/KipeExpressionModuleConfiguration.java
@@ -2,9 +2,9 @@ package tech.jhipster.lite.generator.server.springboot.mvc.security.kipe.infrast
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.JHLiteFeatureSlug;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
 import tech.jhipster.lite.generator.server.springboot.mvc.security.kipe.application.KipeApplicationService;
+import tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/account/infrastructure/primary/OAuth2AccountModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/account/infrastructure/primary/OAuth2AccountModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.account.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/auth0/infrastructure/primary/OAuth2Auth0ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/auth0/infrastructure/primary/OAuth2Auth0ModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.auth0.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.OAUTH_PROVIDER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_AUTH_0;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.OAUTH_PROVIDER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_AUTH_0;
 import static tech.jhipster.lite.module.domain.resource.JHipsterModulePropertyDefinition.mandatoryStringProperty;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/infrastructure/primary/OAuth2ModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/infrastructure/primary/OAuth2ModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.AUTHENTICATION;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_MVC_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.AUTHENTICATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_MVC_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/okta/infrastructure/primary/OAuth2OktaModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/okta/infrastructure/primary/OAuth2OktaModuleConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.okta.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.OAUTH_PROVIDER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_OKTA;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.OAUTH_PROVIDER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_OAUTH_2_OKTA;
 import static tech.jhipster.lite.module.domain.resource.JHipsterModulePropertyDefinition.mandatoryStringProperty;
 
 import org.springframework.context.annotation.Bean;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/web/infrastructure/primary/SpringBootMvcModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/web/infrastructure/primary/SpringBootMvcModulesConfiguration.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.web.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_MVC_SERVER;
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_MVC_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/infrastructure/primary/SpringCloudConfigModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/configclient/infrastructure/primary/SpringCloudConfigModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.springcloud.configclient.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/consul/infrastructure/primary/ConsulModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/consul/infrastructure/primary/ConsulModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.springcloud.consul.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.*;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/eureka/infrastructure/primary/EurekaModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/eureka/infrastructure/primary/EurekaModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.springcloud.eureka.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/gateway/infrastructure/primary/GatewayModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/springcloud/gateway/infrastructure/primary/GatewayModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.springcloud.gateway.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/infrastructure/primary/SpringBootActuatorModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/infrastructure/primary/SpringBootActuatorModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.technicaltools.actuator.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_ACTUATOR;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_ACTUATOR;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/gitinfo/infrastructure/primary/GitInfoModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/gitinfo/infrastructure/primary/GitInfoModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.technicaltools.gitinfo.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.GIT_INFORMATION;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.SPRING_BOOT_ACTUATOR;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.GIT_INFORMATION;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.SPRING_BOOT_ACTUATOR;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/webflux/web/infrastructure/primary/SpringBootWebfluxModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/webflux/web/infrastructure/primary/SpringBootWebfluxModuleConfiguration.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.webflux.web.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteFeatureSlug.SPRING_SERVER;
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.SPRING_SERVER;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/setup/codespaces/infrastructure/primary/CodespaceModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/setup/codespaces/infrastructure/primary/CodespaceModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.setup.codespaces.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/setup/gitpod/infrastructure/primary/GitpodModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/setup/gitpod/infrastructure/primary/GitpodModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.setup.gitpod.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/setup/infinitest/infrastructure/primary/InfinitestModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/setup/infinitest/infrastructure/primary/InfinitestModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.setup.infinitest.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/slug/domain/JHLiteFeatureSlug.java
+++ b/src/main/java/tech/jhipster/lite/generator/slug/domain/JHLiteFeatureSlug.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.generator;
+package tech.jhipster.lite.generator.slug.domain;
 
 import tech.jhipster.lite.module.domain.resource.JHipsterFeatureSlugFactory;
 

--- a/src/main/java/tech/jhipster/lite/generator/slug/domain/JHLiteModuleSlug.java
+++ b/src/main/java/tech/jhipster/lite/generator/slug/domain/JHLiteModuleSlug.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.generator;
+package tech.jhipster.lite.generator.slug.domain;
 
 import java.util.Map;
 import java.util.Optional;

--- a/src/main/java/tech/jhipster/lite/generator/slug/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/slug/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.SharedKernel
+package tech.jhipster.lite.generator.slug;

--- a/src/main/java/tech/jhipster/lite/generator/typescript/core/infrastructure/primary/TypescriptModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/typescript/core/infrastructure/primary/TypescriptModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.typescript.core.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/generator/typescript/optional/infrastructure/primary/OptionalTypescriptModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/typescript/optional/infrastructure/primary/OptionalTypescriptModuleConfiguration.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.typescript.optional.infrastructure.primary;
 
-import static tech.jhipster.lite.generator.JHLiteModuleSlug.*;
+import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;

--- a/src/main/java/tech/jhipster/lite/module/domain/resource/JHipsterModuleOrganization.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/resource/JHipsterModuleOrganization.java
@@ -3,7 +3,7 @@ package tech.jhipster.lite.module.domain.resource;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Optional;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.module.domain.JHipsterFeatureSlug;
 import tech.jhipster.lite.module.domain.landscape.JHipsterFeatureDependency;
 import tech.jhipster.lite.module.domain.landscape.JHipsterLandscapeDependency;

--- a/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
+++ b/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
@@ -2,7 +2,7 @@ package tech.jhipster.lite.statistic.domain.criteria;
 
 import java.time.Instant;
 import java.util.Optional;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 
 /**
  * Criteria class for {@link tech.jhipster.lite.statistic.domain.Statistics}.

--- a/src/main/resources/generator/server/javatool/arch/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/arch/HexagonalArchTest.java.mustache
@@ -160,17 +160,17 @@ class HexagonalArchTest {
     void shouldNotDependOnOutside() {
       classes()
         .that()
-        .resideInAPackage(".domain..")
+        .resideInAPackage("..domain..")
         .should()
         .onlyDependOnClassesThat()
         .resideInAnyPackage(authorizedDomainPackages())
-        .because("Domain model should only depend on himself and a very limited set of external dependencies")
+        .because("Domain model should only depend on domains and a very limited set of external dependencies")
         .check(classes);
     }
 
     private String[] authorizedDomainPackages() {
       return Stream
-        .of(List.of(".domain.."), vanillaPackages, commonToolsAndUtilsPackages, sharedKernelsPackages)
+        .of(List.of("..domain.."), vanillaPackages, commonToolsAndUtilsPackages, sharedKernelsPackages)
         .flatMap(Collection::stream)
         .toArray(String[]::new);
     }

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -161,17 +161,17 @@ class HexagonalArchTest {
     void shouldNotDependOnOutside() {
       classes()
         .that()
-        .resideInAPackage(".domain..")
+        .resideInAPackage("..domain..")
         .should()
         .onlyDependOnClassesThat()
         .resideInAnyPackage(authorizedDomainPackages())
-        .because("Domain model should only depend on himself and a very limited set of external dependencies")
+        .because("Domain model should only depend on domains and a very limited set of external dependencies")
         .check(classes);
     }
 
     private String[] authorizedDomainPackages() {
       return Stream
-        .of(List.of(".domain.."), vanillaPackages, commonToolsAndUtilsPackages, sharedKernelsPackages)
+        .of(List.of("..domain.."), vanillaPackages, commonToolsAndUtilsPackages, sharedKernelsPackages)
         .flatMap(Collection::stream)
         .toArray(String[]::new);
     }

--- a/src/test/java/tech/jhipster/lite/statistic/domain/AppliedModuleFixture.java
+++ b/src/test/java/tech/jhipster/lite/statistic/domain/AppliedModuleFixture.java
@@ -3,7 +3,7 @@ package tech.jhipster.lite.statistic.domain;
 import java.time.Instant;
 import java.util.Map;
 import java.util.UUID;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 
 public final class AppliedModuleFixture {
 

--- a/src/test/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepositoryTest.java
@@ -9,7 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import tech.jhipster.lite.UnitTest;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.statistic.domain.AppliedModule;
 import tech.jhipster.lite.statistic.domain.AppliedModuleFixture;
 import tech.jhipster.lite.statistic.domain.criteria.StatisticsCriteria;

--- a/src/test/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepositoryIT.java
+++ b/src/test/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepositoryIT.java
@@ -18,7 +18,7 @@ import org.springframework.test.context.ActiveProfiles;
 import org.testcontainers.containers.MongoDBContainer;
 import org.testcontainers.utility.DockerImageName;
 import tech.jhipster.lite.IntegrationTest;
-import tech.jhipster.lite.generator.JHLiteModuleSlug;
+import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 import tech.jhipster.lite.statistic.domain.AppliedModule;
 import tech.jhipster.lite.statistic.domain.StatisticsRepository;
 import tech.jhipster.lite.statistic.domain.criteria.StatisticsCriteria;


### PR DESCRIPTION
This fixes the shouldNotDependOnOutside test in HexagonalArchTest.
Before this fix, no classes were included in the filter ".domain..".

This test doesn't validate that a domain class doesn't depend on another domain (but shouldNotDependOnOtherBoundedContextDomains checks it). 

I had to move slugs in a new shared kernel package to make it work.

I've made 2 commits to simplify the code review.