### PR TITLE
Fix: bump org.testcontainers:mongodb from 1.19.1 to 1.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,7 +95,7 @@
     <joox.version>2.0.0</joox.version>
     <dom4j.version>2.1.4</dom4j.version>
     <night-config.version>3.6.7</night-config.version>
-    <testcontainers.version>1.19.1</testcontainers.version>
+    <testcontainers.version>1.19.2</testcontainers.version>
     <mongock.version>5.3.5</mongock.version>
     <git-commit-id-plugin.version>7.0.0</git-commit-id-plugin.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
@@ -268,6 +268,13 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>testcontainers</artifactId>
+      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
 


### PR DESCRIPTION
Fix #8050 

⚠️  Not sure if it is the best solution