### PR TITLE
Update obsolete node version to unlock dependabot updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,7 +92,7 @@
     "vue-tsc": "1.8.27"
   },
   "engines": {
-    "node": ">=16.0.0"
+    "node": ">=20.11.1"
   },
   "cacheDirectories": [
     "node_modules"


### PR DESCRIPTION
Updating obsolete node version declared as engine in package.json should unlock automatic updates of vuejs with dependabot since vuejs is requiring node >=18.12.0.

See https://github.com/dependabot/dependabot-core/issues/1633#issuecomment-577135095 for a similar issue