### PR TITLE
Custom-jhlite should depends on jhlite version that has been used to generate it

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -384,7 +384,7 @@ jobs:
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: ./current-branch/
         run: |
-          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
+          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
           echo "JHLITE_VERSION=${JHLITE_VERSION}"
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -385,6 +385,7 @@ jobs:
         working-directory: ./current-branch/
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
+          echo "JHLITE_VERSION=${JHLITE_VERSION}"
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jhlite-jar
-          path: '${{ github.workspace }}/target/*.jar.*'
+          path: '${{ github.workspace }}/target/*.jar*'
           retention-days: 1
   #------------------------------------------------------
   # Build and Upload *.jar from main branch on Linux

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -313,12 +313,6 @@ jobs:
         with:
           name: jhlite-jar
           path: ./current-branch/tests-ci/
-      - name: 'Install jhlite snapshot jar in local maven repository'
-        working-directory: ./current-branch/
-        run: |
-          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Generation: generate ${{ matrix.app }}'
         working-directory: ./current-branch/tests-ci/
         run: |
@@ -386,6 +380,13 @@ jobs:
             ${{ github.workspace }}/current-branch/tests-ci/wait_sonar.sh
             docker ps -a
           fi
+      - name: 'Install jhlite snapshot jar in local maven repository'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        working-directory: ./current-branch/
+        run: |
+          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -136,6 +136,9 @@ jobs:
           name: lcov
           path: '${{ github.workspace }}/target/test-results/lcov.info'
           retention-days: 1
+      - name: 'Artifact: remove unused JARs'
+        run: |
+          rm target/*-javadoc.jar target/*-sources.jar
       - name: 'Artifact: upload JAR'
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -314,7 +314,6 @@ jobs:
           name: jhlite-jar
           path: ./current-branch/tests-ci/
       - name: 'Install jhlite snapshot jar in local maven repository'
-        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: ./current-branch/
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -381,7 +381,9 @@ jobs:
             docker ps -a
           fi
       - name: 'Install jhlite snapshot in local maven repository for ${{ matrix.app }}'
-        if: steps.tests-requirement-check.outputs.execute_tests == 'true' && ${{ matrix.app }} == 'customjhlite'
+        if: >-
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          '${{ matrix.app }}' == 'customjhlite'
         working-directory: ./current-branch/
         run: |
           export JHLITE_VERSION=$(grep "<jhlite.version>" /tmp/jhlite/${{ matrix.app }}/pom.xml | sed -e 's/<jhlite.version>\(.*\)<\/jhlite.version>/\1/')

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -384,7 +384,7 @@ jobs:
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: ./current-branch/
         run: |
-          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
+          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*-tests.jar" | sed -e 's/.*jhlite-\(.*\)-tests\.jar/\1/')
           echo "JHLITE_VERSION=${JHLITE_VERSION}"
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jhlite-jar
-          path: '${{ github.workspace }}/target/*.jar'
+          path: '${{ github.workspace }}/target/*.jar.*'
           retention-days: 1
   #------------------------------------------------------
   # Build and Upload *.jar from main branch on Linux
@@ -386,7 +386,7 @@ jobs:
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
           echo "JHLITE_VERSION=${JHLITE_VERSION}"
-          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar.original -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -380,6 +380,12 @@ jobs:
             ${{ github.workspace }}/current-branch/tests-ci/wait_sonar.sh
             docker ps -a
           fi
+      - name: 'Install jhlite snapshot in local maven repository for ${{ matrix.app }}'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true' && ${{ matrix.app }} == 'customjhlite'
+        working-directory: ./current-branch/
+        run: |
+          export JHLITE_VERSION=$(grep "<jhlite.version>" /tmp/jhlite/${{ matrix.app }}/pom.xml | sed -e 's/<jhlite.version>\(.*\)<\/jhlite.version>/\1/')
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -380,13 +380,11 @@ jobs:
             ${{ github.workspace }}/current-branch/tests-ci/wait_sonar.sh
             docker ps -a
           fi
-      - name: 'Install jhlite snapshot in local maven repository for ${{ matrix.app }}'
-        if: >-
-          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
-          '${{ matrix.app }}' == 'customjhlite'
+      - name: 'Install jhlite snapshot jar in local maven repository'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: ./current-branch/
         run: |
-          export JHLITE_VERSION=$(grep "<jhlite.version>" /tmp/jhlite/${{ matrix.app }}/pom.xml | sed -e 's/<jhlite.version>\(.*\)<\/jhlite.version>/\1/')
+          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
           mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -313,6 +313,13 @@ jobs:
         with:
           name: jhlite-jar
           path: ./current-branch/tests-ci/
+      - name: 'Install jhlite snapshot jar in local maven repository'
+        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        working-directory: ./current-branch/
+        run: |
+          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Generation: generate ${{ matrix.app }}'
         working-directory: ./current-branch/tests-ci/
         run: |
@@ -380,13 +387,6 @@ jobs:
             ${{ github.workspace }}/current-branch/tests-ci/wait_sonar.sh
             docker ps -a
           fi
-      - name: 'Install jhlite snapshot jar in local maven repository'
-        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
-        working-directory: ./current-branch/
-        run: |
-          export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -140,7 +140,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: jhlite-jar
-          path: '${{ github.workspace }}/target/*.jar*'
+          path: '${{ github.workspace }}/target/*.jar'
           retention-days: 1
   #------------------------------------------------------
   # Build and Upload *.jar from main branch on Linux
@@ -386,7 +386,7 @@ jobs:
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
           echo "JHLITE_VERSION=${JHLITE_VERSION}"
-          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar.original -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
           ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -386,6 +386,7 @@ jobs:
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
           mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -385,8 +385,8 @@ jobs:
         working-directory: ./current-branch/
         run: |
           export JHLITE_VERSION=$(find tests-ci -maxdepth 1 -name "*.jar" | grep -P "jhlite-\d+\.\d+\.\d+(-SNAPSHOT)?\.jar" | sed -e 's/.*jhlite-\(.*\)\.jar/\1/')
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
-          mvn install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
+          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION}
+          ./mvnw install:install-file -Dfile=tests-ci/jhlite-${JHLITE_VERSION}-tests.jar -DgroupId=tech.jhipster.lite -DartifactId=jhlite -Dversion=${JHLITE_VERSION} -Dclassifier=tests
       - name: 'Test: verify ${{ matrix.app }}'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build application with Buildpacks
         run: |
-          ./mvnw -Pnative -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }}
+          ./mvnw -Pnative -P'!spring-boot-build' -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Login to Docker Registry
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Build application with Buildpacks
         run: |
-          ./mvnw -Pnative -P'!spring-boot-build' -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }}
+          ./mvnw -Pnative -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Login to Docker Registry
         if: ${{ startsWith(github.ref, 'refs/tags/v') }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,12 @@ jobs:
         run: |
           chmod +x mvnw
           ./mvnw clean verify
-          rm target/*-javadoc.jar target/*-sources.jar target/*-tests.jar
+          ARTIFACT_VERSION=$(./mvnw help:evaluate -Dexpression=project.version -q -DforceStdout)
+          rm target/*${ARTIFACT_VERSION}.jar
+          rm target/*${ARTIFACT_VERSION}-javadoc.jar
+          rm target/*${ARTIFACT_VERSION}-sources.jar
+          rm target/*${ARTIFACT_VERSION}-tests.jar
+          mv target/jhlite-${ARTIFACT_VERSION}-exec.jar target/jhlite-${ARTIFACT_VERSION}.jar
       - name: 'Artifact: upload JAR'
         uses: actions/upload-artifact@v4
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@ FROM openjdk:21-slim AS build
 COPY . /code/jhipster-app/
 WORKDIR /code/jhipster-app/
 RUN chmod +x mvnw && ./mvnw package -B -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip
-RUN mv /code/jhipster-app/target/*.jar /code/ && \
-    rm -rf /code/*-tests.jar
+RUN mv /code/jhipster-app/target/*-exec.jar /code/
 
 FROM openjdk:21-slim
 COPY --from=build /code/*.jar /code/

--- a/pom.xml
+++ b/pom.xml
@@ -267,14 +267,12 @@
         <directory>${basedir}/src/main/resources</directory>
         <filtering>true</filtering>
         <includes>
-          <include>config/*.properties</include>
           <include>generator/dependencies/pom.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
         <excludes>
-          <exclude>config/*.properties</exclude>
           <exclude>generator/dependencies/pom.xml</exclude>
         </excludes>
       </resource>

--- a/pom.xml
+++ b/pom.xml
@@ -558,6 +558,11 @@
       </plugin>
 
       <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-maven-plugin</artifactId>
         <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,6 @@
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
-    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -563,16 +562,6 @@
     </plugins>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-resources-plugin</artifactId>
-          <version>${maven-resources-plugin.version}</version>
-          <configuration>
-            <delimiters>
-              <delimiter>@</delimiter>
-            </delimiters>
-          </configuration>
-        </plugin>
         <plugin>
           <groupId>io.github.git-commit-id</groupId>
           <artifactId>git-commit-id-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,37 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.graalvm.buildtools</groupId>
+        <artifactId>native-maven-plugin</artifactId>
+      </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${project.parent.version}</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>repackage</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <classifier>exec</classifier>
+          <image>
+            <env>
+              <BP_JVM_VERSION>21</BP_JVM_VERSION>
+            </env>
+            <buildpacks>
+              <buildpack>gcr.io/paketo-buildpacks/bellsoft-liberica:10.4.3</buildpack>
+              <buildpack>gcr.io/paketo-buildpacks/java-native-image</buildpack>
+            </buildpacks>
+          </image>
+          <mainClass>${start-class}</mainClass>
+        </configuration>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -711,48 +742,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>spring-boot-build</id>
-      <activation>
-        <property>
-          <name>release</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <version>${project.parent.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>repackage</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <image>
-                <env>
-                  <BP_JVM_VERSION>21</BP_JVM_VERSION>
-                </env>
-                <buildpacks>
-                  <buildpack>gcr.io/paketo-buildpacks/bellsoft-liberica:10.4.3</buildpack>
-                  <buildpack>gcr.io/paketo-buildpacks/java-native-image</buildpack>
-                </buildpacks>
-              </image>
-              <mainClass>${start-class}</mainClass>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>deploy-central</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -559,6 +559,20 @@
           </execution>
         </executions>
       </plugin>
+
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <id>repackage</id>
+            <configuration>
+              <attach>false</attach>
+              <classifier>exec</classifier>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -711,46 +725,6 @@
   </build>
 
   <profiles>
-    <profile>
-      <id>spring-boot-build</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.graalvm.buildtools</groupId>
-            <artifactId>native-maven-plugin</artifactId>
-          </plugin>
-          <plugin>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-maven-plugin</artifactId>
-            <version>${project.parent.version}</version>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>repackage</goal>
-                </goals>
-              </execution>
-            </executions>
-            <configuration>
-              <classifier>exec</classifier>
-              <image>
-                <env>
-                  <BP_JVM_VERSION>21</BP_JVM_VERSION>
-                </env>
-                <buildpacks>
-                  <buildpack>gcr.io/paketo-buildpacks/bellsoft-liberica:10.4.3</buildpack>
-                  <buildpack>gcr.io/paketo-buildpacks/java-native-image</buildpack>
-                </buildpacks>
-              </image>
-              <mainClass>${start-class}</mainClass>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-
     <profile>
       <id>deploy-central</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -734,6 +734,7 @@
               </execution>
             </executions>
             <configuration>
+              <classifier>exec</classifier>
               <image>
                 <env>
                   <BP_JVM_VERSION>21</BP_JVM_VERSION>

--- a/pom.xml
+++ b/pom.xml
@@ -559,37 +559,6 @@
           </execution>
         </executions>
       </plugin>
-
-      <plugin>
-        <groupId>org.graalvm.buildtools</groupId>
-        <artifactId>native-maven-plugin</artifactId>
-      </plugin>
-
-      <plugin>
-        <groupId>org.springframework.boot</groupId>
-        <artifactId>spring-boot-maven-plugin</artifactId>
-        <version>${project.parent.version}</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>repackage</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <classifier>exec</classifier>
-          <image>
-            <env>
-              <BP_JVM_VERSION>21</BP_JVM_VERSION>
-            </env>
-            <buildpacks>
-              <buildpack>gcr.io/paketo-buildpacks/bellsoft-liberica:10.4.3</buildpack>
-              <buildpack>gcr.io/paketo-buildpacks/java-native-image</buildpack>
-            </buildpacks>
-          </image>
-          <mainClass>${start-class}</mainClass>
-        </configuration>
-      </plugin>
     </plugins>
     <pluginManagement>
       <plugins>
@@ -742,6 +711,45 @@
   </build>
 
   <profiles>
+    <profile>
+      <id>spring-boot-build</id>
+      <activation>
+        <activeByDefault />
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.graalvm.buildtools</groupId>
+            <artifactId>native-maven-plugin</artifactId>
+          </plugin>
+          <plugin>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-maven-plugin</artifactId>
+            <version>${project.parent.version}</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>repackage</goal>
+                </goals>
+              </execution>
+            </executions>
+            <configuration>
+              <image>
+                <env>
+                  <BP_JVM_VERSION>21</BP_JVM_VERSION>
+                </env>
+                <buildpacks>
+                  <buildpack>gcr.io/paketo-buildpacks/bellsoft-liberica:10.4.3</buildpack>
+                  <buildpack>gcr.io/paketo-buildpacks/java-native-image</buildpack>
+                </buildpacks>
+              </image>
+              <mainClass>${start-class}</mainClass>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+
     <profile>
       <id>deploy-central</id>
       <activation>

--- a/pom.xml
+++ b/pom.xml
@@ -313,9 +313,6 @@
         <artifactId>maven-failsafe-plugin</artifactId>
         <version>${surefire-plugin.version}</version>
         <configuration>
-          <!-- Due to spring-boot repackage, without adding this property test classes are not found
-               See https://github.com/spring-projects/spring-boot/issues/6254 -->
-          <classesDirectory>${project.build.outputDirectory}</classesDirectory>
           <!-- Force alphabetical order to have a reproducible build -->
           <runOrder>alphabetical</runOrder>
           <includes>

--- a/pom.xml
+++ b/pom.xml
@@ -82,6 +82,7 @@
     <frontend-maven-plugin.version>1.15.0</frontend-maven-plugin.version>
     <checksum-maven-plugin.version>1.11</checksum-maven-plugin.version>
     <maven-antrun-plugin.version>3.1.0</maven-antrun-plugin.version>
+    <maven-resources-plugin.version>3.3.1</maven-resources-plugin.version>
   </properties>
 
   <dependencyManagement>
@@ -267,12 +268,14 @@
         <filtering>true</filtering>
         <includes>
           <include>config/*.properties</include>
+          <include>generator/dependencies/pom.xml</include>
         </includes>
       </resource>
       <resource>
         <directory>${basedir}/src/main/resources</directory>
         <excludes>
           <exclude>config/*.properties</exclude>
+          <exclude>generator/dependencies/pom.xml</exclude>
         </excludes>
       </resource>
     </resources>
@@ -562,6 +565,16 @@
     </plugins>
     <pluginManagement>
       <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-resources-plugin</artifactId>
+          <version>${maven-resources-plugin.version}</version>
+          <configuration>
+            <delimiters>
+              <delimiter>@</delimiter>
+            </delimiters>
+          </configuration>
+        </plugin>
         <plugin>
           <groupId>io.github.git-commit-id</groupId>
           <artifactId>git-commit-id-maven-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -714,7 +714,7 @@
     <profile>
       <id>spring-boot-build</id>
       <activation>
-        <activeByDefault />
+        <activeByDefault>true</activeByDefault>
       </activation>
       <build>
         <plugins>

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -44,7 +44,7 @@
     <jacoco.version>0.8.11</jacoco.version>
     <reflections.version>0.10.2</reflections.version>
     <json-web-token.version>0.12.5</json-web-token.version>
-    <jhlite.version>1.3.0</jhlite.version>
+    <jhlite.version>@project.version@</jhlite.version>
     <commons-lang3.version>3.14.0</commons-lang3.version>
     <ehcache.version>3.10.8</ehcache.version>
     <git-commit-id-plugin.version>7.0.0</git-commit-id-plugin.version>

--- a/tests-ci/start.sh
+++ b/tests-ci/start.sh
@@ -19,11 +19,14 @@ elif test -f "gradlew"; then
 fi
 
 echo "*** Identifying application executable..."
-export APP_JAR=$(find . -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests")
+export EXEC_JAR=$(\
+  find . -maxdepth 1 -name "*-exec.jar" | grep . \
+  || find . -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests" \
+)
 
-echo "*** Starting application ${APP_JAR}..."
+echo "*** Starting application using ${EXEC_JAR}..."
 java \
-  -jar ${APP_JAR} \
+  -jar ${EXEC_JAR} \
   --logging.level.ROOT=OFF & > /dev/null
 echo $! > .pid-jhlite
 

--- a/tests-ci/start.sh
+++ b/tests-ci/start.sh
@@ -18,12 +18,12 @@ elif test -f "gradlew"; then
   cd build/libs/
 fi
 
-echo "*** Removing other jar files..."
-rm *-javadoc.jar *-sources.jar *-tests.jar
+echo "*** Identifying application executable..."
+export APP_JAR=$(find . -maxdepth 1 -name "*.jar" | grep -v "\-javadoc" | grep -v "\-sources" | grep -v "\-tests")
 
-echo "*** Starting application..."
+echo "*** Starting application ${APP_JAR}..."
 java \
-  -jar *.jar \
+  -jar ${APP_JAR} \
   --logging.level.ROOT=OFF & > /dev/null
 echo $! > .pid-jhlite
 


### PR DESCRIPTION
See https://github.com/jhipster/jhipster-lite/pull/8760#issuecomment-1913704631
- jhlite version in `src/main/resources/generator/dependencies/pom.xml` is now computed from project version
- in ci tests, the jhlite jars of the current branch are installed in local maven repository
- jar repackaged by spring-boot-plugin now has its own `exec` classifier, in order to have both jar: the one for running jhlite, and the one custom-jhlite depends on, as [recommended by Spring](https://docs.spring.io/spring-boot/docs/current/maven-plugin/reference/htmlsingle/#packaging.examples.custom-classifier) in situation where module is both runnable and a dependency for other module