### PR TITLE
(ci) Introduce java-build-tool in build matrix

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -394,7 +394,7 @@ jobs:
             build.gradle.kts \
             settings.gradle.kts \
             gradle/libs.versions.toml \
-            gradle/wrapper/gradle-wrapper.properties\
+            gradle/wrapper/gradle-wrapper.properties \
             | md5sum | head -n1 | cut -d " " -f1)
           echo $GRADLE_DEPS_MD5
           echo "md5sum=${GRADLE_DEPS_MD5}" >> $GITHUB_OUTPUT

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -366,9 +366,10 @@ jobs:
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
           ${{ matrix.java-build-tool }} == 'maven'
         id: cache_maven_md5sum
+        working-directory: /tmp/jhlite/${{ matrix.app }}/
         run: |
-          ls -al /tmp/jhlite/${{ matrix.app }}
-          MD5SUM_POM_XML=$(md5sum /tmp/jhlite/${{ matrix.app }}/pom.xml | cut -d ' ' -f 1)
+          ls -al
+          MD5SUM_POM_XML=$(md5sum pom.xml | cut -d ' ' -f 1)
           echo $MD5SUM_POM_XML
           echo "md5sum_pom_xml=${MD5SUM_POM_XML}" >> $GITHUB_OUTPUT
       - name: 'Init: cache local Maven repository'
@@ -386,8 +387,9 @@ jobs:
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
           ${{ matrix.java-build-tool }} == 'gradle'
         id: cache_gradle_md5sum
+        working-directory: /tmp/jhlite/${{ matrix.app }}/
         run: |
-          ls -al /tmp/jhlite/${{ matrix.app }}
+          ls -al
           GRADLE_DEPS_MD5=$(md5sum \
             build.gradle.kts \
             settings.gradle.kts \

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -370,13 +370,27 @@ jobs:
           echo $MD5SUM_POM_XML
           echo "md5sum_pom_xml=${MD5SUM_POM_XML}" >> $GITHUB_OUTPUT
       - name: 'Init: cache local Maven repository'
-        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
+        if: |
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          ${{ matrix.java-build-tool }} == 'maven'
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ matrix.app }}-${{ steps.cache_md5sum.outputs.md5sum_pom_xml }}
+          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_md5sum.outputs.md5sum_pom_xml }}
           restore-keys: |
-            ${{ runner.os }}-maven-
+            ${{ runner.os }}-${{ matrix.java-build-tool }}-
+      - name: 'Init: cache local Gradle repository'
+        if: |
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          ${{ matrix.java-build-tool }} == 'gradle'
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_md5sum.outputs.md5sum_pom_xml }}
+          restore-keys: |
+            ${{ runner.os }}-${{ matrix.java-build-tool }}-
       - name: 'Test: starting Sonar'
         if: steps.tests-requirement-check.outputs.execute_tests == 'true'
         working-directory: /tmp/jhlite/${{ matrix.app }}/

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -262,7 +262,7 @@ jobs:
           - app: customjhlite
             spring-config-format: properties
           - app: gradleapp
-            java-build-tool: maven
+            java-build-tool: gradle
     steps:
       - name: 'Setup: checkout project from main branch'
         if: github.event_name == 'pull_request'

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -257,9 +257,12 @@ jobs:
           - gradleapp
           - thymeleafapp
         include:
+          - java-build-tool: maven
           - spring-config-format: yaml
           - app: customjhlite
             spring-config-format: properties
+          - app: gradleapp
+            java-build-tool: maven
     steps:
       - name: 'Setup: checkout project from main branch'
         if: github.event_name == 'pull_request'
@@ -320,7 +323,7 @@ jobs:
         working-directory: ./current-branch/tests-ci/
         run: |
           ./start.sh 7471
-          ./generate.sh ${{ matrix.app }} ${{ matrix.spring-config-format }}
+          ./generate.sh ${{ matrix.app }} ${{ matrix.java-build-tool }} ${{ matrix.spring-config-format }}
           ./stop.sh
       - name: 'Generation: calculate md5sum ${{ matrix.app }}'
         id: calculate-md5sum

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -362,8 +362,10 @@ jobs:
             echo "execute_tests=false" >> $GITHUB_OUTPUT
           fi
       - name: 'Test: list ${{ matrix.app }}'
-        if: steps.tests-requirement-check.outputs.execute_tests == 'true'
-        id: cache_md5sum
+        if: |
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          ${{ matrix.java-build-tool }} == 'maven'
+        id: cache_maven_md5sum
         run: |
           ls -al /tmp/jhlite/${{ matrix.app }}
           MD5SUM_POM_XML=$(md5sum /tmp/jhlite/${{ matrix.app }}/pom.xml | cut -d ' ' -f 1)
@@ -376,9 +378,24 @@ jobs:
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_md5sum.outputs.md5sum_pom_xml }}
+          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_maven_md5sum.outputs.md5sum_pom_xml }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java-build-tool }}-
+      - name: 'Test: list ${{ matrix.app }}'
+        if: |
+          steps.tests-requirement-check.outputs.execute_tests == 'true' &&
+          ${{ matrix.java-build-tool }} == 'gradle'
+        id: cache_gradle_md5sum
+        run: |
+          ls -al /tmp/jhlite/${{ matrix.app }}
+          GRADLE_DEPS_MD5=$(md5sum \
+            build.gradle.kts \
+            settings.gradle.kts \
+            gradle/libs.versions.toml \
+            gradle/wrapper/gradle-wrapper.properties\
+            | md5sum | head -n1 | cut -d " " -f1)
+          echo $GRADLE_DEPS_MD5
+          echo "md5sum=${GRADLE_DEPS_MD5}" >> $GITHUB_OUTPUT
       - name: 'Init: cache local Gradle repository'
         if: |
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
@@ -388,7 +405,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_md5sum.outputs.md5sum_pom_xml }}
+          key: ${{ runner.os }}-${{ matrix.java-build-tool }}-${{ matrix.app }}-${{ steps.cache_gradle_md5sum.outputs.md5sum }}
           restore-keys: |
             ${{ runner.os }}-${{ matrix.java-build-tool }}-
       - name: 'Test: starting Sonar'

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -1,11 +1,11 @@
 #!/usr/bin/env bash
 
 show_syntax() {
-  echo "Usage: $0 <application> <spring-configuration-format>" >&2
+  echo "Usage: $0 <application> <java-build-tool> <spring-configuration-format>" >&2
   exit 1
 }
 
-if [ "$#" -ne 2 ]; then
+if [ "$#" -ne 3 ]; then
   show_syntax
 fi
 
@@ -16,7 +16,8 @@ elif test -f tests-ci/modulePayload.json; then
 fi
 
 application=$1
-configuration_format=$2
+java_build_tool=$2
+configuration_format=$3
 
 applyModules() {
   for module in $@
@@ -45,23 +46,16 @@ applyModules() {
   done
 }
 
-maven() {
+init_server() {
   applyModules \
   "init" \
-  "maven-wrapper" \
-  "maven-java"
-}
-
-gradle() {
-  applyModules \
-  "init" \
-  "gradle-wrapper" \
-  "gradle-java"
+  "${java_build_tool}-wrapper" \
+  "${java_build_tool}-java"
 }
 
 spring_boot() {
   applyModules \
-  "github-actions-maven" \
+  "github-actions-${java_build_tool}" \
   "java-base" \
   "checkstyle" \
   "protobuf" \
@@ -114,21 +108,23 @@ cucumber_with_jwt() {
 }
 
 if [[ $application == 'spring-boot' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
 elif [[ $application == 'fullstack' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
+# This is a temporary test app for testing features supporting gradle
+# It should be removed once gradle is fully supported
 elif [[ $application == 'gradleapp' ]]; then
-  gradle
+  init_server
   # TODO: use "spring_boot", "spring_boot_mvc" instead of the following individual modules
-  #  when jacoco-check-min-coverage and github-actions support gradle
+  #  when jacoco-check-min-coverage supports gradle
   applyModules \
-    "github-actions-gradle" \
+    "github-actions-${java_build_tool}" \
     "java-base" \
     "checkstyle" \
     "java-memoizers" \
@@ -148,7 +144,7 @@ elif [[ $application == 'gradleapp' ]]; then
   cucumber_with_jwt
 
 elif [[ $application == 'fullapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -195,7 +191,7 @@ elif [[ $application == 'fullapp' ]]; then
   applyModules "frontend-maven-plugin" "vue-core"
 
 elif [[ $application == 'oauth2app' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -217,7 +213,7 @@ elif [[ $application == 'oauth2app' ]]; then
   "dummy-feature"
 
 elif [[ $application == 'mysqlapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -238,7 +234,7 @@ elif [[ $application == 'mysqlapp' ]]; then
   applyModules "ehcache-xml-config"
 
 elif [[ $application == 'mariadbapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -247,7 +243,7 @@ elif [[ $application == 'mariadbapp' ]]; then
   applyModules "ehcache-xml-config"
 
 elif [[ $application == 'mssqlapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -255,7 +251,7 @@ elif [[ $application == 'mssqlapp' ]]; then
   applyModules "mssql"
 
 elif [[ $application == 'flywayapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -273,7 +269,7 @@ elif [[ $application == 'flywayapp' ]]; then
   "dummy-postgresql-flyway-changelog" \
 
 elif [[ $application == 'undertowapp' ]]; then
-  maven
+  init_server
   spring_boot_undertow
   sonar_back
 
@@ -295,7 +291,7 @@ elif [[ $application == 'undertowapp' ]]; then
   applyModules "spring-boot-cache"
 
 elif [[ $application == 'eurekaapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -304,14 +300,14 @@ elif [[ $application == 'eurekaapp' ]]; then
   "spring-cloud" \
 
 elif [[ $application == 'consulapp' ]]; then
-  maven
+  init_server
   spring_boot_undertow
   sonar_back
 
   applyModules "consul"
 
 elif [[ $application == 'gatewayapp' ]]; then
-  maven
+  init_server
   spring_boot_webflux
   sonar_back
 
@@ -321,7 +317,7 @@ elif [[ $application == 'gatewayapp' ]]; then
   "gateway"
 
 elif [[ $application == 'mongodbapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -336,7 +332,7 @@ elif [[ $application == 'mongodbapp' ]]; then
   "dummy-mongodb-persistence"
 
 elif [[ $application == 'redisapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -345,7 +341,7 @@ elif [[ $application == 'redisapp' ]]; then
   cucumber_with_jwt
 
 elif [[ $application == 'cassandraapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
   cucumber_with_jwt
@@ -359,7 +355,7 @@ elif [[ $application == 'cassandraapp' ]]; then
   "dummy-cassandra-persistence"
 
 elif [[ $application == 'neo4japp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
@@ -368,7 +364,7 @@ elif [[ $application == 'neo4japp' ]]; then
   cucumber_with_jwt
 
 elif [[ $application == 'angularapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -381,7 +377,7 @@ elif [[ $application == 'angularapp' ]]; then
   applyModules "angular-jwt" "angular-health"
 
 elif [[ $application == 'angularoauth2app' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -402,7 +398,7 @@ elif [[ $application == 'angularoauth2app' ]]; then
   applyModules "angular-oauth2"
 
 elif [[ $application == 'reactapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -416,7 +412,7 @@ elif [[ $application == 'reactapp' ]]; then
   applyModules "react-jwt"
 
 elif [[ $application == 'vueapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -427,7 +423,7 @@ elif [[ $application == 'vueapp' ]]; then
   "cypress"
 
 elif [[ $application == 'svelteapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back_front
 
@@ -437,21 +433,21 @@ elif [[ $application == 'svelteapp' ]]; then
   "svelte-core"
 
 elif [[ $application == 'kafkaapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
   applyModules "spring-boot-kafka" "spring-boot-kafka-akhq"
 
 elif [[ $application == 'pulsarapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 
   applyModules "spring-boot-pulsar"
 
 elif [[ $application == 'reactiveapp' ]]; then
-  maven
+  init_server
   spring_boot_webflux
   sonar_back
 
@@ -459,7 +455,7 @@ elif [[ $application == 'reactiveapp' ]]; then
   "springdoc-webflux-openapi"
 
 elif [[ $application == 'customjhlite' ]]; then
-  maven
+  init_server
   spring_boot
   sonar_back
 
@@ -472,7 +468,7 @@ elif [[ $application == 'typescriptapp' ]]; then
     "optional-typescript"
 
 elif [[ $application == 'thymeleafapp' ]]; then
-  maven
+  init_server
   spring_boot_mvc
   sonar_back
 

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -139,7 +139,7 @@ elif [[ $application == 'gradleapp' ]]; then
     "java-memoizers" \
     "java-enums" \
     "jib" \
-    "dockerfile-gradle" \
+    "dockerfile-${java_build_tool}" \
     "protobuf" \
     "pagination-domain" \
     "spring-boot" \
@@ -167,7 +167,7 @@ elif [[ $application == 'fullapp' ]]; then
   "spring-boot-devtools" \
   "logstash" \
   "jib" \
-  "dockerfile-maven" \
+  "dockerfile-${java_build_tool}" \
   "java-archunit" \
   "git-information" \
   "github-codespaces" \

--- a/tests-ci/generate.sh
+++ b/tests-ci/generate.sh
@@ -97,6 +97,15 @@ sonar_back_front() {
   applyModules "sonar-qube-java-backend-and-frontend"
 }
 
+frontend_server_plugin() {
+  if [[ $java_build_tool == 'maven' ]]; then
+    applyModules "frontend-maven-plugin"
+  else
+    echo -e "No frontend server plugin for $java_build_tool!"
+    exit 1
+  fi
+}
+
 cucumber_with_jwt() {
   applyModules \
   "spring-boot-jwt" \
@@ -188,7 +197,8 @@ elif [[ $application == 'fullapp' ]]; then
 
   applyModules "hibernate-2nd-level-cache"
 
-  applyModules "frontend-maven-plugin" "vue-core"
+  frontend_server_plugin
+  applyModules "vue-core"
 
 elif [[ $application == 'oauth2app' ]]; then
   init_server
@@ -368,9 +378,8 @@ elif [[ $application == 'angularapp' ]]; then
   spring_boot_mvc
   sonar_back_front
 
-  applyModules \
-  "frontend-maven-plugin" \
-  "angular-core" \
+  frontend_server_plugin
+  applyModules "angular-core"
 
   cucumber_with_jwt
 
@@ -384,8 +393,8 @@ elif [[ $application == 'angularoauth2app' ]]; then
   applyModules \
   "java-memoizers" \
 
+  frontend_server_plugin
   applyModules \
-  "frontend-maven-plugin" \
   "angular-core" \
   "cypress"
 
@@ -402,8 +411,8 @@ elif [[ $application == 'reactapp' ]]; then
   spring_boot_mvc
   sonar_back_front
 
+  frontend_server_plugin
   applyModules \
-  "frontend-maven-plugin" \
   "react-core" \
   "cypress"
 
@@ -416,8 +425,8 @@ elif [[ $application == 'vueapp' ]]; then
   spring_boot_mvc
   sonar_back_front
 
+  frontend_server_plugin
   applyModules \
-  "frontend-maven-plugin" \
   "vue-core" \
   "vue-pinia" \
   "cypress"
@@ -427,8 +436,8 @@ elif [[ $application == 'svelteapp' ]]; then
   spring_boot_mvc
   sonar_back_front
 
+  frontend_server_plugin
   applyModules \
-  "frontend-maven-plugin" \
   "prettier" \
   "svelte-core"
 


### PR DESCRIPTION
It allows better handling of build cache, and this will help testing more easily different gradle applications.
This will also solve the issue of applying a feature rather than a module: since we can't apply through JHipster REST API a feature 'github-actions' that regroups either 'github-actions-maven' or 'github-actions-gradle', we can either have bash function that return the right module for the java-build-tool or use expression like 'github-actions-${java_build_tool}'