### PR TITLE
Add JaCoCo configuration to check minimum coverage

### DIFF
--- a/.jhipster/modules/history.json
+++ b/.jhipster/modules/history.json
@@ -3,5 +3,25 @@
     "module" : "application-service-hexagonal-architecture-documentation",
     "date" : "2022-07-29T05:45:39.864617462Z",
     "properties" : { }
+  }, {
+    "module" : "maven-java",
+    "date" : "2024-01-29T22:31:20.121046866Z",
+    "properties" : {
+      "packageName" : "com.mycompany.myapp",
+      "projectName" : "JHipster Sample Application",
+      "baseName" : "jhipsterSampleApplication",
+      "endOfLine" : "lf",
+      "indentSize" : 2
+    }
+  }, {
+    "module" : "jacoco-check-min-coverage",
+    "date" : "2024-01-29T22:31:20.126024517Z",
+    "properties" : {
+      "packageName" : "com.mycompany.myapp",
+      "projectName" : "JHipster Sample Application",
+      "baseName" : "jhipsterSampleApplication",
+      "endOfLine" : "lf",
+      "indentSize" : 2
+    }
   } ]
 }

--- a/pom.xml
+++ b/pom.xml
@@ -658,32 +658,6 @@
                 <outputDirectory>target/jacoco/</outputDirectory>
               </configuration>
             </execution>
-            <execution>
-              <id>check</id>
-              <goals>
-                <goal>check</goal>
-              </goals>
-              <configuration>
-                <dataFile>target/jacoco/allTest.exec</dataFile>
-                <rules>
-                  <rule>
-                    <element>CLASS</element>
-                    <limits>
-                      <limit>
-                        <counter>LINE</counter>
-                        <value>COVEREDRATIO</value>
-                        <minimum>1.00</minimum>
-                      </limit>
-                      <limit>
-                        <counter>BRANCH</counter>
-                        <value>COVEREDRATIO</value>
-                        <minimum>1.00</minimum>
-                      </limit>
-                    </limits>
-                  </rule>
-                </rules>
-              </configuration>
-            </execution>
           </executions>
         </plugin>
 
@@ -747,6 +721,50 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>jacoco-check</id>
+      <activation>
+        <os>
+          <family>unix</family>
+        </os>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>check</id>
+                <goals>
+                  <goal>check</goal>
+                </goals>
+                <configuration>
+                  <dataFile>target/jacoco/allTest.exec</dataFile>
+                  <rules>
+                    <rule>
+                      <element>CLASS</element>
+                      <limits>
+                        <limit>
+                          <counter>LINE</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>1.00</minimum>
+                        </limit>
+                        <limit>
+                          <counter>BRANCH</counter>
+                          <value>COVEREDRATIO</value>
+                          <minimum>1.00</minimum>
+                        </limit>
+                      </limits>
+                    </rule>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <profile>
       <id>deploy-central</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -336,6 +336,7 @@
         <configuration>
           <excludes>
             <exclude>**/generator/buildtool/maven/.mvn/wrapper/*</exclude>
+            <exclude>**/generator/buildtool/gradle/gradle/wrapper/*</exclude>
             <exclude>src/main/webapp/app/common/primary/applicationlistener/WindowApplicationListener.ts</exclude>
           </excludes>
         </configuration>
@@ -655,6 +656,32 @@
               <configuration>
                 <dataFile>target/jacoco/allTest.exec</dataFile>
                 <outputDirectory>target/jacoco/</outputDirectory>
+              </configuration>
+            </execution>
+            <execution>
+              <id>check</id>
+              <goals>
+                <goal>check</goal>
+              </goals>
+              <configuration>
+                <dataFile>target/jacoco/allTest.exec</dataFile>
+                <rules>
+                  <rule>
+                    <element>CLASS</element>
+                    <limits>
+                      <limit>
+                        <counter>LINE</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>1.00</minimum>
+                      </limit>
+                      <limit>
+                        <counter>BRANCH</counter>
+                        <value>COVEREDRATIO</value>
+                        <minimum>1.00</minimum>
+                      </limit>
+                    </limits>
+                  </rule>
+                </rules>
               </configuration>
             </execution>
           </executions>


### PR DESCRIPTION
This will help checking coverage locally when developing jhlite: a first feedback without the need to wait for CI build and Codecov report.