### PR TITLE
Fix java prettier formatting in gradle packages

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -4,7 +4,3 @@ build
 package-lock.json
 .git
 .mvn
-gradle
-.gradle
-!src/main/java/tech/jhipster/lite/generator/buildtool/gradle
-!src/test/java/tech/jhipster/lite/generator/buildtool/gradle

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
@@ -45,9 +45,18 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   private static final String BUILD_GRADLE_FILE = "build.gradle.kts";
 
   private static final Pattern GRADLE_PLUGIN_NEEDLE = Pattern.compile("^\\s+// jhipster-needle-gradle-plugins$", Pattern.MULTILINE);
-  private static final Pattern GRADLE_PLUGIN_PROJECT_EXTENSION_CONFIGURATION_NEEDLE = Pattern.compile("^// jhipster-needle-gradle-plugins-configurations$", Pattern.MULTILINE);
-  private static final Pattern GRADLE_DEPENDENCY_NEEDLE = Pattern.compile("^\\s+// jhipster-needle-gradle-dependencies$", Pattern.MULTILINE);
-  private static final Pattern GRADLE_TEST_DEPENDENCY_NEEDLE = Pattern.compile("^\\s+// jhipster-needle-gradle-test-dependencies$", Pattern.MULTILINE);
+  private static final Pattern GRADLE_PLUGIN_PROJECT_EXTENSION_CONFIGURATION_NEEDLE = Pattern.compile(
+    "^// jhipster-needle-gradle-plugins-configurations$",
+    Pattern.MULTILINE
+  );
+  private static final Pattern GRADLE_DEPENDENCY_NEEDLE = Pattern.compile(
+    "^\\s+// jhipster-needle-gradle-dependencies$",
+    Pattern.MULTILINE
+  );
+  private static final Pattern GRADLE_TEST_DEPENDENCY_NEEDLE = Pattern.compile(
+    "^\\s+// jhipster-needle-gradle-test-dependencies$",
+    Pattern.MULTILINE
+  );
 
   private final Indentation indentation;
   private final JHipsterProjectFolder projectFolder;
@@ -92,19 +101,22 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       ),
       dependencyDeclaration
     );
-    fileReplacer.handle(projectFolder, ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer)));
+    fileReplacer.handle(
+      projectFolder,
+      ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer))
+    );
   }
 
   private static String versionCatalogReference(JavaDependency dependency) {
-      return "libs.%s".formatted(applyVersionCatalogReferenceConvention(dependencySlug(dependency)));
+    return "libs.%s".formatted(applyVersionCatalogReferenceConvention(dependencySlug(dependency)));
   }
 
   private static String applyVersionCatalogReferenceConvention(String rawVersionCatalogReference) {
-      return rawVersionCatalogReference.replace("-", ".");
+    return rawVersionCatalogReference.replace("-", ".");
   }
 
   private static GradleDependencyScope gradleDependencyScope(JavaDependency dependency) {
-    return switch(dependency.scope()) {
+    return switch (dependency.scope()) {
       case TEST -> GradleDependencyScope.TEST_IMPLEMENTATION;
       case PROVIDED -> GradleDependencyScope.COMPILE_ONLY;
       case RUNTIME -> GradleDependencyScope.RUNTIME_ONLY;
@@ -119,7 +131,8 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
   }
 
   private void removeDependencyFromBuildGradle(DependencySlug dependencySlug) {
-    String scopePattern = Stream.of(GradleDependencyScope.values())
+    String scopePattern = Stream
+      .of(GradleDependencyScope.values())
       .map(GradleDependencyScope::command)
       .collect(Collectors.joining("|", "(", ")"));
     Pattern dependencyLinePattern = Pattern.compile(
@@ -127,7 +140,10 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       Pattern.MULTILINE
     );
     MandatoryReplacer replacer = new MandatoryReplacer(new RegexReplacer(always(), dependencyLinePattern), "");
-    fileReplacer.handle(projectFolder, ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer)));
+    fileReplacer.handle(
+      projectFolder,
+      ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer))
+    );
   }
 
   @Override
@@ -191,7 +207,10 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       ),
       indentation.times(1) + pluginDeclaration
     );
-    fileReplacer.handle(projectFolder, ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer)));
+    fileReplacer.handle(
+      projectFolder,
+      ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer))
+    );
   }
 
   private void addPluginConfiguration(GradlePluginConfiguration pluginConfiguration) {
@@ -202,6 +221,9 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       ),
       LINE_BREAK + pluginConfiguration.get()
     );
-    fileReplacer.handle(projectFolder, ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer)));
+    fileReplacer.handle(
+      projectFolder,
+      ContentReplacers.of(new MandatoryFileReplacer(new JHipsterProjectFilePath(BUILD_GRADLE_FILE), replacer))
+    );
   }
 }

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleDependencyScope.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleDependencyScope.java
@@ -7,8 +7,7 @@ enum GradleDependencyScope {
   RUNTIME_ONLY("runtimeOnly"),
   TEST_IMPLEMENTATION("testImplementation"),
   TEST_COMPILE_ONLY("testCompileOnly"),
-  TEST_RUNTIME_ONLY("testRuntimeOnly"),
-  ;
+  TEST_RUNTIME_ONLY("testRuntimeOnly");
 
   private final String command;
 

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/VersionsCatalog.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/VersionsCatalog.java
@@ -31,9 +31,7 @@ public class VersionsCatalog {
   }
 
   public VersionsCatalog(Path tomlVersionCatalogFile) {
-    tomlConfigFile = FileConfig.builder(tomlVersionCatalogFile)
-      .sync()
-      .build();
+    tomlConfigFile = FileConfig.builder(tomlVersionCatalogFile).sync().build();
 
     // Missing TOML file will be automatically created, but its parent folder should exist
     if (!Files.exists(tomlVersionCatalogFile.getParent())) {
@@ -75,12 +73,15 @@ public class VersionsCatalog {
   }
 
   public void removeLibrary(DependencyId dependency) {
-    libraryEntriesMatchingDependency(dependency).forEach(libraryConfig -> tomlConfigFile.remove(List.of(LIBRARIES_TOML_KEY, libraryConfig.getKey())));
+    libraryEntriesMatchingDependency(dependency)
+      .forEach(libraryConfig -> tomlConfigFile.remove(List.of(LIBRARIES_TOML_KEY, libraryConfig.getKey())));
     save();
   }
 
   private List<? extends Entry> libraryEntriesMatchingDependency(DependencyId dependency) {
-    return tomlConfigFile.entrySet().stream()
+    return tomlConfigFile
+      .entrySet()
+      .stream()
       .filter(entry -> entry.getKey().equals(LIBRARIES_TOML_KEY))
       .map(Entry::getValue)
       .filter(Config.class::isInstance)
@@ -107,15 +108,13 @@ public class VersionsCatalog {
   }
 
   public Collection<DependencySlug> retrieveDependencySlugsFrom(DependencyId dependency) {
-    return libraryEntriesMatchingDependency(dependency)
-      .stream()
-      .map(UnmodifiableConfig.Entry::getKey)
-      .map(DependencySlug::new)
-      .toList();
+    return libraryEntriesMatchingDependency(dependency).stream().map(UnmodifiableConfig.Entry::getKey).map(DependencySlug::new).toList();
   }
 
   public Collection<JavaDependencyVersion> retrieveVersions() {
-    return tomlConfigFile.entrySet().stream()
+    return tomlConfigFile
+      .entrySet()
+      .stream()
       .filter(entry -> entry.getKey().equals(VERSIONS_TOML_KEY))
       .map(Entry::getValue)
       .filter(Config.class::isInstance)

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
@@ -50,7 +50,6 @@ class GradleCommandHandlerTest {
     GradleCommandHandler gradleCommandHandler = new GradleCommandHandler(Indentation.DEFAULT, projectFolder);
     SetBuildProperty command = new SetBuildProperty(springProfilesActiveProperty());
     assertThatThrownBy(() -> gradleCommandHandler.handle(command)).isInstanceOf(NotImplementedException.class);
-
   }
 
   @Test
@@ -72,10 +71,12 @@ class GradleCommandHandlerTest {
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new SetVersion(springBootVersion()));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [versions]
           \tspring-boot = "1.2.3"
-          """);
+          """
+        );
     }
 
     @Test
@@ -85,10 +86,12 @@ class GradleCommandHandlerTest {
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new SetVersion(springBootVersion()));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [versions]
           \tspring-boot = "1.2.3"
-          """);
+          """
+        );
     }
 
     @Test
@@ -100,10 +103,12 @@ class GradleCommandHandlerTest {
       gradleCommandHandler.handle(new SetVersion(new JavaDependencyVersion("jjwt", "0.13.0")));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [versions]
           \tjjwt = "0.13.0"
-          """);
+          """
+        );
     }
   }
 
@@ -117,34 +122,32 @@ class GradleCommandHandlerTest {
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new AddDirectJavaDependency(springBootStarterWebDependency()));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [libraries.spring-boot-starter-web]
           \t\tname = "spring-boot-starter-web"
           \t\tgroup = "org.springframework.boot"
-          """);
+          """
+        );
     }
 
     @Test
     void shouldUpdateEntryInLibrariesSectionToExistingTomlVersionCatalog() {
       GradleCommandHandler gradleCommandHandler = new GradleCommandHandler(Indentation.DEFAULT, projectFolder);
-      JavaDependency initialDependency = javaDependency()
-        .groupId("org.springframework.boot")
-        .artifactId("spring-boot-starter-web")
-        .build();
+      JavaDependency initialDependency = javaDependency().groupId("org.springframework.boot").artifactId("spring-boot-starter-web").build();
       gradleCommandHandler.handle(new AddDirectJavaDependency(initialDependency));
 
-      JavaDependency updatedDependency = javaDependency()
-        .groupId("org.spring.boot")
-        .artifactId("spring-boot-starter-web")
-        .build();
+      JavaDependency updatedDependency = javaDependency().groupId("org.spring.boot").artifactId("spring-boot-starter-web").build();
       gradleCommandHandler.handle(new AddDirectJavaDependency(updatedDependency));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [libraries.spring-boot-starter-web]
           \t\tname = "spring-boot-starter-web"
           \t\tgroup = "org.spring.boot"
-          """);
+          """
+        );
     }
 
     @Test
@@ -159,20 +162,18 @@ class GradleCommandHandlerTest {
       gradleCommandHandler.handle(new AddDirectJavaDependency(dependency));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [libraries.spring-boot-starter-web.version]
           \t\t\tref = "spring-boot"
-          """);
+          """
+        );
     }
 
-    @EnumSource(value = JavaDependencyScope.class, mode = EXCLUDE, names = {"TEST", "RUNTIME", "PROVIDED", "IMPORT"})
+    @EnumSource(value = JavaDependencyScope.class, mode = EXCLUDE, names = { "TEST", "RUNTIME", "PROVIDED", "IMPORT" })
     @ParameterizedTest
     void shouldAddImplementationDependencyInBuildGradleFileForScope(JavaDependencyScope scope) {
-      JavaDependency dependency = javaDependency()
-        .groupId("org.spring.boot")
-        .artifactId("spring-boot-starter-web")
-        .scope(scope)
-        .build();
+      JavaDependency dependency = javaDependency().groupId("org.spring.boot").artifactId("spring-boot-starter-web").scope(scope).build();
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new AddDirectJavaDependency(dependency));
 
       assertThat(buildGradleContent(projectFolder)).contains("implementation(libs.spring.boot.starter.web)");
@@ -229,10 +230,12 @@ class GradleCommandHandlerTest {
 
       assertThat(versionCatalogContent(projectFolder))
         .doesNotContain("[libraries.spring-boot-starter-web]")
-        .doesNotContain("""
+        .doesNotContain(
+          """
           \t\tname = "spring-boot-starter-web"
           \t\tgroup = "org.springframework.boot"
-          """);
+          """
+        );
     }
 
     @Test
@@ -298,25 +301,31 @@ class GradleCommandHandlerTest {
 
     @Test
     void shouldAddEntryInLibrariesSectionToExistingTomlVersionCatalog() {
-      new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
+      new GradleCommandHandler(Indentation.DEFAULT, projectFolder)
+        .handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [libraries.spring-boot-dependencies]
           \t\tname = "spring-boot-dependencies"
           \t\tgroup = "org.springframework.boot"
-          """);
+          """
+        );
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           [libraries.spring-boot-dependencies.version]
           \t\t\tref = "spring-boot"
-          """);
+          """
+        );
     }
 
     @Test
     void shouldAddImplementationDependencyInBuildGradleFileForScope() {
-      new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
+      new GradleCommandHandler(Indentation.DEFAULT, projectFolder)
+        .handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
 
       assertThat(buildGradleContent(projectFolder)).contains("implementation(platform(libs.spring.boot.dependencies))");
     }
@@ -336,10 +345,12 @@ class GradleCommandHandlerTest {
 
       assertThat(versionCatalogContent(projectFolder))
         .doesNotContain("[libraries.spring-boot-dependencies]")
-        .doesNotContain("""
+        .doesNotContain(
+          """
           \t\tname = "spring-boot-dependencies"
           \t\tgroup = "org.springframework.boot"
-          """);
+          """
+        );
     }
 
     @Test
@@ -360,16 +371,19 @@ class GradleCommandHandlerTest {
 
     @Test
     void shouldDeclareAndConfigurePluginInBuildGradleFile() {
-      new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(AddGradlePlugin.builder().plugin(checkstyleGradlePlugin()).build());
+      new GradleCommandHandler(Indentation.DEFAULT, projectFolder)
+        .handle(AddGradlePlugin.builder().plugin(checkstyleGradlePlugin()).build());
 
       assertThat(buildGradleContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           plugins {
             java
             checkstyle
             // jhipster-needle-gradle-plugins
           }
-          """)
+          """
+        )
         .contains(
           """
 
@@ -384,10 +398,7 @@ class GradleCommandHandlerTest {
 
     @Test
     void shouldApplyVersionCatalogReferenceConvention() {
-      GradlePlugin plugin = gradleCommunityPlugin()
-        .id("org.springframework.boot")
-        .pluginSlug("spring-boot")
-        .build();
+      GradlePlugin plugin = gradleCommunityPlugin().id("org.springframework.boot").pluginSlug("spring-boot").build();
       AddGradlePlugin build = AddGradlePlugin.builder().plugin(plugin).build();
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(build);
 
@@ -402,19 +413,24 @@ class GradleCommandHandlerTest {
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(build);
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           checkstyle = "8.42.1"
-          """);
+          """
+        );
     }
+
     @Test
     void shouldAddPluginVersion() {
       AddGradlePlugin build = AddGradlePlugin.builder().plugin(checkstyleGradlePlugin()).pluginVersion(checkstyleToolVersion()).build();
       new GradleCommandHandler(Indentation.DEFAULT, projectFolder).handle(build);
 
       assertThat(versionCatalogContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           checkstyle = "8.42.1"
-          """);
+          """
+        );
     }
 
     @Test
@@ -426,13 +442,15 @@ class GradleCommandHandlerTest {
       gradleCommandHandler.handle(command);
 
       assertThat(buildGradleContent(projectFolder))
-        .contains("""
+        .contains(
+          """
           plugins {
             java
             checkstyle
             // jhipster-needle-gradle-plugins
           }
-          """)
+          """
+        )
         .contains(
           """
           java {
@@ -486,5 +504,4 @@ class GradleCommandHandlerTest {
   private static String versionCatalogContent(JHipsterProjectFolder projectFolder) {
     return contentNormalizingNewLines(Paths.get(projectFolder.get()).resolve("gradle/libs.versions.toml"));
   }
-
 }


### PR DESCRIPTION
Unneeded configuration in `.prettierignore` was preventing prettier to format content of package `tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle`