### PR TITLE
awaitility is now included in spring-boot-starter-test

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -253,12 +253,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.awaitility</groupId>
-      <artifactId>awaitility</artifactId>
-      <scope>test</scope>
-    </dependency>
-
-    <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>mongodb</artifactId>
       <scope>test</scope>

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
@@ -50,17 +50,10 @@ public class CucumberModuleFactory {
         .addTemplate("SyncResponseAsserter.java")
         .and()
       .add(SOURCE.file("gitkeep"), to("src/test/features/.gitkeep"))
-      .and()
-    .javaDependencies()
-      .addDependency(awaitilityDependency())
       .and();
     //@formatter:on
 
     return builder.build();
-  }
-
-  private JavaDependency awaitilityDependency() {
-    return javaDependency().groupId("org.awaitility").artifactId("awaitility").scope(JavaDependencyScope.TEST).build();
   }
 
   public JHipsterModule buildJpaResetModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
@@ -6,8 +6,6 @@ import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
-import tech.jhipster.lite.module.domain.javadependency.JavaDependency;
-import tech.jhipster.lite.module.domain.javadependency.JavaDependencyScope;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.shared.error.domain.Assert;
 

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -196,11 +196,6 @@
         <scope>test</scope>
       </dependency>
       <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
         <groupId>org.liquibase</groupId>
         <artifactId>liquibase-core</artifactId>
         <version>${liquibase.version}</version>

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactoryTest.java
@@ -54,7 +54,6 @@ class CucumberModuleFactoryTest {
       .containing("<artifactId>cucumber-java</artifactId>")
       .containing("<artifactId>cucumber-spring</artifactId>")
       .containing("<artifactId>junit-platform-suite</artifactId>")
-      .containing("<artifactId>awaitility</artifactId>")
       .containing("<version>${cucumber.version}</version>")
       .and()
       .doNotHaveFiles("src/test/java/com/jhipster/test/cucumber/CucumberJpaReset.java");


### PR DESCRIPTION
Since Spring Boot 3.2. So there's no need anymore to declare it explicitly