### PR TITLE
Sonar: %n should be used in place of \n to produce the platform-specific line separator.

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
@@ -176,7 +176,7 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       .map(GradleDependencyScope::command)
       .collect(Collectors.joining("|", "(?:", ")"));
     Pattern dependencyLinePattern = Pattern.compile(
-      "^\\s+%s\\((?:platform\\()?libs\\.%s\\)?\\)(?:\\s+\\{\\n(?:\\s+exclude\\([^)]*\\)\\n)+\\s+\\})?$".formatted(
+      "^\\s+%s\\((?:platform\\()?libs\\.%s\\)?\\)(?:\\s+\\{(?:\\s+exclude\\([^)]*\\))+\\s+\\})?$".formatted(
           scopePattern,
           dependencySlug.slug().replace("-", "\\.")
         ),

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandlerTest.java
@@ -476,6 +476,7 @@ class GradleCommandHandlerTest {
         .groupId("org.springframework.boot")
         .artifactId("spring-boot-dependencies")
         .addExclusion(jsonWebTokenDependencyId())
+        .addExclusion(springBootDependencyId())
         .scope(JavaDependencyScope.IMPORT)
         .type(JavaDependencyType.POM)
         .build();


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?resolved=false&types=CODE_SMELL&id=jhipster_jhipster-lite&open=AY32YPdwSjlKq-G0oiu5&tab=code