### PR TITLE
Revert "Upgrade JHLite Engine to Spring Boot 3.2.0-RC2"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -9,28 +9,8 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>3.2.0-RC2</version>
+    <version>3.1.5</version>
   </parent>
-  <repositories>
-    <repository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </repository>
-  </repositories>
-  <pluginRepositories>
-    <pluginRepository>
-      <id>spring-milestones</id>
-      <name>Spring Milestones</name>
-      <url>https://repo.spring.io/milestone</url>
-      <snapshots>
-        <enabled>false</enabled>
-      </snapshots>
-    </pluginRepository>
-  </pluginRepositories>
 
   <groupId>tech.jhipster.lite</groupId>
   <artifactId>jhlite</artifactId>


### PR DESCRIPTION
Reverts jhipster/jhipster-lite#7937

As discussed with @murdos, it's not a good idea to use RC version, because we can have some issue with corporate artifactory