### PR TITLE
Fix: bump org.testcontainers:mongodb from 1.19.1 to 1.19.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <joox.version>2.0.0</joox.version>
     <dom4j.version>2.1.4</dom4j.version>
     <night-config.version>3.6.7</night-config.version>
-    <testcontainers.version>1.19.1</testcontainers.version>
+    <testcontainers.version>1.19.2</testcontainers.version>
     <mongock.version>5.3.5</mongock.version>
     <git-commit-id-plugin.version>7.0.0</git-commit-id-plugin.version>
     <maven-checkstyle-plugin.version>3.3.1</maven-checkstyle-plugin.version>
@@ -91,6 +91,13 @@
         <groupId>io.mongock</groupId>
         <artifactId>mongock-bom</artifactId>
         <version>${mongock.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>${testcontainers.version}</version>
         <scope>import</scope>
         <type>pom</type>
       </dependency>
@@ -254,7 +261,6 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
-      <version>${testcontainers.version}</version>
       <scope>test</scope>
     </dependency>
   </dependencies>


### PR DESCRIPTION
Since we're using our own version of testcontainers, and not the one managed by spring-boot-dependencies, we should use the testcontainers bom to make sure all testcontainers dependencies are aligned

Before the fix:
![image](https://github.com/jhipster/jhipster-lite/assets/155828/d7e2f454-25d3-4993-9b48-2a296ec0a5a3)
