### PR TITLE
Remove useless cacheDirectories in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,8 +93,5 @@
   },
   "engines": {
     "node": ">=20.11.1"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
@@ -16,7 +16,7 @@ public class AngularModuleFactory {
 
   private static final JHipsterSource COMMON_ESLINT = from("client/common/eslint");
 
-  private static final String END_OF_PACKAGE_JSON_NEEDLE = "^}$";
+  private static final String ENGINES_NEEDLE = "  \"engines\":";
   private static final PackageName ANGULAR_CORE_PACKAGE = packageName("@angular/core");
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
@@ -100,7 +100,7 @@ public class AngularModuleFactory {
         .and()
       .mandatoryReplacements()
         .in(path("package.json"))
-          .add(lineBeforeRegex(END_OF_PACKAGE_JSON_NEEDLE), jestSonar(properties.indentation()))
+          .add(lineBeforeText(ENGINES_NEEDLE), jestSonar(properties.indentation()))
         .and()
       .and()
       .build();

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.client.angular.core.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.packagejson.VersionSource.*;
+import static tech.jhipster.lite.module.domain.packagejson.VersionSource.ANGULAR;
 
 import tech.jhipster.lite.generator.client.common.domain.ClientsModulesFactory;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -16,7 +16,7 @@ public class AngularModuleFactory {
 
   private static final JHipsterSource COMMON_ESLINT = from("client/common/eslint");
 
-  private static final String CACHE_NEEDLE = "  \"cacheDirectories\":";
+  private static final String END_OF_PACKAGE_JSON_NEEDLE = "^}$";
   private static final PackageName ANGULAR_CORE_PACKAGE = packageName("@angular/core");
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
@@ -100,7 +100,7 @@ public class AngularModuleFactory {
         .and()
       .mandatoryReplacements()
         .in(path("package.json"))
-          .add(lineBeforeText(CACHE_NEEDLE), jestSonar(properties.indentation()))
+          .add(lineBeforeRegex(END_OF_PACKAGE_JSON_NEEDLE), jestSonar(properties.indentation()))
         .and()
       .and()
       .build();

--- a/src/main/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactory.java
@@ -15,7 +15,7 @@ public class SvelteModuleFactory {
 
   private static final JHipsterSource SOURCE = from("client/svelte");
 
-  private static final String CACHE_NEEDLE = "  \"cacheDirectories\":";
+  private static final String ENGINES_NEEDLE = "  \"engines\":";
 
   private static final JHipsterSource PRIMARY_MAIN_SOURCE = SOURCE.append("src/main/webapp/app/common/primary/app");
   private static final JHipsterDestination PRIMARY_MAIN_DESTINATION = to("src/main/webapp/app/common/primary/app");
@@ -69,7 +69,7 @@ public class SvelteModuleFactory {
         .and()
       .optionalReplacements()
         .in(path("package.json"))
-          .add(lineBeforeText(CACHE_NEEDLE), type(properties.indentation()))
+          .add(lineBeforeText(ENGINES_NEEDLE), type(properties.indentation()))
           .and()
         .and()
       .files()

--- a/src/main/resources/generator/init/package.json.mustache
+++ b/src/main/resources/generator/init/package.json.mustache
@@ -6,8 +6,5 @@
   "license": "UNLICENSED",
   "engines": {
     "node": ">={{nodeVersion}}"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/test/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactoryTest.java
@@ -52,7 +52,7 @@ class AngularModuleFactoryTest {
       .containing("\"build\": \"ng build --output-path=target/classes/static\"")
       .containing("\"test\": \"ng test --coverage\"")
       .containing("\"lint\": \"ng lint\"")
-      .containing("  \"jestSonar\": {\n    \"reportPath\": \"target/test-results\",\n    \"reportFile\": \"TESTS-results-sonar.xml\"\n  },")
+      .containing("  \"jestSonar\": {\n    \"reportPath\": \"target/test-results\",\n    \"reportFile\": \"TESTS-results-sonar.xml\"\n  }")
       .and()
       .hasFile(".lintstagedrc.cjs")
       .containing(

--- a/src/test/resources/generator/command/package-complete.json
+++ b/src/test/resources/generator/command/package-complete.json
@@ -14,6 +14,5 @@
   },
   "engines": {
     "node": ">=14.18.1"
-  },
-  "cacheDirectories": ["node_modules"]
+  }
 }

--- a/src/test/resources/generator/command/package-empty.json
+++ b/src/test/resources/generator/command/package-empty.json
@@ -6,6 +6,5 @@
   "devDependencies": {},
   "engines": {
     "node": ">=14.18.1"
-  },
-  "cacheDirectories": ["node_modules"]
+  }
 }

--- a/src/test/resources/generator/command/package-nothing.json
+++ b/src/test/resources/generator/command/package-nothing.json
@@ -3,6 +3,5 @@
   "version": "0.0.1",
   "engines": {
     "node": ">=14.18.1"
-  },
-  "cacheDirectories": ["node_modules"]
+  }
 }

--- a/src/test/resources/generator/command/package-test.json
+++ b/src/test/resources/generator/command/package-test.json
@@ -10,6 +10,5 @@
   },
   "engines": {
     "node": ">=14.18.1"
-  },
-  "cacheDirectories": ["node_modules"]
+  }
 }

--- a/src/test/resources/projects/empty-node/package.json
+++ b/src/test/resources/projects/empty-node/package.json
@@ -6,8 +6,5 @@
   "license": "UNLICENSED",
   "engines": {
     "node": ">=16.13.0"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/test/resources/projects/files/package.json
+++ b/src/test/resources/projects/files/package.json
@@ -19,8 +19,5 @@
   },
   "engines": {
     "node": ">=16.16.0"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/test/resources/projects/node-multiple-scripts/package.json
+++ b/src/test/resources/projects/node-multiple-scripts/package.json
@@ -16,8 +16,5 @@
   },
   "engines": {
     "node": ">=16.13.0"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/test/resources/projects/node-template/package.json
+++ b/src/test/resources/projects/node-template/package.json
@@ -9,8 +9,5 @@
   "devDependencies": {},
   "engines": {
     "node": ">=16.13.0"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }

--- a/src/test/resources/projects/node/package.json
+++ b/src/test/resources/projects/node/package.json
@@ -15,8 +15,5 @@
   },
   "engines": {
     "node": ">=16.13.0"
-  },
-  "cacheDirectories": [
-    "node_modules"
-  ]
+  }
 }


### PR DESCRIPTION
- this is a non-standard configuration that is not mentionned in https://docs.npmjs.com/cli/v10/configuring-npm/package-json
- it's a specific heroku configuration, that is not useful for us, especially as its value is the default value: https://devcenter.heroku.com/articles/nodejs-support#custom-caching