### PR TITLE
Move all Cucumber REST tooling in a dedicated sub-package

### DIFF
--- a/documentation/cucumber.md
+++ b/documentation/cucumber.md
@@ -15,7 +15,7 @@ Feature: Simple WebService test
 You'll then have to define the glue code:
 
 ```java
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.*;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/documentation/cucumber.md
+++ b/documentation/cucumber.md
@@ -82,9 +82,9 @@ public void shouldGetResponseContent(List<Map<String, Object>> responses) {
 Sometimes you may want to access the last response content without asserting it, you can do:
 
 ```java
-CucumberTestContext.getElement("$.path");
-CucumberTestContext.getElement("uri-path", "$.path");
-CucumberTestContext.countEntries("$.path");
+CucumberRestTestContext.getElement("$.path");
+CucumberRestTestContext.getElement("uri-path", "$.path");
+CucumberRestTestContext.countEntries("$.path");
 ```
 
 ## Async services

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactory.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.cucumber.domain;
 
-import static tech.jhipster.lite.generator.server.springboot.cucumbercommon.domain.CucumbersModules.*;
+import static tech.jhipster.lite.generator.server.springboot.cucumbercommon.domain.CucumbersModules.cucumberModuleBuilder;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
@@ -27,17 +27,19 @@ public class CucumberModuleFactory {
     .documentation(documentationTitle("Cucumber"), SOURCE.template("cucumber.md"))
     .files()
       .batch(SOURCE, destination)
+        .addTemplate("CucumberConfiguration.java")
+        .addTemplate("CucumberTest.java")
+        .and()
+      .batch(SOURCE.append("rest"), destination.append("rest"))
         .addTemplate("AsyncElementAsserter.java")
         .addTemplate("AsyncHeaderAsserter.java")
         .addTemplate("AsyncResponseAsserter.java")
         .addTemplate("Awaiter.java")
-        .addTemplate("CucumberAssertions.java")
+        .addTemplate("CucumberRestAssertions.java")
         .addTemplate("CucumberRestTemplate.java")
-        .addTemplate("CucumberConfiguration.java")
         .addTemplate("CucumberJson.java")
-        .addTemplate("CucumberTest.java")
-        .addTemplate("CucumberTestContext.java")
-        .addTemplate("CucumberTestContextUnitTest.java")
+        .addTemplate("CucumberRestTestContext.java")
+        .addTemplate("CucumberRestTestContextUnitTest.java")
         .addTemplate("ElementAsserter.java")
         .addTemplate("ElementAssertions.java")
         .addTemplate("HeaderAsserter.java")

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/customjhlite/domain/CustomJHLiteModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/customjhlite/domain/CustomJHLiteModuleFactory.java
@@ -66,7 +66,7 @@ public class CustomJHLiteModuleFactory {
       .files()
         .add(SOURCE.template("CucumberTest.java"), cucumberDestination.append("CucumberTest.java"))
         .add(SOURCE.template("CucumberConfiguration.java"), cucumberDestination.append("CucumberConfiguration.java"))
-        .add(CUCUMBER_SOURCE.template("CucumberRestTemplate.java"), cucumberDestination.append("CucumberRestTemplate.java"))
+        .add(CUCUMBER_SOURCE.append("rest").template("CucumberRestTemplate.java"), cucumberDestination.append("rest").append("CucumberRestTemplate.java"))
         .add(CUCUMBER_SOURCE.file("gitkeep"), to("src/test/features/.gitkeep"))
         .and()
       .build();

--- a/src/main/resources/generator/server/springboot/cucumber/CucumberConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/CucumberConfiguration.java.mustache
@@ -20,6 +20,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import {{packageName}}.{{ baseName }}App;
 import {{packageName}}.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
+import {{packageName}}.cucumber.rest.CucumberRestTemplate;
+import {{packageName}}.cucumber.rest.CucumberTestContext;
 
 @ActiveProfiles("test")
 @CucumberContextConfiguration
@@ -31,7 +33,7 @@ public class CucumberConfiguration {
 
   @Before
   public void resetTestContext() {
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
   }
 
   @Before
@@ -48,7 +50,7 @@ public class CucumberConfiguration {
     return (request, body, execution) -> {
       ClientHttpResponse response = execution.execute(request, body);
 
-      CucumberTestContext.addResponse(request, response, execution, body);
+      CucumberRestTestContext.addResponse(request, response, execution, body);
 
       return response;
     };

--- a/src/main/resources/generator/server/springboot/cucumber/CucumberConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/CucumberConfiguration.java.mustache
@@ -21,7 +21,7 @@ import org.springframework.test.context.ActiveProfiles;
 import {{packageName}}.{{ baseName }}App;
 import {{packageName}}.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
 import {{packageName}}.cucumber.rest.CucumberRestTemplate;
-import {{packageName}}.cucumber.rest.CucumberTestContext;
+import {{packageName}}.cucumber.rest.CucumberRestTestContext;
 
 @ActiveProfiles("test")
 @CucumberContextConfiguration

--- a/src/main/resources/generator/server/springboot/cucumber/cucumber.md.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/cucumber.md.mustache
@@ -15,7 +15,7 @@ Feature: Simple WebService test
 You'll then have to define the glue code:
 
 ```java
-import static {{packageName}}.cucumber.CucumberAssertions.*;
+import static {{packageName}}.cucumber.rest.CucumberRestAssertions.*;
 
 import {{packageName}}.cucumber.CucumberRestTemplate;
 import io.cucumber.java.en.Then;
@@ -86,9 +86,9 @@ public void shouldGetResponseContent(List<Map<String, Object>> responses) {
 Sometimes you may want to access the last response content without asserting it, you can do:
 
 ```java
-CucumberTestContext.getElement("$.path");
-CucumberTestContext.getElement("uri-path", "$.path");
-CucumberTestContext.countEntries("$.path");
+CucumberRestTestContext.getElement("$.path");
+CucumberRestTestContext.getElement("uri-path", "$.path");
+CucumberRestTestContext.countEntries("$.path");
 ```
 
 ## Async services

--- a/src/main/resources/generator/server/springboot/cucumber/rest/AsyncElementAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/AsyncElementAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.time.Duration;
 import java.util.Collection;

--- a/src/main/resources/generator/server/springboot/cucumber/rest/AsyncHeaderAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/AsyncHeaderAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.time.Duration;
 

--- a/src/main/resources/generator/server/springboot/cucumber/rest/AsyncResponseAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/AsyncResponseAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -15,14 +15,14 @@ class AsyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public AsyncResponseAsserter hasHttpStatus(HttpStatus status) {
-    Awaiter.await(maxTime, () -> CucumberAssertions.assertHttpStatus(status));
+    Awaiter.await(maxTime, () -> CucumberRestAssertions.assertHttpStatus(status));
 
     return this;
   }
 
   @Override
   public ResponseAsserter hasHttpStatusIn(HttpStatus... statuses) {
-    Awaiter.await(maxTime, () -> CucumberAssertions.assertHttpStatusIn(statuses));
+    Awaiter.await(maxTime, () -> CucumberRestAssertions.assertHttpStatusIn(statuses));
 
     return this;
   }
@@ -39,7 +39,7 @@ class AsyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public AsyncResponseAsserter hasRawBody(String info) {
-    Awaiter.await(maxTime, () -> assertThat(CucumberAssertions.responseBody()).isEqualTo(info));
+    Awaiter.await(maxTime, () -> assertThat(CucumberRestAssertions.responseBody()).isEqualTo(info));
 
     return this;
   }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/Awaiter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/Awaiter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.time.Duration;
 import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
@@ -15,7 +15,7 @@ class Awaiter {
         try {
           assertion.run();
         } catch (AssertionError e) {
-          CucumberTestContext.retry();
+          CucumberRestTestContext.retry();
 
           assertion.run();
         }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberJson.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberJson.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestAssertions.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestAssertions.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -8,11 +8,11 @@ import java.util.stream.Stream;
 import org.assertj.core.description.Description;
 import org.springframework.http.HttpStatus;
 
-public final class CucumberAssertions {
+public final class CucumberRestAssertions {
 
   private static final CallDescription JSON_DESCRIPTION = new CallDescription();
 
-  private CucumberAssertions() {}
+  private CucumberRestAssertions() {}
 
   public static ResponseAsserter assertThatLastResponse() {
     return new SyncResponseAsserter();
@@ -29,20 +29,20 @@ public final class CucumberAssertions {
   }
 
   static void assertHttpStatus(HttpStatus status) {
-    assertThat(CucumberTestContext.getStatus())
-      .as(() -> "Expecting request to result in " + status + " but got " + CucumberTestContext.getStatus() + callContext())
+    assertThat(CucumberRestTestContext.getStatus())
+      .as(() -> "Expecting request to result in " + status + " but got " + CucumberRestTestContext.getStatus() + callContext())
       .isEqualTo(status);
   }
 
   static void assertHttpStatusIn(HttpStatus[] statuses) {
     assertThat(statuses).as("Can't check statuses without statuses").isNotEmpty();
 
-    assertThat(CucumberTestContext.getStatus())
+    assertThat(CucumberRestTestContext.getStatus())
       .as(() ->
         "Expecting request to result in any of " +
         Stream.of(statuses).map(HttpStatus::toString).collect(Collectors.joining(", ")) +
         " but got " +
-        CucumberTestContext.getStatus() +
+        CucumberRestTestContext.getStatus() +
         callContext()
       )
       .isIn((Object[]) statuses);
@@ -53,7 +53,7 @@ public final class CucumberAssertions {
   }
 
   static String responseBody() {
-    return CucumberTestContext.getResponse().get();
+    return CucumberRestTestContext.getResponse().get();
   }
 
   private static class CallDescription extends Description {
@@ -62,10 +62,10 @@ public final class CucumberAssertions {
     public String value() {
       return (
         " from " +
-        CucumberTestContext.getUri() +
+        CucumberRestTestContext.getUri() +
         " in " +
         System.lineSeparator() +
-        CucumberTestContext.getResponse().map(CucumberJson::pretty).orElse("empty")
+        CucumberRestTestContext.getResponse().map(CucumberJson::pretty).orElse("empty")
       );
     }
   }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTemplate.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTemplate.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.util.List;
 import org.springframework.boot.test.web.client.TestRestTemplate;
@@ -30,7 +30,7 @@ public class CucumberRestTemplate {
   public void delete(String uri) {
     rest.delete(uri);
   }
-  
+
   public TestRestTemplate template() {
     return rest;
   }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContext.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContext.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
@@ -24,12 +24,12 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StreamUtils;
 
-public final class CucumberTestContext {
+public final class CucumberRestTestContext {
 
   private static final Deque<RestQuery> queries = new ConcurrentLinkedDeque<>();
   private static final JsonProvider jsonReader = Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS).jsonProvider();
 
-  private CucumberTestContext() {}
+  private CucumberRestTestContext() {}
 
   public static void addResponse(HttpRequest request, ClientHttpResponse response, ClientHttpRequestExecution execution, byte[] body) {
     queries.addFirst(new RestQuery(request, response, execution, body));
@@ -194,7 +194,7 @@ public final class CucumberTestContext {
       try {
         ClientHttpResponse response = execution.execute(request, body);
 
-        CucumberTestContext.addResponse(request, response, execution, body);
+        CucumberRestTestContext.addResponse(request, response, execution, body);
       } catch (IOException e) {
         throw new AssertionError("Error while retrying last call: " + e.getMessage(), e);
       }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContextUnitTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContextUnitTest.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
@@ -22,39 +22,39 @@ class CucumberTestContextUnitTest {
   void shouldGetQueryInformation() {
     addQuery("{}");
 
-    assertThat(CucumberTestContext.getStatus()).isEqualTo(HttpStatus.OK);
-    assertThat(CucumberTestContext.getUri()).isEqualTo("http://localhost/");
-    assertThat(CucumberTestContext.getResponse()).contains("{}");
+    assertThat(CucumberRestTestContext.getStatus()).isEqualTo(HttpStatus.OK);
+    assertThat(CucumberRestTestContext.getUri()).isEqualTo("http://localhost/");
+    assertThat(CucumberRestTestContext.getResponse()).contains("{}");
   }
 
   @Test
   void shouldResetTestContext() {
     addQuery("{}");
 
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
 
-    assertThatThrownBy(() -> CucumberTestContext.getResponse()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("empty");
+    assertThatThrownBy(() -> CucumberRestTestContext.getResponse()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("empty");
   }
 
   @Test
   void shouldGetZeroEntriesForUnknownPath() {
     addQuery("{}");
 
-    assertThat(CucumberTestContext.countEntries("$.dummy")).isZero();
+    assertThat(CucumberRestTestContext.countEntries("$.dummy")).isZero();
   }
 
   @Test
   void shouldGetNulForUnknownElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.getElement("dummy")).isNull();
+    assertThat(CucumberRestTestContext.getElement("dummy")).isNull();
   }
 
   @Test
   void shouldGetElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.getElement("element")).isEqualTo("value");
+    assertThat(CucumberRestTestContext.getElement("element")).isEqualTo("value");
   }
 
   @Test
@@ -64,28 +64,28 @@ class CucumberTestContextUnitTest {
     addQuery("/dumm", "{\"element\":\"dd\"}");
     addQuery("/employees", "{\"element\":\"test\"}");
 
-    assertThat(CucumberTestContext.getElement("dummies", "element")).isEqualTo("value");
+    assertThat(CucumberRestTestContext.getElement("dummies", "element")).isEqualTo("value");
   }
 
   @Test
   void shouldGetOneEntryForSingleElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isEqualTo(1);
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isEqualTo(1);
   }
 
   @Test
   void shouldGetZeroEntryForEmptyArray() {
     addQuery("{\"element\":[]}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isZero();
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isZero();
   }
 
   @Test
   void shouldGetArraySize() {
     addQuery("{\"element\":[{\"key\":\"value\"},{\"key\":\"value\"}]}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isEqualTo(2);
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isEqualTo(2);
   }
 
   @Test
@@ -98,7 +98,7 @@ class CucumberTestContextUnitTest {
     }
 
     assertThatThrownBy(() ->
-        CucumberTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes())
+        CucumberRestTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes())
       )
       .isExactlyInstanceOf(AssertionError.class);
   }
@@ -113,9 +113,9 @@ class CucumberTestContextUnitTest {
       fail(e.getMessage());
     }
 
-    CucumberTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
+    CucumberRestTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
 
-    assertThat(CucumberTestContext.getResponse()).isEmpty();
+    assertThat(CucumberRestTestContext.getResponse()).isEmpty();
   }
 
   @Test
@@ -126,9 +126,9 @@ class CucumberTestContextUnitTest {
     HttpRequest request = mockedRequest("/");
     when(execution.execute(request, body)).thenThrow(IOException.class);
 
-    CucumberTestContext.addResponse(request, mockedResponse("response"), execution, body);
+    CucumberRestTestContext.addResponse(request, mockedResponse("response"), execution, body);
 
-    assertThatThrownBy(() -> CucumberTestContext.retry()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("retrying");
+    assertThatThrownBy(() -> CucumberRestTestContext.retry()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("retrying");
   }
 
   private void addQuery(String response) {
@@ -138,7 +138,7 @@ class CucumberTestContextUnitTest {
   private void addQuery(String path, String response) {
     ClientHttpResponse httpResponse = mockedResponse(response);
 
-    CucumberTestContext.addResponse(mockedRequest(path), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
+    CucumberRestTestContext.addResponse(mockedRequest(path), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
   }
 
   private ClientHttpResponse mockedResponse(String response) {

--- a/src/main/resources/generator/server/springboot/cucumber/rest/ElementAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/ElementAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 

--- a/src/main/resources/generator/server/springboot/cucumber/rest/ElementAssertions.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/ElementAssertions.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -14,7 +14,7 @@ class ElementAssertions {
   public ElementAssertions(String jsonPath) {
     this.jsonPath = buildJsonPath(jsonPath);
 
-    assertThat(CucumberTestContext.getElement(this.jsonPath)).as("Can't find " + this.jsonPath + " in response").isNotNull();
+    assertThat(CucumberRestTestContext.getElement(this.jsonPath)).as("Can't find " + this.jsonPath + " in response").isNotNull();
   }
 
   private String buildJsonPath(String jsonPath) {
@@ -41,18 +41,18 @@ class ElementAssertions {
   }
 
   void withElementsCount(int count) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
     assertThat(elementsCount)
-      .as("Expecting " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberAssertions.callContext())
+      .as("Expecting " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberRestAssertions.callContext())
       .isEqualTo(count);
   }
 
   void withMoreThanElementsCount(int count) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
     assertThat(elementsCount)
-      .as("Expecting at least " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberAssertions.callContext())
+      .as("Expecting at least " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberRestAssertions.callContext())
       .isGreaterThanOrEqualTo(count);
   }
 
@@ -71,7 +71,7 @@ class ElementAssertions {
   void withValues(Collection<String> values) {
     assertThat(values).as("Can't check object against null values").isNotNull();
 
-    Object responseValue = CucumberTestContext.getElement(jsonPath);
+    Object responseValue = CucumberRestTestContext.getElement(jsonPath);
 
     if (!(responseValue instanceof JSONArray)) {
       fail(jsonPath + " is not an array");
@@ -79,19 +79,19 @@ class ElementAssertions {
 
     JSONArray array = (JSONArray) responseValue;
     assertThat(array)
-      .as("Expecting " + jsonPath + " to contain " + values + " but got " + responseValue + CucumberAssertions.callContext())
+      .as("Expecting " + jsonPath + " to contain " + values + " but got " + responseValue + CucumberRestAssertions.callContext())
       .containsExactlyElementsOf(values);
   }
 
   private void assertPathValue(String jsonPath, Object value) {
-    Object responseValue = CucumberTestContext.getElement(jsonPath);
+    Object responseValue = CucumberRestTestContext.getElement(jsonPath);
 
     if (responseValue != null && value instanceof String && !(responseValue instanceof String)) {
       responseValue = responseValue.toString();
     }
 
     assertThat(responseValue)
-      .as("Expecting " + jsonPath + " to contain " + value + " but got " + responseValue + CucumberAssertions.callContext())
+      .as("Expecting " + jsonPath + " to contain " + value + " but got " + responseValue + CucumberRestAssertions.callContext())
       .isEqualTo(value);
   }
 }

--- a/src/main/resources/generator/server/springboot/cucumber/rest/HeaderAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/HeaderAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 public interface HeaderAsserter<T extends ResponseAsserter> {
   HeaderAsserter<T> containing(String value);

--- a/src/main/resources/generator/server/springboot/cucumber/rest/HeaderAssertions.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/HeaderAssertions.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -12,18 +12,18 @@ class HeaderAssertions {
   HeaderAssertions(String header) {
     this.header = header;
 
-    assertThat(CucumberTestContext.getResponseHeader(header)).as("Can't find header " + header).isNotEmpty();
+    assertThat(CucumberRestTestContext.getResponseHeader(header)).as("Can't find header " + header).isNotEmpty();
   }
 
   public void containing(String value) {
-    List<String> values = CucumberTestContext.getResponseHeader(header);
+    List<String> values = CucumberRestTestContext.getResponseHeader(header);
     assertThat(values)
       .as("Expecting header " + header + " to contain " + value + " but can't find it, current values are " + displayValues(values))
       .contains(value);
   }
 
   public void startingWith(String prefix) {
-    List<String> values = CucumberTestContext.getResponseHeader(header);
+    List<String> values = CucumberRestTestContext.getResponseHeader(header);
 
     assertThat(values)
       .as("Expecting header " + header + " to start with " + prefix + " but can't find it, current values are " + displayValues(values))

--- a/src/main/resources/generator/server/springboot/cucumber/rest/ResponseAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/ResponseAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.util.stream.Stream;
 import org.springframework.http.HttpStatus;

--- a/src/main/resources/generator/server/springboot/cucumber/rest/SyncElementAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/SyncElementAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/resources/generator/server/springboot/cucumber/rest/SyncHeaderAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/SyncHeaderAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 class SyncHeaderAsserter implements HeaderAsserter<SyncResponseAsserter> {
 

--- a/src/main/resources/generator/server/springboot/cucumber/rest/SyncResponseAsserter.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/SyncResponseAsserter.java.mustache
@@ -1,4 +1,4 @@
-package {{packageName}}.cucumber;
+package {{packageName}}.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
 
@@ -8,14 +8,14 @@ class SyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public SyncResponseAsserter hasHttpStatus(HttpStatus status) {
-    CucumberAssertions.assertHttpStatus(status);
+    CucumberRestAssertions.assertHttpStatus(status);
 
     return this;
   }
 
   @Override
   public ResponseAsserter hasHttpStatusIn(HttpStatus... statuses) {
-    CucumberAssertions.assertHttpStatusIn(statuses);
+    CucumberRestAssertions.assertHttpStatusIn(statuses);
 
     return this;
   }
@@ -31,16 +31,16 @@ class SyncResponseAsserter implements ResponseAsserter {
   }
 
   public SyncResponseAsserter doNotHaveElement(String jsonPath) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
-    assertThat(elementsCount).as("Expecting " + jsonPath + " to not exists " + CucumberAssertions.callContext()).isZero();
+    assertThat(elementsCount).as("Expecting " + jsonPath + " to not exists " + CucumberRestAssertions.callContext()).isZero();
 
     return this;
   }
 
   @Override
   public SyncResponseAsserter hasRawBody(String info) {
-    assertThat(CucumberAssertions.responseBody()).isEqualTo(info);
+    assertThat(CucumberRestAssertions.responseBody()).isEqualTo(info);
 
     return this;
   }

--- a/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
@@ -18,7 +18,7 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
-import tech.jhipster.lite.cucumber.CucumberTestContext;
+import tech.jhipster.lite.cucumber.rest.CucumberRestTestContext;
 
 import {{packageName}}.{{ baseName }}App;
 import {{packageName}}.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;

--- a/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
@@ -18,12 +18,11 @@ import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
 
-import tech.jhipster.lite.cucumber.rest.CucumberRestTestContext;
+import tech.jhipster.lite.cucumber.CucumberTestContext;
 
 import {{packageName}}.{{ baseName }}App;
 import {{packageName}}.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
 import {{packageName}}.cucumber.rest.CucumberRestTemplate;
-import {{packageName}}.cucumber.rest.CucumberRestTestContext;
 
 @CucumberContextConfiguration
 @SpringBootTest(classes = { {{ baseName }}App.class, CucumberRestTemplateConfiguration.class }, webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -34,7 +33,7 @@ public class CucumberConfiguration {
 
   @Before
   public void resetTestContext() {
-    CucumberRestTestContext.reset();
+    CucumberTestContext.reset();
   }
 
   @Before
@@ -51,7 +50,7 @@ public class CucumberConfiguration {
     return (request, body, execution) -> {
       ClientHttpResponse response = execution.execute(request, body);
 
-      CucumberRestTestContext.addResponse(request, response, execution, body);
+      CucumberTestContext.addResponse(request, response, execution, body);
 
       return response;
     };

--- a/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/custom-jhlite/CucumberConfiguration.java.mustache
@@ -22,6 +22,8 @@ import tech.jhipster.lite.cucumber.rest.CucumberRestTestContext;
 
 import {{packageName}}.{{ baseName }}App;
 import {{packageName}}.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
+import {{packageName}}.cucumber.rest.CucumberRestTemplate;
+import {{packageName}}.cucumber.rest.CucumberRestTestContext;
 
 @CucumberContextConfiguration
 @SpringBootTest(classes = { {{ baseName }}App.class, CucumberRestTemplateConfiguration.class }, webEnvironment = WebEnvironment.RANDOM_PORT)
@@ -32,7 +34,7 @@ public class CucumberConfiguration {
 
   @Before
   public void resetTestContext() {
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
   }
 
   @Before
@@ -49,7 +51,7 @@ public class CucumberConfiguration {
     return (request, body, execution) -> {
       ClientHttpResponse response = execution.execute(request, body);
 
-      CucumberTestContext.addResponse(request, response, execution, body);
+      CucumberRestTestContext.addResponse(request, response, execution, body);
 
       return response;
     };

--- a/src/main/resources/generator/server/springboot/mvc/dummy/feature/test/HttpSteps.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/feature/test/HttpSteps.java.mustache
@@ -1,6 +1,6 @@
 package {{packageName}};
 
-import static {{packageName}}.cucumber.CucumberAssertions.*;
+import static {{packageName}}.cucumber.rest.CucumberRestAssertions.*;
 
 import org.springframework.http.HttpStatus;
 

--- a/src/main/resources/generator/server/springboot/mvc/dummy/feature/test/dummy/infrastructure/primary/beer/BeersSteps.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/dummy/feature/test/dummy/infrastructure/primary/beer/BeersSteps.java.mustache
@@ -1,9 +1,9 @@
 package {{packageName}}.dummy.infrastructure.primary.beer;
 
-import static {{packageName}}.cucumber.CucumberAssertions.*;
+import static {{packageName}}.cucumber.rest.CucumberRestAssertions.*;
 
-import {{packageName}}.cucumber.CucumberRestTemplate;
-import {{packageName}}.cucumber.CucumberTestContext;
+import {{packageName}}.cucumber.rest.CucumberRestTemplate;
+import {{packageName}}.cucumber.rest.CucumberRestTestContext;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
 import java.util.List;
@@ -31,7 +31,7 @@ public class BeersSteps {
 
   @When("I remove the created beer from the catalog")
   public void removeCreatedBeerFromCatalog() {
-    rest.delete("/api/beers/" + CucumberTestContext.getElement("$.id"));
+    rest.delete("/api/beers/" + CucumberRestTestContext.getElement("$.id"));
   }
 
   @Then("I should have beers catalog")

--- a/src/test/java/tech/jhipster/lite/cucumber/CucumberConfiguration.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/CucumberConfiguration.java
@@ -17,6 +17,7 @@ import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.web.client.RestTemplate;
 import tech.jhipster.lite.JHLiteApp;
+import tech.jhipster.lite.cucumber.rest.CucumberRestTestContext;
 import tech.jhipster.lite.project.infrastructure.secondary.MockedProjectFormatterConfiguration;
 
 @ActiveProfiles("test")
@@ -29,7 +30,7 @@ public class CucumberConfiguration {
 
   @Before
   public void resetTestContext() {
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
   }
 
   @Before
@@ -46,7 +47,7 @@ public class CucumberConfiguration {
     return (request, body, execution) -> {
       ClientHttpResponse response = execution.execute(request, body);
 
-      CucumberTestContext.addResponse(request, response, execution, body);
+      CucumberRestTestContext.addResponse(request, response, execution, body);
 
       return response;
     };

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncElementAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncElementAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import java.time.Duration;
 import java.util.Collection;

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncHeaderAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncHeaderAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import java.time.Duration;
 

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncResponseAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncResponseAsserter.java
@@ -1,6 +1,6 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import org.springframework.http.HttpStatus;
@@ -15,14 +15,14 @@ class AsyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public AsyncResponseAsserter hasHttpStatus(HttpStatus status) {
-    Awaiter.await(maxTime, () -> CucumberAssertions.assertHttpStatus(status));
+    Awaiter.await(maxTime, () -> CucumberRestAssertions.assertHttpStatus(status));
 
     return this;
   }
 
   @Override
   public ResponseAsserter hasHttpStatusIn(HttpStatus... statuses) {
-    Awaiter.await(maxTime, () -> CucumberAssertions.assertHttpStatusIn(statuses));
+    Awaiter.await(maxTime, () -> CucumberRestAssertions.assertHttpStatusIn(statuses));
 
     return this;
   }
@@ -39,7 +39,7 @@ class AsyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public AsyncResponseAsserter hasRawBody(String info) {
-    Awaiter.await(maxTime, () -> assertThat(CucumberAssertions.responseBody()).isEqualTo(info));
+    Awaiter.await(maxTime, () -> assertThat(CucumberRestAssertions.responseBody()).isEqualTo(info));
 
     return this;
   }

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/Awaiter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/Awaiter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import java.time.Duration;
 import org.assertj.core.api.SoftAssertionsProvider.ThrowingRunnable;
@@ -15,7 +15,7 @@ class Awaiter {
         try {
           assertion.run();
         } catch (AssertionError e) {
-          CucumberTestContext.retry();
+          CucumberRestTestContext.retry();
 
           assertion.run();
         }

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberJson.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberJson.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.DeserializationFeature;

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestAssertions.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestAssertions.java
@@ -1,18 +1,19 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Duration;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.description.Description;
 import org.springframework.http.HttpStatus;
 
-public final class CucumberAssertions {
+public final class CucumberRestAssertions {
 
   private static final CallDescription JSON_DESCRIPTION = new CallDescription();
 
-  private CucumberAssertions() {}
+  private CucumberRestAssertions() {}
 
   public static ResponseAsserter assertThatLastResponse() {
     return new SyncResponseAsserter();
@@ -29,20 +30,21 @@ public final class CucumberAssertions {
   }
 
   static void assertHttpStatus(HttpStatus status) {
-    assertThat(CucumberTestContext.getStatus())
-      .as(() -> "Expecting request to result in " + status + " but got " + CucumberTestContext.getStatus() + callContext())
+    Assertions
+      .assertThat(CucumberRestTestContext.getStatus())
+      .as(() -> "Expecting request to result in " + status + " but got " + CucumberRestTestContext.getStatus() + callContext())
       .isEqualTo(status);
   }
 
   static void assertHttpStatusIn(HttpStatus[] statuses) {
     assertThat(statuses).as("Can't check statuses without statuses").isNotEmpty();
 
-    assertThat(CucumberTestContext.getStatus())
+    assertThat(CucumberRestTestContext.getStatus())
       .as(() ->
         "Expecting request to result in any of " +
         Stream.of(statuses).map(HttpStatus::toString).collect(Collectors.joining(", ")) +
         " but got " +
-        CucumberTestContext.getStatus() +
+        CucumberRestTestContext.getStatus() +
         callContext()
       )
       .isIn((Object[]) statuses);
@@ -53,7 +55,7 @@ public final class CucumberAssertions {
   }
 
   static String responseBody() {
-    return CucumberTestContext.getResponse().get();
+    return CucumberRestTestContext.getResponse().get();
   }
 
   private static class CallDescription extends Description {
@@ -62,10 +64,10 @@ public final class CucumberAssertions {
     public String value() {
       return (
         " from " +
-        CucumberTestContext.getUri() +
+        CucumberRestTestContext.getUri() +
         " in " +
         System.lineSeparator() +
-        CucumberTestContext.getResponse().map(CucumberJson::pretty).orElse("empty")
+        CucumberRestTestContext.getResponse().map(CucumberJson::pretty).orElse("empty")
       );
     }
   }

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestTestContext.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestTestContext.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import com.jayway.jsonpath.Configuration;
 import com.jayway.jsonpath.JsonPath;
@@ -9,7 +9,11 @@ import java.io.IOException;
 import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentLinkedDeque;
 import java.util.function.Function;
 import net.minidev.json.JSONArray;
@@ -22,12 +26,12 @@ import org.springframework.http.client.ClientHttpRequestExecution;
 import org.springframework.http.client.ClientHttpResponse;
 import org.springframework.util.StreamUtils;
 
-public final class CucumberTestContext {
+public final class CucumberRestTestContext {
 
   private static final Deque<RestQuery> queries = new ConcurrentLinkedDeque<>();
   private static final JsonProvider jsonReader = Configuration.defaultConfiguration().addOptions(Option.SUPPRESS_EXCEPTIONS).jsonProvider();
 
-  private CucumberTestContext() {}
+  private CucumberRestTestContext() {}
 
   public static void addResponse(HttpRequest request, ClientHttpResponse response, ClientHttpRequestExecution execution, byte[] body) {
     queries.addFirst(new RestQuery(request, response, execution, body));
@@ -194,7 +198,7 @@ public final class CucumberTestContext {
       try {
         ClientHttpResponse response = execution.execute(request, body);
 
-        CucumberTestContext.addResponse(request, response, execution, body);
+        CucumberRestTestContext.addResponse(request, response, execution, body);
       } catch (IOException e) {
         throw new AssertionError("Error while retrying last call: " + e.getMessage(), e);
       }

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestTestContextUnitTest.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestTestContextUnitTest.java
@@ -1,7 +1,8 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
@@ -15,45 +16,45 @@ import org.springframework.http.client.ClientHttpResponse;
 import tech.jhipster.lite.UnitTest;
 
 @UnitTest
-class CucumberTestContextUnitTest {
+class CucumberRestTestContextUnitTest {
 
   @Test
   void shouldGetQueryInformation() {
     addQuery("{}");
 
-    assertThat(CucumberTestContext.getStatus()).isEqualTo(HttpStatus.OK);
-    assertThat(CucumberTestContext.getUri()).isEqualTo("http://localhost/");
-    assertThat(CucumberTestContext.getResponse()).contains("{}");
+    assertThat(CucumberRestTestContext.getStatus()).isEqualTo(HttpStatus.OK);
+    assertThat(CucumberRestTestContext.getUri()).isEqualTo("http://localhost/");
+    assertThat(CucumberRestTestContext.getResponse()).contains("{}");
   }
 
   @Test
   void shouldResetTestContext() {
     addQuery("{}");
 
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
 
-    assertThatThrownBy(() -> CucumberTestContext.getResponse()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("empty");
+    assertThatThrownBy(() -> CucumberRestTestContext.getResponse()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("empty");
   }
 
   @Test
   void shouldGetZeroEntriesForUnknownPath() {
     addQuery("{}");
 
-    assertThat(CucumberTestContext.countEntries("$.dummy")).isZero();
+    assertThat(CucumberRestTestContext.countEntries("$.dummy")).isZero();
   }
 
   @Test
   void shouldGetNulForUnknownElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.getElement("dummy")).isNull();
+    assertThat(CucumberRestTestContext.getElement("dummy")).isNull();
   }
 
   @Test
   void shouldGetElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.getElement("element")).isEqualTo("value");
+    assertThat(CucumberRestTestContext.getElement("element")).isEqualTo("value");
   }
 
   @Test
@@ -63,28 +64,28 @@ class CucumberTestContextUnitTest {
     addQuery("/dumm", "{\"element\":\"dd\"}");
     addQuery("/employees", "{\"element\":\"test\"}");
 
-    assertThat(CucumberTestContext.getElement("dummies", "element")).isEqualTo("value");
+    assertThat(CucumberRestTestContext.getElement("dummies", "element")).isEqualTo("value");
   }
 
   @Test
   void shouldGetOneEntryForSingleElement() {
     addQuery("{\"element\":\"value\"}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isEqualTo(1);
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isEqualTo(1);
   }
 
   @Test
   void shouldGetZeroEntryForEmptyArray() {
     addQuery("{\"element\":[]}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isZero();
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isZero();
   }
 
   @Test
   void shouldGetArraySize() {
     addQuery("{\"element\":[{\"key\":\"value\"},{\"key\":\"value\"}]}");
 
-    assertThat(CucumberTestContext.countEntries("$.element")).isEqualTo(2);
+    assertThat(CucumberRestTestContext.countEntries("$.element")).isEqualTo(2);
   }
 
   @Test
@@ -97,7 +98,7 @@ class CucumberTestContextUnitTest {
     }
 
     assertThatThrownBy(() ->
-        CucumberTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes())
+        CucumberRestTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes())
       )
       .isExactlyInstanceOf(AssertionError.class);
   }
@@ -112,9 +113,9 @@ class CucumberTestContextUnitTest {
       fail(e.getMessage());
     }
 
-    CucumberTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
+    CucumberRestTestContext.addResponse(mockedRequest("/"), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
 
-    assertThat(CucumberTestContext.getResponse()).isEmpty();
+    assertThat(CucumberRestTestContext.getResponse()).isEmpty();
   }
 
   @Test
@@ -125,9 +126,9 @@ class CucumberTestContextUnitTest {
     HttpRequest request = mockedRequest("/");
     when(execution.execute(request, body)).thenThrow(IOException.class);
 
-    CucumberTestContext.addResponse(request, mockedResponse("response"), execution, body);
+    CucumberRestTestContext.addResponse(request, mockedResponse("response"), execution, body);
 
-    assertThatThrownBy(() -> CucumberTestContext.retry()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("retrying");
+    assertThatThrownBy(() -> CucumberRestTestContext.retry()).isExactlyInstanceOf(AssertionError.class).hasMessageContaining("retrying");
   }
 
   private void addQuery(String response) {
@@ -137,7 +138,7 @@ class CucumberTestContextUnitTest {
   private void addQuery(String path, String response) {
     ClientHttpResponse httpResponse = mockedResponse(response);
 
-    CucumberTestContext.addResponse(mockedRequest(path), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
+    CucumberRestTestContext.addResponse(mockedRequest(path), httpResponse, mock(ClientHttpRequestExecution.class), "body".getBytes());
   }
 
   private ClientHttpResponse mockedResponse(String response) {

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/ElementAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/ElementAsserter.java
@@ -1,6 +1,6 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/ElementAssertions.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/ElementAssertions.java
@@ -1,11 +1,13 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
 
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import net.minidev.json.JSONArray;
+import org.assertj.core.api.Assertions;
 
 class ElementAssertions {
 
@@ -14,7 +16,7 @@ class ElementAssertions {
   public ElementAssertions(String jsonPath) {
     this.jsonPath = buildJsonPath(jsonPath);
 
-    assertThat(CucumberTestContext.getElement(this.jsonPath)).as("Can't find " + this.jsonPath + " in response").isNotNull();
+    Assertions.assertThat(CucumberRestTestContext.getElement(this.jsonPath)).as("Can't find " + this.jsonPath + " in response").isNotNull();
   }
 
   private String buildJsonPath(String jsonPath) {
@@ -41,18 +43,18 @@ class ElementAssertions {
   }
 
   void withElementsCount(int count) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
     assertThat(elementsCount)
-      .as("Expecting " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberAssertions.callContext())
+      .as("Expecting " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberRestAssertions.callContext())
       .isEqualTo(count);
   }
 
   void withMoreThanElementsCount(int count) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
     assertThat(elementsCount)
-      .as("Expecting at least " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberAssertions.callContext())
+      .as("Expecting at least " + count + " element(s) in " + jsonPath + " but got " + elementsCount + CucumberRestAssertions.callContext())
       .isGreaterThanOrEqualTo(count);
   }
 
@@ -71,7 +73,7 @@ class ElementAssertions {
   void withValues(Collection<String> values) {
     assertThat(values).as("Can't check object against null values").isNotNull();
 
-    Object responseValue = CucumberTestContext.getElement(jsonPath);
+    Object responseValue = CucumberRestTestContext.getElement(jsonPath);
 
     if (!(responseValue instanceof JSONArray)) {
       fail(jsonPath + " is not an array");
@@ -79,19 +81,19 @@ class ElementAssertions {
 
     JSONArray array = (JSONArray) responseValue;
     assertThat(array)
-      .as("Expecting " + jsonPath + " to contain " + values + " but got " + responseValue + CucumberAssertions.callContext())
+      .as("Expecting " + jsonPath + " to contain " + values + " but got " + responseValue + CucumberRestAssertions.callContext())
       .containsExactlyElementsOf(values);
   }
 
   private void assertPathValue(String jsonPath, Object value) {
-    Object responseValue = CucumberTestContext.getElement(jsonPath);
+    Object responseValue = CucumberRestTestContext.getElement(jsonPath);
 
     if (responseValue != null && value instanceof String && !(responseValue instanceof String)) {
       responseValue = responseValue.toString();
     }
 
     assertThat(responseValue)
-      .as("Expecting " + jsonPath + " to contain " + value + " but got " + responseValue + CucumberAssertions.callContext())
+      .as("Expecting " + jsonPath + " to contain " + value + " but got " + responseValue + CucumberRestAssertions.callContext())
       .isEqualTo(value);
   }
 }

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/HeaderAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/HeaderAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 public interface HeaderAsserter<T extends ResponseAsserter> {
   HeaderAsserter<T> containing(String value);

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/HeaderAssertions.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/HeaderAssertions.java
@@ -1,9 +1,10 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
 import java.util.stream.Collectors;
+import org.assertj.core.api.Assertions;
 
 class HeaderAssertions {
 
@@ -12,18 +13,18 @@ class HeaderAssertions {
   HeaderAssertions(String header) {
     this.header = header;
 
-    assertThat(CucumberTestContext.getResponseHeader(header)).as("Can't find header " + header).isNotEmpty();
+    Assertions.assertThat(CucumberRestTestContext.getResponseHeader(header)).as("Can't find header " + header).isNotEmpty();
   }
 
   public void containing(String value) {
-    List<String> values = CucumberTestContext.getResponseHeader(header);
+    List<String> values = CucumberRestTestContext.getResponseHeader(header);
     assertThat(values)
       .as("Expecting header " + header + " to contain " + value + " but can't find it, current values are " + displayValues(values))
       .contains(value);
   }
 
   public void startingWith(String prefix) {
-    List<String> values = CucumberTestContext.getResponseHeader(header);
+    List<String> values = CucumberRestTestContext.getResponseHeader(header);
 
     assertThat(values)
       .as("Expecting header " + header + " to start with " + prefix + " but can't find it, current values are " + displayValues(values))

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/ResponseAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/ResponseAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import java.util.stream.Stream;
 import org.springframework.http.HttpStatus;

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/SyncElementAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/SyncElementAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/SyncHeaderAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/SyncHeaderAsserter.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
 class SyncHeaderAsserter implements HeaderAsserter<SyncResponseAsserter> {
 

--- a/src/test/java/tech/jhipster/lite/cucumber/rest/SyncResponseAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/SyncResponseAsserter.java
@@ -1,6 +1,6 @@
-package tech.jhipster.lite.cucumber;
+package tech.jhipster.lite.cucumber.rest;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.springframework.http.HttpStatus;
 
@@ -8,14 +8,14 @@ class SyncResponseAsserter implements ResponseAsserter {
 
   @Override
   public SyncResponseAsserter hasHttpStatus(HttpStatus status) {
-    CucumberAssertions.assertHttpStatus(status);
+    CucumberRestAssertions.assertHttpStatus(status);
 
     return this;
   }
 
   @Override
   public ResponseAsserter hasHttpStatusIn(HttpStatus... statuses) {
-    CucumberAssertions.assertHttpStatusIn(statuses);
+    CucumberRestAssertions.assertHttpStatusIn(statuses);
 
     return this;
   }
@@ -31,16 +31,16 @@ class SyncResponseAsserter implements ResponseAsserter {
   }
 
   public SyncResponseAsserter doNotHaveElement(String jsonPath) {
-    int elementsCount = CucumberTestContext.countEntries(jsonPath);
+    int elementsCount = CucumberRestTestContext.countEntries(jsonPath);
 
-    assertThat(elementsCount).as("Expecting " + jsonPath + " to not exists " + CucumberAssertions.callContext()).isZero();
+    assertThat(elementsCount).as("Expecting " + jsonPath + " to not exists " + CucumberRestAssertions.callContext()).isZero();
 
     return this;
   }
 
   @Override
   public SyncResponseAsserter hasRawBody(String info) {
-    assertThat(CucumberAssertions.responseBody()).isEqualTo(info);
+    assertThat(CucumberRestAssertions.responseBody()).isEqualTo(info);
 
     return this;
   }

--- a/src/test/java/tech/jhipster/lite/generator/ModulesExpositionSteps.java
+++ b/src/test/java/tech/jhipster/lite/generator/ModulesExpositionSteps.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator;
 
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.assertThatLastResponse;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumber/domain/CucumberModuleFactoryTest.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.cucumber.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.pomFile;
 
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
@@ -25,19 +26,18 @@ class CucumberModuleFactoryTest {
     JHipsterModule module = factory.buildInitializationModule(properties);
 
     assertThatModuleWithFiles(module, pomFile())
+      .hasPrefixedFiles("src/test/java/com/jhipster/test/cucumber", "CucumberConfiguration.java", "CucumberTest.java")
       .hasPrefixedFiles(
-        "src/test/java/com/jhipster/test/cucumber",
+        "src/test/java/com/jhipster/test/cucumber/rest",
         "AsyncElementAsserter.java",
         "AsyncHeaderAsserter.java",
         "AsyncResponseAsserter.java",
         "Awaiter.java",
-        "CucumberAssertions.java",
+        "CucumberRestAssertions.java",
         "CucumberRestTemplate.java",
-        "CucumberConfiguration.java",
         "CucumberJson.java",
-        "CucumberTest.java",
-        "CucumberTestContext.java",
-        "CucumberTestContextUnitTest.java",
+        "CucumberRestTestContext.java",
+        "CucumberRestTestContextUnitTest.java",
         "ElementAsserter.java",
         "ElementAssertions.java",
         "HeaderAsserter.java",

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/customjhlite/domain/CustomJHLiteModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/customjhlite/domain/CustomJHLiteModuleFactoryTest.java
@@ -95,7 +95,7 @@ class CustomJHLiteModuleFactoryTest {
       .hasFile("src/test/java/com/jhipster/test/cucumber/CucumberConfiguration.java")
         .containing("import com.jhipster.test.MyappApp;")
         .and()
-      .hasFiles("src/test/java/com/jhipster/test/cucumber/CucumberRestTemplate.java")
+      .hasFiles("src/test/java/com/jhipster/test/cucumber/rest/CucumberRestTemplate.java")
       .hasFiles("src/test/features/.gitkeep");
     //@formatter:on
   }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/primary/ModulesSteps.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/primary/ModulesSteps.java
@@ -1,8 +1,9 @@
 package tech.jhipster.lite.module.infrastructure.primary;
 
-import static org.assertj.core.api.Assertions.*;
-import static tech.jhipster.lite.TestProjects.*;
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.jhipster.lite.TestProjects.lastProjectFolder;
+import static tech.jhipster.lite.TestProjects.newTestFolder;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.assertThatLastResponse;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
@@ -20,8 +21,12 @@ import org.apache.commons.lang3.StringUtils;
 import org.assertj.core.api.SoftAssertions;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.*;
-import tech.jhipster.lite.cucumber.CucumberTestContext;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import tech.jhipster.lite.cucumber.rest.CucumberRestTestContext;
 import tech.jhipster.lite.module.infrastructure.secondary.git.GitTestUtil;
 
 public class ModulesSteps {
@@ -304,7 +309,7 @@ public class ModulesSteps {
     assertThatLastResponse().hasOkStatus();
 
     elements.forEach(element -> {
-      JSONArray types = (JSONArray) CucumberTestContext.getElement(
+      JSONArray types = (JSONArray) CucumberRestTestContext.getElement(
         "$.levels[" + level + "].elements[?(@.slug=='" + element.get("Slug") + "')].type"
       );
 

--- a/src/test/java/tech/jhipster/lite/project/infrastructure/primary/ProjectsSteps.java
+++ b/src/test/java/tech/jhipster/lite/project/infrastructure/primary/ProjectsSteps.java
@@ -1,8 +1,8 @@
 package tech.jhipster.lite.project.infrastructure.primary;
 
-import static org.assertj.core.api.Assertions.*;
-import static tech.jhipster.lite.TestProjects.*;
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static tech.jhipster.lite.TestProjects.lastProjectFolder;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.assertThatLastResponse;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/src/test/java/tech/jhipster/lite/statistic/infrastructure/primary/StatsSteps.java
+++ b/src/test/java/tech/jhipster/lite/statistic/infrastructure/primary/StatsSteps.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.statistic.infrastructure.primary;
 
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.assertThatLastResponse;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/src/test/java/tech/jhipster/lite/wire/springdoc/infrastructure/primary/SpringDocSteps.java
+++ b/src/test/java/tech/jhipster/lite/wire/springdoc/infrastructure/primary/SpringDocSteps.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.wire.springdoc.infrastructure.primary;
 
-import static tech.jhipster.lite.cucumber.CucumberAssertions.*;
+import static tech.jhipster.lite.cucumber.rest.CucumberRestAssertions.assertThatLastResponse;
 
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;

--- a/src/test/resources/projects/cucumber/CucumberConfiguration.java
+++ b/src/test/resources/projects/cucumber/CucumberConfiguration.java
@@ -1,9 +1,8 @@
 package com.jhipster.test.cucumber;
 
 import com.jhipster.test.MyappApp;
-import com.jhipster.test.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
 import com.mycompany.myapp.cucumber.CucumberConfiguration.CucumberRestTemplateConfiguration;
-import com.mycompany.myapp.cucumber.CucumberRestTemplate;
+import com.mycompany.myapp.cucumber.rest.CucumberRestTemplate;
 import io.cucumber.java.Before;
 import io.cucumber.spring.CucumberContextConfiguration;
 import java.nio.charset.StandardCharsets;
@@ -11,7 +10,6 @@ import java.util.List;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.context.annotation.Bean;
@@ -32,7 +30,7 @@ public class CucumberConfiguration {
 
   @Before
   public void resetTestContext() {
-    CucumberTestContext.reset();
+    CucumberRestTestContext.reset();
   }
 
   @Before
@@ -49,7 +47,7 @@ public class CucumberConfiguration {
     return (request, body, execution) -> {
       ClientHttpResponse response = execution.execute(request, body);
 
-      CucumberTestContext.addResponse(request, response, execution, body);
+      CucumberRestTestContext.addResponse(request, response, execution, body);
 
       return response;
     };


### PR DESCRIPTION
This allows clearer organization when you have other technology tooling (SOAP, Kafka, ...) in Cucumber tests