### PR TITLE
Use renovate to update docker-compose dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -104,14 +104,6 @@ updates:
           - '@typescript-eslint*'
 
   - package-ecosystem: 'docker'
-    directory: '/src/main/docker'
-    schedule:
-      interval: 'daily'
-      time: '00:00'
-    open-pull-requests-limit: 20
-    labels:
-      - 'area: dependencies'
-  - package-ecosystem: 'docker'
     directory: '/src/main/resources/generator/dependencies'
     schedule:
       interval: 'daily'

--- a/renovate.json
+++ b/renovate.json
@@ -8,5 +8,8 @@
     ":automergeRequireAllStatusChecks",
     ":label(area: dependencies)"
   ],
-  "enabledManagers": ["maven-wrapper", "gradle-wrapper"]
+  "enabledManagers": ["maven-wrapper", "gradle-wrapper", "docker-compose"],
+  "docker-compose": {
+    "fileMatch": ["^src/main/docker/[^/]*\\.ya?ml$"]
+  }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,12 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:recommended", ":disableDependencyDashboard"],
+  "extends": [
+    "config:recommended",
+    ":disableDependencyDashboard",
+    ":automergeMinor",
+    ":automergePr",
+    ":automergeRequireAllStatusChecks",
+    ":label(area: dependencies)"
+  ],
   "enabledManagers": ["maven-wrapper", "gradle-wrapper"]
 }


### PR DESCRIPTION
Since dependabot does not support docker-compose, let's use renovate.
- Finalize renovate configuration (labels, automerge, ...)
- Enable docker-compose renovate manager, and configure additional fileMatch
- Remove useless dependabot configuration

Tested on my fork: https://github.com/murdos/jhipster-lite/pull/2588