### PR TITLE
Use maven-model-helper library to write changes to the POM model

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     <apache-commons-io.version>2.15.1</apache-commons-io.version>
     <cucumber.version>7.15.0</cucumber.version>
-    <maven-model.version>3.9.6</maven-model.version>
+    <maven-model-helper.version>26-SNAPSHOT</maven-model-helper.version>
     <night-config.version>3.6.7</night-config.version>
     <testcontainers.version>1.19.6</testcontainers.version>
     <mongock.version>5.4.0</mongock.version>
@@ -160,9 +160,9 @@
     </dependency>
 
     <dependency>
-      <groupId>org.apache.maven</groupId>
-      <artifactId>maven-model</artifactId>
-      <version>${maven-model.version}</version>
+      <groupId>io.fabric8</groupId>
+      <artifactId>maven-model-helper</artifactId>
+      <version>${maven-model-helper.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
     <sonar-maven-plugin.version>3.10.0.2594</sonar-maven-plugin.version>
     <apache-commons-io.version>2.15.1</apache-commons-io.version>
     <cucumber.version>7.15.0</cucumber.version>
-    <maven-model-helper.version>26-SNAPSHOT</maven-model-helper.version>
+    <maven-model-helper.version>28</maven-model-helper.version>
     <night-config.version>3.6.7</night-config.version>
     <testcontainers.version>1.19.6</testcontainers.version>
     <mongock.version>5.4.0</mongock.version>

--- a/src/test/java/tech/jhipster/lite/generator/server/javatool/protobuf/domain/ProtobufModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/javatool/protobuf/domain/ProtobufModuleFactoryTest.java
@@ -88,7 +88,6 @@ class ProtobufModuleFactoryTest {
         )
         .containing(
           """
-            <build>
               <extensions>
                 <extension>
                   <groupId>kr.motd.maven</groupId>

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModulesRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemJHipsterModulesRepositoryTest.java
@@ -126,6 +126,29 @@ class FileSystemJHipsterModulesRepositoryTest {
       .containing(
         """
               <build>
+                <plugins>
+                  <plugin>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-maven-plugin</artifactId>
+                  </plugin>
+                  <plugin>
+                    <artifactId>maven-enforcer-plugin</artifactId>
+                  </plugin>
+                  <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <dependencies>
+                      <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-screenshot</artifactId>
+                      </dependency>
+                      <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-diagram</artifactId>
+                      </dependency>
+                    </dependencies>
+                  </plugin>
+                </plugins>
                 <pluginManagement>
                   <plugins>
                     <plugin>
@@ -194,29 +217,6 @@ class FileSystemJHipsterModulesRepositoryTest {
                     </plugin>
                   </plugins>
                 </pluginManagement>
-                <plugins>
-                  <plugin>
-                    <groupId>org.springframework.boot</groupId>
-                    <artifactId>spring-boot-maven-plugin</artifactId>
-                  </plugin>
-                  <plugin>
-                    <artifactId>maven-enforcer-plugin</artifactId>
-                  </plugin>
-                  <plugin>
-                    <groupId>org.asciidoctor</groupId>
-                    <artifactId>asciidoctor-maven-plugin</artifactId>
-                    <dependencies>
-                      <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-screenshot</artifactId>
-                      </dependency>
-                      <dependency>
-                        <groupId>org.asciidoctor</groupId>
-                        <artifactId>asciidoctorj-diagram</artifactId>
-                      </dependency>
-                    </dependencies>
-                  </plugin>
-                </plugins>
               </build>
             """
       )

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.module.infrastructure.secondary.javadependency.maven;
 
 import static org.assertj.core.api.Assertions.*;
+import static tech.jhipster.lite.TestFileUtils.contentNormalizingNewLines;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.*;
 
@@ -50,7 +51,7 @@ class MavenCommandHandlerTest {
 
     new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetVersion(springBootVersion()));
 
-    assertThat(content(pom)).startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+    assertThat(contentNormalizingNewLines(pom)).startsWith("<?xml version=\"1.0\" encoding=\"UTF-8\"?>");
   }
 
   @Test
@@ -59,7 +60,7 @@ class MavenCommandHandlerTest {
 
     new MavenCommandHandler(Indentation.from(4), pom).handle(new SetVersion(springBootVersion()));
 
-    assertThat(content(pom))
+    assertThat(contentNormalizingNewLines(pom))
       .contains("    <properties>")
       .contains("        <spring-boot.version>1.2.3</spring-boot.version>")
       .contains("    </properties>");
@@ -74,7 +75,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetVersion(springBootVersion()));
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains("  <properties>")
         .contains("    <spring-boot.version>1.2.3</spring-boot.version>")
         .contains("  </properties>");
@@ -86,7 +87,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetVersion(springBootVersion()));
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains("  <properties>")
         .contains("    <spring-boot.version>1.2.3</spring-boot.version>")
         .contains("  </properties>");
@@ -98,7 +99,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetVersion(springBootVersion()));
 
-      assertThat(content(pom)).contains("    <spring-boot.version>1.2.3</spring-boot.version>").doesNotContain(">  ");
+      assertThat(contentNormalizingNewLines(pom)).contains("    <spring-boot.version>1.2.3</spring-boot.version>").doesNotContain(">  ");
     }
 
     @Test
@@ -107,7 +108,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetVersion(new JavaDependencyVersion("json-web-token", "0.12.0")));
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains("    <json-web-token.version>0.12.0</json-web-token.version>")
         .doesNotContain("    <json-web-token.version>0.11.5</json-web-token.version>")
         .doesNotContain(">  ");
@@ -126,7 +127,7 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty()));
 
-        assertThat(content(pom)).contains(
+        assertThat(contentNormalizingNewLines(pom)).contains(
           """
             <properties>
               <spring.profiles.active>local</spring.profiles.active>
@@ -141,7 +142,7 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty()));
 
-        assertThat(content(pom)).contains(
+        assertThat(contentNormalizingNewLines(pom)).contains(
           """
             <properties>
               <spring.profiles.active>local</spring.profiles.active>
@@ -156,7 +157,7 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty()));
 
-        assertThat(content(pom)).contains("    <spring.profiles.active>local</spring.profiles.active>").doesNotContain(">  ");
+        assertThat(contentNormalizingNewLines(pom)).contains("    <spring.profiles.active>local</spring.profiles.active>").doesNotContain(">  ");
       }
 
       @Test
@@ -167,7 +168,7 @@ class MavenCommandHandlerTest {
           new SetBuildProperty(new BuildProperty(new PropertyKey("spring.profiles.active"), new PropertyValue("dev")))
         );
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains("    <spring.profiles.active>dev</spring.profiles.active>")
           .doesNotContain("    <spring.profiles.active>local</spring.profiles.active>")
           .doesNotContain(">  ");
@@ -195,7 +196,7 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty(), localMavenProfile()));
 
-        assertThat(content(pom)).contains(
+        assertThat(contentNormalizingNewLines(pom)).contains(
           """
             <profiles>
               <profile>
@@ -215,7 +216,7 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty(), localMavenProfile()));
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(
             """
                     <spring.profiles.active>local</spring.profiles.active>
@@ -237,7 +238,7 @@ class MavenCommandHandlerTest {
           new SetBuildProperty(new BuildProperty(new PropertyKey("spring.profiles.active"), new PropertyValue("dev")), localMavenProfile())
         );
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(
             """
                     <spring.profiles.active>dev</spring.profiles.active>
@@ -260,7 +261,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaBuildProfile(localMavenProfile()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
             <profile>
               <id>local</id>
@@ -278,7 +279,7 @@ class MavenCommandHandlerTest {
         new AddJavaBuildProfile(localMavenProfile(), BuildProfileActivation.builder().activeByDefault().build())
       );
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
           <profiles>
             <profile>
@@ -298,7 +299,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaBuildProfile(new BuildProfileId("dev")));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
             <profile>
               <id>dev</id>
@@ -314,7 +315,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaBuildProfile(localMavenProfile()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
           <profiles>
             <profile>
@@ -333,7 +334,7 @@ class MavenCommandHandlerTest {
         new AddJavaBuildProfile(localMavenProfile(), BuildProfileActivation.builder().build())
       );
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
           <profiles>
             <profile>
@@ -366,7 +367,7 @@ class MavenCommandHandlerTest {
 
       mavenCommandHandler.handle(new RemoveJavaDependencyManagement(springBootDependencyId()));
 
-      assertThat(content(pom)).doesNotContain(
+      assertThat(contentNormalizingNewLines(pom)).doesNotContain(
         """
               <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -394,7 +395,7 @@ class MavenCommandHandlerTest {
         )
       );
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains(
           """
               <profile>
@@ -417,7 +418,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
           <dependencyManagement>
             <dependencies>
@@ -440,7 +441,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
               <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -461,7 +462,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddJavaDependencyManagement(springBootStarterWebDependency()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
               <dependency>
                 <groupId>org.springframework.boot</groupId>
@@ -487,7 +488,7 @@ class MavenCommandHandlerTest {
         new AddJavaDependencyManagement(defaultVersionDependency(), localMavenProfile())
       );
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
             <profile>
               <id>local</id>
@@ -523,7 +524,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new RemoveDirectJavaDependency(jsonWebTokenDependencyId()));
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .doesNotContain("      <groupId>io.jsonwebtoken</groupId>")
         .doesNotContain("      <artifactId>jjwt-api</artifactId>")
         .doesNotContain("      <version>${json-web-token.version}</version>")
@@ -537,7 +538,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new RemoveDirectJavaDependency(jsonWebTokenDependencyId()));
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains(
           """
               <dependency>
@@ -568,7 +569,7 @@ class MavenCommandHandlerTest {
         )
       );
 
-      assertThat(content(pom))
+      assertThat(contentNormalizingNewLines(pom))
         .contains(
           """
               <profile>
@@ -590,7 +591,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(optionalTestDependency()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
           <dependencies>
             <dependency>
@@ -612,7 +613,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(optionalTestDependency()));
 
-      String content = content(pom);
+      String content = contentNormalizingNewLines(pom);
       assertThat(content).contains(
         """
             <dependency>
@@ -636,7 +637,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(springBootStarterWebDependency()));
 
-      String content = content(pom);
+      String content = contentNormalizingNewLines(pom);
       assertThat(content).contains(
         """
             <dependency>
@@ -659,7 +660,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(defaultVersionDependency()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
               <artifactId>logstash-logback-encoder</artifactId>
             </dependency>
@@ -679,7 +680,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(defaultVersionDependency()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-starter</artifactId>
@@ -695,7 +696,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddDirectJavaDependency(defaultVersionDependency()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
               <groupId>org.springframework.boot</groupId>
               <artifactId>spring-boot-starter</artifactId>
@@ -713,7 +714,7 @@ class MavenCommandHandlerTest {
         new AddDirectJavaDependency(defaultVersionDependency(), localMavenProfile())
       );
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
             <profile>
               <id>local</id>
@@ -753,7 +754,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains(pluginManagement());
+        assertThat(contentNormalizingNewLines(pom)).contains(pluginManagement());
       }
 
       @Test
@@ -764,7 +765,7 @@ class MavenCommandHandlerTest {
           AddMavenPluginManagement.builder().plugin(mavenEnforcerPlugin()).pluginVersion(mavenEnforcerVersion()).build()
         );
 
-        assertThat(content(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
       }
 
       @Test
@@ -777,7 +778,7 @@ class MavenCommandHandlerTest {
           .build();
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(command);
 
-        assertThat(content(pom)).contains("<json-web-token.version>1.1.1</json-web-token.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<json-web-token.version>1.1.1</json-web-token.version>");
       }
 
       @Test
@@ -786,7 +787,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(pluginManagement())
           .doesNotContain(
             """
@@ -802,7 +803,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(pluginManagement())
           .doesNotContain(
             """
@@ -820,7 +821,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains(pluginManagement());
+        assertThat(contentNormalizingNewLines(pom)).contains(pluginManagement());
       }
 
       private void addMavenEnforcerPlugin(Path pom) {
@@ -900,7 +901,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
       }
 
       @Test
@@ -909,7 +910,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains(plugins());
+        assertThat(contentNormalizingNewLines(pom)).contains(plugins());
       }
 
       private void addMavenEnforcerPlugin(Path pom) {
@@ -998,7 +999,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains(plugins());
+        assertThat(contentNormalizingNewLines(pom)).contains(plugins());
       }
 
       @Test
@@ -1009,7 +1010,7 @@ class MavenCommandHandlerTest {
           AddDirectMavenPlugin.builder().plugin(mavenEnforcerPlugin()).pluginVersion(mavenEnforcerVersion()).build()
         );
 
-        assertThat(content(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
       }
 
       @Test
@@ -1022,7 +1023,7 @@ class MavenCommandHandlerTest {
           .build();
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(command);
 
-        assertThat(content(pom)).contains("<json-web-token.version>1.1.1</json-web-token.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<json-web-token.version>1.1.1</json-web-token.version>");
       }
 
       @Test
@@ -1031,7 +1032,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(plugins())
           .doesNotContain(
             """
@@ -1047,7 +1048,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(plugins())
           .doesNotContain(
             """
@@ -1067,7 +1068,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom))
+        assertThat(contentNormalizingNewLines(pom))
           .contains(plugins())
           .doesNotContain(
             """
@@ -1159,7 +1160,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
+        assertThat(contentNormalizingNewLines(pom)).contains("<maven-enforcer-plugin.version>1.1.1</maven-enforcer-plugin.version>");
       }
 
       @Test
@@ -1168,7 +1169,7 @@ class MavenCommandHandlerTest {
 
         addMavenEnforcerPlugin(pom);
 
-        assertThat(content(pom)).contains(plugins());
+        assertThat(contentNormalizingNewLines(pom)).contains(plugins());
       }
 
       private void addMavenEnforcerPlugin(Path pom) {
@@ -1253,7 +1254,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddMavenBuildExtension(mavenBuildExtensionWithSlug()));
 
-      assertThat(content(pom)).contains(
+      assertThat(contentNormalizingNewLines(pom)).contains(
         """
             <extensions>
               <extension>
@@ -1272,7 +1273,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddMavenBuildExtension(mavenBuildExtensionWithSlug()));
 
-      String content = content(pom);
+      String content = contentNormalizingNewLines(pom);
       assertThat(content).contains(
         """
             <extensions>
@@ -1294,7 +1295,7 @@ class MavenCommandHandlerTest {
 
       new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new AddMavenBuildExtension(mavenBuildExtensionWithSlug()));
 
-      String content = content(pom);
+      String content = contentNormalizingNewLines(pom);
       assertThat(content).contains(
         """
           <build>
@@ -1343,13 +1344,5 @@ class MavenCommandHandlerTest {
     }
 
     return pomPath;
-  }
-
-  private static String content(Path path) {
-    try {
-      return Files.readString(path);
-    } catch (IOException e) {
-      throw new AssertionError(e);
-    }
   }
 }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -157,7 +157,9 @@ class MavenCommandHandlerTest {
 
         new MavenCommandHandler(Indentation.DEFAULT, pom).handle(new SetBuildProperty(springProfilesActiveProperty()));
 
-        assertThat(contentNormalizingNewLines(pom)).contains("    <spring.profiles.active>local</spring.profiles.active>").doesNotContain(">  ");
+        assertThat(contentNormalizingNewLines(pom))
+          .contains("    <spring.profiles.active>local</spring.profiles.active>")
+          .doesNotContain(">  ");
       }
 
       @Test

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -1274,17 +1274,16 @@ class MavenCommandHandlerTest {
 
       String content = content(pom);
       assertThat(content).contains(
-        """
-          <build>
-            <extensions>
-              <extension>
-                <groupId>kr.motd.maven</groupId>
-                <artifactId>os-maven-plugin</artifactId>
-                <version>${os-maven-plugin.version}</version>
-              </extension>
-            </extensions>
-        """
-      );
+          """
+              <extensions>
+                <extension>
+                  <groupId>kr.motd.maven</groupId>
+                  <artifactId>os-maven-plugin</artifactId>
+                  <version>${os-maven-plugin.version}</version>
+                </extension>
+              </extensions>
+          """
+        );
 
       assertThat(Pattern.compile("^ +$", Pattern.MULTILINE).matcher(content).find()).isFalse();
     }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -1274,16 +1274,16 @@ class MavenCommandHandlerTest {
 
       String content = content(pom);
       assertThat(content).contains(
-          """
-              <extensions>
-                <extension>
-                  <groupId>kr.motd.maven</groupId>
-                  <artifactId>os-maven-plugin</artifactId>
-                  <version>${os-maven-plugin.version}</version>
-                </extension>
-              </extensions>
-          """
-        );
+        """
+            <extensions>
+              <extension>
+                <groupId>kr.motd.maven</groupId>
+                <artifactId>os-maven-plugin</artifactId>
+                <version>${os-maven-plugin.version}</version>
+              </extension>
+            </extensions>
+        """
+      );
 
       assertThat(Pattern.compile("^ +$", Pattern.MULTILINE).matcher(content).find()).isFalse();
     }


### PR DESCRIPTION
This will allow better preservation of original comments and order of existing elements when updating a pom.xml