### PR TITLE
Fix warning ConstraintDeclarationException

### DIFF
--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
@@ -1,6 +1,5 @@
 package tech.jhipster.lite.statistic.infrastructure.secondary;
 
-import jakarta.validation.constraints.NotNull;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.ConcurrentHashMap;
@@ -25,7 +24,9 @@ class InMemoryStatisticsRepository implements StatisticsRepository {
   }
 
   @Override
-  public Statistics get(@NotNull StatisticsCriteria criteria) {
+  public Statistics get(StatisticsCriteria criteria) {
+    Assert.notNull("criteria", criteria);
+
     long appliedModulesCount = appliedModules.size();
     if (criteria.isAnyCriteriaApplied()) {
       appliedModulesCount =

--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepository.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepository.java
@@ -33,7 +33,9 @@ class MongoDBStatisticsRepository implements StatisticsRepository {
   }
 
   @Override
-  public Statistics get(@NotNull StatisticsCriteria criteria) {
+  public Statistics get(StatisticsCriteria criteria) {
+    Assert.notNull("criteria", criteria);
+
     if (criteria.isAnyCriteriaApplied()) {
       Query query = generateQuery(criteria);
       return new Statistics(mongoTemplate.count(query, AppliedModuleDocument.class));


### PR DESCRIPTION
> A method overriding another method must not redefine the parameter constraint configuration, but method InMemoryStatisticsRepository#get(StatisticsCriteria) redefines the configuration of StatisticsRepository#get(StatisticsCriteria)