### PR TITLE
(docker-compose) Follow Docker recommandation for ports mapping

### DIFF
--- a/src/main/resources/generator/server/springboot/broker/kafka/kafka.yml.mustache
+++ b/src/main/resources/generator/server/springboot/broker/kafka/kafka.yml.mustache
@@ -10,7 +10,7 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:9092:9092
+      - '127.0.0.1:9092:9092'
     environment:
       KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181

--- a/src/main/resources/generator/server/springboot/database/cassandra/cassandra.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/cassandra/cassandra.yml.mustache
@@ -7,7 +7,7 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - "127.0.0.1:9042:9042"  # cql native port
+      - '127.0.0.1:9042:9042'  # cql native port
     environment:
       - CASSANDRA_DC={{ DC }}
     #volumes:

--- a/src/main/resources/generator/server/springboot/database/mariadb/mariadb.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/mariadb/mariadb.yml.mustache
@@ -11,4 +11,4 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:3306:3306
+      - '127.0.0.1:3306:3306'

--- a/src/main/resources/generator/server/springboot/database/mongodb/mongodb.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/mongodb/mongodb.yml.mustache
@@ -6,6 +6,6 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:27017:27017
+      - '127.0.0.1:27017:27017'
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/

--- a/src/main/resources/generator/server/springboot/database/mssql/mssql.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/mssql/mssql.yml.mustache
@@ -14,5 +14,5 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:1433:1433
+      - '127.0.0.1:1433:1433'
     command: /bin/bash -c '/opt/mssql/bin/sqlservr & echo "wait $$MSSQL_SLEEP sec for DB to start "; sleep $$MSSQL_SLEEP; /opt/mssql-tools/bin/sqlcmd -U sa -P $$SA_PASSWORD -d tempdb -q "EXIT(CREATE DATABASE $$MSSQL_DATABASE)"; wait;'

--- a/src/main/resources/generator/server/springboot/database/mysql/mysql.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/mysql/mysql.yml.mustache
@@ -11,4 +11,4 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:3306:3306
+      - '127.0.0.1:3306:3306'

--- a/src/main/resources/generator/server/springboot/database/postgresql/postgresql.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/postgresql/postgresql.yml.mustache
@@ -12,4 +12,4 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:5432:5432
+      - '127.0.0.1:5432:5432'

--- a/src/main/resources/generator/server/springboot/database/redis/redis.yml.mustache
+++ b/src/main/resources/generator/server/springboot/database/redis/redis.yml.mustache
@@ -6,6 +6,6 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:6379:6379
+      - '127.0.0.1:6379:6379'
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/redis/:/data/

--- a/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/docker/keycloak.yml.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/docker/keycloak.yml.mustache
@@ -16,5 +16,5 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:9080:9080
-      - 127.0.0.1:9443:9443
+      - '127.0.0.1:9080:9080'
+      - '127.0.0.1:9443:9443'

--- a/src/main/resources/generator/server/springboot/springcloud/configclient/jhipster-registry.yml.mustache
+++ b/src/main/resources/generator/server/springboot/springcloud/configclient/jhipster-registry.yml.mustache
@@ -22,4 +22,4 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-    - 127.0.0.1:8761:8761
+    - '127.0.0.1:8761:8761'

--- a/src/main/resources/generator/server/springboot/springcloud/consul/src/consul.yml.mustache
+++ b/src/main/resources/generator/server/springboot/springcloud/consul/src/consul.yml.mustache
@@ -6,9 +6,9 @@ services:
     # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
-      - 127.0.0.1:8300:8300
-      - 127.0.0.1:8500:8500
-      - 127.0.0.1:8600:8600
+      - '127.0.0.1:8300:8300'
+      - '127.0.0.1:8500:8500'
+      - '127.0.0.1:8600:8600'
     command: consul agent -dev -ui -client 0.0.0.0 -log-level=INFO
 
   consul-config-loader:


### PR DESCRIPTION
https://docs.docker.com/compose/compose-file/compose-file-v3/#ports
> we recommend always explicitly specifying your port mappings as strings.