### PR TITLE
Vue: Upgrade Vite 5.0.0

### DIFF
--- a/src/main/resources/generator/client/vue/tsconfig.json
+++ b/src/main/resources/generator/client/vue/tsconfig.json
@@ -6,6 +6,7 @@
     "moduleResolution": "node",
     "strict": true,
     "jsx": "preserve",
+    "skipLibCheck": true,
     "sourceMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,

--- a/src/main/resources/generator/dependencies/vue/package.json
+++ b/src/main/resources/generator/dependencies/vue/package.json
@@ -25,7 +25,7 @@
     "jsdom": "22.1.0",
     "sinon": "17.0.1",
     "typescript": "5.2.2",
-    "vite": "4.5.0",
+    "vite": "5.0.0",
     "vitest": "0.34.6",
     "vitest-sonar-reporter": "0.5.0",
     "vue-tsc": "1.8.22"


### PR DESCRIPTION
Update `tsconfig.json` to fix:
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/5dd23dda-4e51-43e0-8462-69a208ceade8)

When we generate an app with `npm create vite@latest`, this `"skipLibCheck": true` property is present by default