### PR TITLE
Declare checkstyle as direct dependency for dependabot

### DIFF
--- a/src/main/resources/generator/dependencies/build.gradle.kts
+++ b/src/main/resources/generator/dependencies/build.gradle.kts
@@ -31,6 +31,7 @@ ext {
 }
 
 dependencies {
+  implementation(libs.checkstyle)
   // jhipster-needle-gradle-dependencies
   // jhipster-needle-gradle-test-dependencies
 }

--- a/src/main/resources/generator/dependencies/gradle/libs.versions.toml
+++ b/src/main/resources/generator/dependencies/gradle/libs.versions.toml
@@ -3,6 +3,10 @@ checkstyle = "10.12.6"
 jib = "3.4.0"
 
 [libraries]
+[libraries.checkstyle]
+group = "com.puppycrawl.tools"
+name = "checkstyle"
+version.ref = "checkstyle"
 
 [plugins]
 [plugins.jib]


### PR DESCRIPTION
With that, dependabot should be able to automatically update version, since it does not seem to detect toolVersion