### PR TITLE
Use renovate for handling npm dependencies of jhlite engine

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -53,14 +53,6 @@ updates:
       - 'area: dependencies'
 
   - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'daily'
-      time: '00:00'
-    open-pull-requests-limit: 10
-    labels:
-      - 'area: dependencies'
-  - package-ecosystem: 'npm'
     directory: '/src/main/resources/generator/dependencies/common'
     schedule:
       interval: 'daily'

--- a/renovate.json
+++ b/renovate.json
@@ -8,7 +8,7 @@
     ":automergeRequireAllStatusChecks",
     ":label(area: dependencies)"
   ],
-  "enabledManagers": ["maven-wrapper", "gradle-wrapper", "docker-compose"],
+  "enabledManagers": ["maven-wrapper", "gradle-wrapper", "docker-compose", "npm"],
   "docker-compose": {
     "fileMatch": ["^src/main/docker/[^/]*\\.ya?ml$"]
   }

--- a/renovate.json
+++ b/renovate.json
@@ -11,5 +11,8 @@
   "enabledManagers": ["maven-wrapper", "gradle-wrapper", "docker-compose", "npm"],
   "docker-compose": {
     "fileMatch": ["^src/main/docker/[^/]*\\.ya?ml$"]
+  },
+  "npm": {
+    "ignorePaths": ["src/**"]
   }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -8,6 +8,7 @@
     ":automergeRequireAllStatusChecks",
     ":label(area: dependencies)"
   ],
+  "prHourlyLimit": 20,
   "enabledManagers": ["maven-wrapper", "gradle-wrapper", "docker-compose", "npm"],
   "docker-compose": {
     "fileMatch": ["^src/main/docker/[^/]*\\.ya?ml$"]


### PR DESCRIPTION
dependabot doesn't seem verify reliable with npm dependencies according to recent issues, e.g., #9101 and #9030
Renovate seems to better handle things: https://github.com/murdos/jhipster-lite/pull/2604