### PR TITLE
add develocity integration

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -39,6 +39,13 @@ jobs:
         run: |
           ./mvnw clean verify
 
+      - name: Archive results
+        uses: actions/upload-artifact@v4
+        with:
+          name: target
+          path: |
+            target/**/*.*
+
   #--------------------------------------------------
   # Build and Tests the project on Linux
   #--------------------------------------------------

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,11 +34,11 @@ jobs:
       - name: 'Init: install Node.js packages'
         run: npm ci
       - name: 'Test: run backend tests'
-        with:
-          env:
-            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./mvnw clean verify
+
   #--------------------------------------------------
   # Build and Tests the project on Linux
   #--------------------------------------------------

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -34,6 +34,9 @@ jobs:
       - name: 'Init: install Node.js packages'
         run: npm ci
       - name: 'Test: run backend tests'
+        with:
+          env:
+            GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./mvnw clean verify
   #--------------------------------------------------

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -75,6 +75,8 @@ jobs:
       - name: 'TEMP: enable gradle build tool slug'
         run: sed -i '/- gradle-java/d' src/main/resources/config/application.yml
       - name: 'Test: run backend tests'
+        env:
+          GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           chmod +x mvnw
           ./mvnw clean verify -Dsonar.qualitygate.wait=true sonar:sonar

--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -38,14 +38,6 @@ jobs:
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GRADLE_ENTERPRISE_ACCESS_KEY }}
         run: |
           ./mvnw clean verify
-
-      - name: Archive results
-        uses: actions/upload-artifact@v4
-        with:
-          name: target
-          path: |
-            target/**/*.*
-
   #--------------------------------------------------
   # Build and Tests the project on Linux
   #--------------------------------------------------

--- a/.gitignore
+++ b/.gitignore
@@ -190,3 +190,8 @@ dist/
 # Spring personal profile
 ######################
 src/main/resources/config/application-perso.*
+
+######################
+# Gradle Develocity Settings
+######################
+.mvn/.gradle-enterprise/gradle-enterprise-workspace-id

--- a/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+++ b/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
@@ -1,1 +1,0 @@
-yunztrsuizcldcwm5dwyegb57u

--- a/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
+++ b/.mvn/.gradle-enterprise/gradle-enterprise-workspace-id
@@ -1,0 +1,1 @@
+yunztrsuizcldcwm5dwyegb57u

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.20</version>
+    <version>1.20.1</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,0 +1,12 @@
+<extensions>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <version>1.20</version>
+  </extension>
+  <extension>
+    <groupId>com.gradle</groupId>
+    <artifactId>common-custom-user-data-maven-extension</artifactId>
+    <version>1.12.5</version>
+  </extension>
+</extensions>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.20</version>
+    <version>1.19</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.19</version>
+    <version>1.20</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -1,0 +1,25 @@
+<gradleEnterprise>
+  <server>
+    <url>https://ge.jhipster.tech</url>
+  </server>
+  <buildScan>
+    <capture>                                         
+      <goalInputFiles>true</goalInputFiles>
+    </capture>
+    <publish>ALWAYS</publish>
+    <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
+    <publishIfAuthenticated>true</publishIfAuthenticated>
+    <obfuscation>
+      <ipAddresses>#{{'0.0.0.0'}}</ipAddresses>
+    </obfuscation>
+  </buildScan>
+    <buildCache>
+    <local>
+      <enabled>false</enabled>
+    </local>
+    <remote>
+      <enabled>false</enabled>
+      <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
+    </remote>
+  </buildCache>
+</gradleEnterprise>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -3,7 +3,7 @@
     <url>https://ge.jhipster.tech</url>
   </server>
   <buildScan>
-    <capture>                                         
+    <capture>
       <goalInputFiles>true</goalInputFiles>
     </capture>
     <publish>ALWAYS</publish>
@@ -15,7 +15,7 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
       <enabled>false</enabled>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -18,7 +18,7 @@
       <enabled>true</enabled>
     </local>
     <remote>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
       <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -15,7 +15,7 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>false</enabled>
+      <enabled>true</enabled>
     </local>
     <remote>
       <enabled>true</enabled>

--- a/.mvn/gradle-enterprise.xml
+++ b/.mvn/gradle-enterprise.xml
@@ -15,7 +15,7 @@
   </buildScan>
     <buildCache>
     <local>
-      <enabled>true</enabled>
+      <enabled>false</enabled>
     </local>
     <remote>
       <enabled>true</enabled>

--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@
 [![sonarcloud-security][sonarcloud-security]][sonarcloud-url]
 [![sonarcloud-code-smells][sonarcloud-code-smells]][sonarcloud-url]
 
+[![Revved up by Develocity][develocity-badge]][develocity-url]
+
 ## Description
 
 [JHipster][jhipster-url] is a development platform to quickly generate, develop & deploy modern web applications & microservice architectures.
@@ -308,3 +310,5 @@ Support this project by becoming a sponsor! [Become a sponsor](https://opencolle
 [webservices-with-jhlite]: https://youtu.be/mEECPRZjajI
 [jhipster-vs-jhlite]: https://youtu.be/t5GA329FMfU
 [cdamon]: https://www.linkedin.com/in/colin-damon/
+[develocity-badge]: https://img.shields.io/badge/Revved%20up%20by-Develocity-06A0CE?logo=Gradle&labelColor=02303A
+[develocity-url]: https://ge.jhipster.tech/scans

--- a/pom.xml
+++ b/pom.xml
@@ -728,20 +728,27 @@
                 <plugin>
                   <groupId>com.github.eirslett</groupId>
                   <artifactId>frontend-maven-plugin</artifactId>
-                  <execution>
-                    <executions>
-                      <execution>
-                        <id>build front</id>
+                  <executions>
+                    <execution>
+                      <id>npm install</id>
+                      <inputs />
+                      <outputs>
                         <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
-                      </execution>
-                    </executions>
-                    <executions>
-                      <execution>
-                        <id>front test</id>
+                      </outputs>
+                    </execution>
+                    <execution>
+                      <id>build front</id>
+                      <outputs>
+                        <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
+                      </outputs>
+                    </execution>
+                    <execution>
+                      <id>front test</id>
+                      <outputs>
                         <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
-                      </execution>
-                    </executions>
-                  </execution>
+                      </outputs>
+                    </execution>
+                  </executions>
                 </plugin>
                 <plugin>
                   <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -730,12 +730,16 @@
                   <artifactId>frontend-maven-plugin</artifactId>
                   <execution>
                     <executions>
-                      <id>build front</id>
-                      <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
+                      <execution>
+                        <id>build front</id>
+                        <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
+                      </execution>
                     </executions>
                     <executions>
-                      <id>front test</id>
-                      <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
+                      <execution>
+                        <id>front test</id>
+                        <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
+                      </execution>
                     </executions>
                   </execution>
                 </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -720,6 +720,30 @@
                 </runtimeClassPath>
               </normalization>
             </gradleEnterprise>
+            <plugins>
+              <plugin>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <inputs>
+                  <properties>
+                    <property>
+                      <name>junit.platform.listeners.uid.tracking.output.dir</name>
+                      <value>target/test-ids</value>
+                    </property>
+                  </properties>
+                </inputs>
+                <outputs>
+                  <fileSets>
+                    <fileSet>
+                      <name>test-ids</name>
+                      <paths>
+                        <path>target/test-ids</path>
+                      </paths>
+                      <normalization>RELATIVE_PATH</normalization>
+                    </fileSet>
+                  </fileSets>
+                </outputs>
+              </plugin>
+            </plugins>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -287,6 +287,12 @@
           <source>${java.version}</source>
           <target>${java.version}</target>
           <parameters>true</parameters>
+          <annotationProcessorPaths>
+            <path>
+              <groupId>org.springframework.boot</groupId>
+              <artifactId>spring-boot-configuration-processor</artifactId>
+            </path>
+          </annotationProcessorPaths>
         </configuration>
       </plugin>
 

--- a/pom.xml
+++ b/pom.xml
@@ -722,56 +722,14 @@
             </gradleEnterprise>
             <plugins>
               <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <executions>
-                  <execution>
-                    <id>enforce-versions</id>
-                  </execution>
-                  <execution>
-                    <id>enforce-dependencyConvergence</id>
-                    <inputs>
-                      <properties>
-                        <property>
-                          <name>fail</name>
-                        </property>
-                        <property>
-                          <name>failFast</name>
-                        </property>
-                        <property>
-                          <name>failIfNoRules</name>
-                        </property>
-                        <property>
-                          <name>rulesToSkip</name>
-                        </property>
-                        <property>
-                          <name>rulesToExecute</name>
-                        </property>
-                        <property>
-                          <name>rules</name>
-                        </property>
-                        <property>
-                          <name>skip</name>
-                        </property>
-                      </properties>
-                      <ignoredProperties>
-                        <ignore>ignoreCache</ignore>
-                        <ignore>mojoExecution</ignore>
-                        <ignore>session</ignore>
-                      </ignoredProperties>
-                    </inputs>
-                  </execution>
-                </executions>
-              </plugin>
-              <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inputs>
-                  <systemProperties>
-                    <systemProperty>
+                  <systemPropertyVariables>
+                    <systemPropertyVariable>
                       <name>junit.platform.listeners.uid.tracking.output.dir</name>
                       <value>target/test-ids</value>
-                    </systemProperty>
-                  </systemProperties>
+                    </systemPropertyVariable>
+                  </systemPropertyVariables>
                   <properties>
                     <property>
                       <name>junit.platform.listeners.uid.tracking.output.dir</name>

--- a/pom.xml
+++ b/pom.xml
@@ -722,8 +722,56 @@
             </gradleEnterprise>
             <plugins>
               <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-enforcer-plugin</artifactId>
+                <executions>
+                  <execution>
+                    <id>enforce-versions</id>
+                  </execution>
+                  <execution>
+                    <id>enforce-dependencyConvergence</id>
+                    <inputs>
+                      <properties>
+                        <property>
+                          <name>fail</name>
+                        </property>
+                        <property>
+                          <name>failFast</name>
+                        </property>
+                        <property>
+                          <name>failIfNoRules</name>
+                        </property>
+                        <property>
+                          <name>rulesToSkip</name>
+                        </property>
+                        <property>
+                          <name>rulesToExecute</name>
+                        </property>
+                        <property>
+                          <name>rules</name>
+                        </property>
+                        <property>
+                          <name>skip</name>
+                        </property>
+                      </properties>
+                      <ignoredProperties>
+                        <ignore>ignoreCache</ignore>
+                        <ignore>mojoExecution</ignore>
+                        <ignore>session</ignore>
+                      </ignoredProperties>
+                    </inputs>
+                  </execution>
+                </executions>
+              </plugin>
+              <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <inputs>
+                  <systemProperties>
+                    <systemProperty>
+                      <name>junit.platform.listeners.uid.tracking.output.dir</name>
+                      <value>target/test-ids</value>
+                    </systemProperty>
+                  </systemProperties>
                   <properties>
                     <property>
                       <name>junit.platform.listeners.uid.tracking.output.dir</name>

--- a/pom.xml
+++ b/pom.xml
@@ -719,37 +719,20 @@
                   </propertiesNormalizations>
                 </runtimeClassPath>
               </normalization>
+              <plugins>
+                <plugin>
+                  <artifactId>maven-surefire-plugin</artifactId>
+                  <outputs>
+                    <directories>
+                      <directory>
+                        <name>target/test-ids</name>
+                      </directory>
+                    </directories>
+                    <cacheableBecause>same content if nothing has changed</cacheableBecause>
+                  </outputs>
+                </plugin>
+              </plugins>
             </gradleEnterprise>
-            <plugins>
-              <plugin>
-                <artifactId>maven-surefire-plugin</artifactId>
-                <inputs>
-                  <systemPropertyVariables>
-                    <systemPropertyVariable>
-                      <name>junit.platform.listeners.uid.tracking.output.dir</name>
-                      <value>target/test-ids</value>
-                    </systemPropertyVariable>
-                  </systemPropertyVariables>
-                  <properties>
-                    <property>
-                      <name>junit.platform.listeners.uid.tracking.output.dir</name>
-                      <value>target/test-ids</value>
-                    </property>
-                  </properties>
-                </inputs>
-                <outputs>
-                  <fileSets>
-                    <fileSet>
-                      <name>test-ids</name>
-                      <paths>
-                        <path>target/test-ids</path>
-                      </paths>
-                      <normalization>RELATIVE_PATH</normalization>
-                    </fileSet>
-                  </fileSets>
-                </outputs>
-              </plugin>
-            </plugins>
           </configuration>
         </plugin>
       </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -301,11 +301,6 @@
             <exclude>**/*IT*</exclude>
             <exclude>**/*CucumberTest*</exclude>
           </excludes>
-          <!--          <systemPropertyVariables>-->
-          <!--            <junit.platform.listeners.uid.tracking.output.dir>-->
-          <!--              ${junit.platform.listeners.uid.tracking.output.dir}-->
-          <!--            </junit.platform.listeners.uid.tracking.output.dir>-->
-          <!--          </systemPropertyVariables>-->
         </configuration>
       </plugin>
 
@@ -729,20 +724,172 @@
                   </propertiesNormalizations>
                 </runtimeClassPath>
               </normalization>
-              <!--              <plugins>-->
-              <!--                <plugin>-->
-              <!--                  <groupId>org.apache.maven.plugins</groupId>-->
-              <!--                  <artifactId>maven-surefire-plugin</artifactId>-->
-              <!--                  <outputs>-->
-              <!--                    <directories>-->
-              <!--                      <directory>-->
-              <!--                        <name>test-ids</name>-->
-              <!--                        <path>${junit.platform.listeners.uid.tracking.output.dir}</path>-->
-              <!--                      </directory>-->
-              <!--                    </directories>-->
-              <!--                  </outputs>-->
-              <!--                </plugin>-->
-              <!--              </plugins>-->
+              <plugins>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-compiler-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>default-compile</id>
+                      <inputs>
+                        <ignoredProperties>
+                          <ignore>outputTimestamp</ignore>
+                        </ignoredProperties>
+                      </inputs>
+                      <outputs>
+                        <cacheableBecause>compilation outcome does not not change with property</cacheableBecause>
+                      </outputs>
+                    </execution>
+                    <execution>
+                      <id>default-testCompile</id>
+                      <inputs>
+                        <ignoredProperties>
+                          <ignore>outputTimestamp</ignore>
+                        </ignoredProperties>
+                      </inputs>
+                      <outputs>
+                        <cacheableBecause>compilation outcome does not not change with property</cacheableBecause>
+                      </outputs>
+                    </execution>
+                  </executions>
+                </plugin>
+                <plugin>
+                  <groupId>org.apache.maven.plugins</groupId>
+                  <artifactId>maven-enforcer-plugin</artifactId>
+                  <executions>
+                    <execution>
+                      <id>enforce-versions</id>
+                      <outputs>
+                        <cacheableBecause>version check should be cached</cacheableBecause>
+                      </outputs>
+                      <inputs>
+                        <properties>
+                          <property>
+                            <name>fail</name>
+                          </property>
+                          <property>
+                            <name>failFast</name>
+                          </property>
+                          <property>
+                            <name>failIfNoRules</name>
+                          </property>
+                          <property>
+                            <name>rulesToSkip</name>
+                          </property>
+                          <property>
+                            <name>rulesToExecute</name>
+                          </property>
+                          <property>
+                            <name>rules</name>
+                          </property>
+                          <property>
+                            <name>skip</name>
+                          </property>
+                        </properties>
+                        <ignoredProperties>
+                          <ignore>ignoreCache</ignore>
+                          <ignore>mojoExecution</ignore>
+                          <ignore>session</ignore>
+                        </ignoredProperties>
+                      </inputs>
+                      <nestedProperties>
+                        <property>
+                          <name>project</name>
+                          <iteratedProperties>
+                            <property>
+                              <name>dependencies</name>
+                              <inputs>
+                                <properties>
+                                  <property>
+                                    <name>groupId</name>
+                                  </property>
+                                  <property>
+                                    <name>artifactId</name>
+                                  </property>
+                                  <property>
+                                    <name>version</name>
+                                  </property>
+                                  <property>
+                                    <name>type</name>
+                                  </property>
+                                  <property>
+                                    <name>scope</name>
+                                  </property>
+                                </properties>
+                              </inputs>
+                            </property>
+                          </iteratedProperties>
+                        </property>
+                      </nestedProperties>
+                    </execution>
+                    <execution>
+                      <id>enforce-dependencyConvergence</id>
+                      <outputs>
+                        <cacheableBecause>depencency convergenve should be cached</cacheableBecause>
+                      </outputs>
+                      <inputs>
+                        <properties>
+                          <property>
+                            <name>fail</name>
+                          </property>
+                          <property>
+                            <name>failFast</name>
+                          </property>
+                          <property>
+                            <name>failIfNoRules</name>
+                          </property>
+                          <property>
+                            <name>rulesToSkip</name>
+                          </property>
+                          <property>
+                            <name>rulesToExecute</name>
+                          </property>
+                          <property>
+                            <name>rules</name>
+                          </property>
+                          <property>
+                            <name>skip</name>
+                          </property>
+                        </properties>
+                        <ignoredProperties>
+                          <ignore>ignoreCache</ignore>
+                          <ignore>mojoExecution</ignore>
+                          <ignore>session</ignore>
+                        </ignoredProperties>
+                      </inputs>
+                      <nestedProperties>
+                        <property>
+                          <name>project</name>
+                          <iteratedProperties>
+                            <property>
+                              <name>dependencies</name>
+                              <inputs>
+                                <properties>
+                                  <property>
+                                    <name>groupId</name>
+                                  </property>
+                                  <property>
+                                    <name>artifactId</name>
+                                  </property>
+                                  <property>
+                                    <name>version</name>
+                                  </property>
+                                  <property>
+                                    <name>type</name>
+                                  </property>
+                                  <property>
+                                    <name>scope</name>
+                                  </property>
+                                </properties>
+                              </inputs>
+                            </property>
+                          </iteratedProperties>
+                        </property>
+                      </nestedProperties>
+                    </execution>
+                  </executions>
+                </plugin>
+              </plugins>
             </gradleEnterprise>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -731,19 +731,173 @@
                   <executions>
                     <execution>
                       <id>npm install</id>
-                      <inputs />
+                      <inputs>
+                        <properties>
+                          <property>
+                            <name>arguments</name>
+                          </property>
+                          <property>
+                            <name>environmentVariables</name>
+                          </property>
+                          <property>
+                            <name>npmInheritsProxyConfigFromMaven</name>
+                          </property>
+                          <property>
+                            <name>npmRegistryURL</name>
+                          </property>
+                          <property>
+                            <name>skip</name>
+                          </property>
+                          <property>
+                            <name>testFailureIgnore</name>
+                          </property>
+                          <property>
+                            <name>installDirectory</name>
+                          </property>
+                        </properties>
+                        <ignoredProperties>
+                          <ignore>execution</ignore>
+                          <ignore>project</ignore>
+                          <ignore>repositorySystemSession</ignore>
+                          <ignore>workingDirectory</ignore>
+                          <ignore>skipTests</ignore>
+                          <ignore>session</ignore>
+                        </ignoredProperties>
+                        <fileSets>
+                          <fileSet>
+                            <name>package-json</name>
+                            <paths>
+                              <path>${project.basedir}/package.json</path>
+                            </paths>
+                            <normalization>RELATIVE_PATH</normalization>
+                          </fileSet>
+                          <fileSet>
+                            <name>package-lock</name>
+                            <paths>
+                              <path>${project.basedir}/package-lock.json</path>
+                            </paths>
+                            <normalization>RELATIVE_PATH</normalization>
+                          </fileSet>
+                        </fileSets>
+                      </inputs>
                       <outputs>
+                        <directories>
+                          <directory>
+                            <name>node_modules</name>
+                            <path>node_modules</path>
+                          </directory>
+                        </directories>
                         <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
                       </outputs>
                     </execution>
                     <execution>
                       <id>build front</id>
+                      <inputs>
+                        <properties>
+                          <property>
+                            <name>arguments</name>
+                          </property>
+                          <property>
+                            <name>environmentVariables</name>
+                          </property>
+                          <property>
+                            <name>npmInheritsProxyConfigFromMaven</name>
+                          </property>
+                          <property>
+                            <name>npmRegistryURL</name>
+                          </property>
+                          <property>
+                            <name>skip</name>
+                          </property>
+                          <property>
+                            <name>testFailureIgnore</name>
+                          </property>
+                          <property>
+                            <name>installDirectory</name>
+                          </property>
+                        </properties>
+                        <ignoredProperties>
+                          <ignore>execution</ignore>
+                          <ignore>project</ignore>
+                          <ignore>repositorySystemSession</ignore>
+                          <ignore>workingDirectory</ignore>
+                          <ignore>skipTests</ignore>
+                          <ignore>session</ignore>
+                        </ignoredProperties>
+                        <fileSets>
+                          <fileSet>
+                            <name>sources</name>
+                            <paths>
+                              <path>${project.basedir}/src/main/webapp</path>
+                            </paths>
+                            <includes>
+                              <include>**/*.*</include>
+                            </includes>
+                            <normalization>RELATIVE_PATH</normalization>
+                          </fileSet>
+                        </fileSets>
+                      </inputs>
                       <outputs>
                         <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
                       </outputs>
                     </execution>
                     <execution>
                       <id>front test</id>
+                      <inputs>
+                        <properties>
+                          <property>
+                            <name>arguments</name>
+                          </property>
+                          <property>
+                            <name>environmentVariables</name>
+                          </property>
+                          <property>
+                            <name>npmInheritsProxyConfigFromMaven</name>
+                          </property>
+                          <property>
+                            <name>npmRegistryURL</name>
+                          </property>
+                          <property>
+                            <name>skip</name>
+                          </property>
+                          <property>
+                            <name>testFailureIgnore</name>
+                          </property>
+                          <property>
+                            <name>installDirectory</name>
+                          </property>
+                        </properties>
+                        <ignoredProperties>
+                          <ignore>execution</ignore>
+                          <ignore>project</ignore>
+                          <ignore>repositorySystemSession</ignore>
+                          <ignore>workingDirectory</ignore>
+                          <ignore>skipTests</ignore>
+                          <ignore>session</ignore>
+                        </ignoredProperties>
+                        <fileSets>
+                          <fileset>
+                            <name>sources</name>
+                            <paths>
+                              <path>${project.basedir}/src/main/webapp</path>
+                            </paths>
+                            <includes>
+                              <include>**/*.*</include>
+                            </includes>
+                            <normalization>RELATIVE_PATH</normalization>
+                          </fileset>
+                          <fileSet>
+                            <name>test-sources</name>
+                            <paths>
+                              <path>${project.basedir}/src/main/test/javascript</path>
+                            </paths>
+                            <includes>
+                              <include>**/*.*</include>
+                            </includes>
+                            <normalization>RELATIVE_PATH</normalization>
+                          </fileSet>
+                        </fileSets>
+                      </inputs>
                       <outputs>
                         <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
                       </outputs>
@@ -756,22 +910,12 @@
                   <executions>
                     <execution>
                       <id>default-compile</id>
-                      <inputs>
-                        <ignoredProperties>
-                          <ignore>outputTimestamp</ignore>
-                        </ignoredProperties>
-                      </inputs>
                       <outputs>
                         <cacheableBecause>compilation outcome does not not change with property</cacheableBecause>
                       </outputs>
                     </execution>
                     <execution>
                       <id>default-testCompile</id>
-                      <inputs>
-                        <ignoredProperties>
-                          <ignore>outputTimestamp</ignore>
-                        </ignoredProperties>
-                      </inputs>
                       <outputs>
                         <cacheableBecause>compilation outcome does not not change with property</cacheableBecause>
                       </outputs>

--- a/pom.xml
+++ b/pom.xml
@@ -838,6 +838,16 @@
                         </fileSets>
                       </inputs>
                       <outputs>
+                        <directories>
+                          <directory>
+                            <name>target-classes-public</name>
+                            <path>${project.basedir}/target/classes/public</path>
+                          </directory>
+                          <directory>
+                            <name>target-classes-static</name>
+                            <path>${project.basedir}/target/classes/static</path>
+                          </directory>
+                        </directories>
                         <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
                       </outputs>
                     </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -702,6 +702,26 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>com.gradle</groupId>
+          <artifactId>gradle-enterprise-maven-extension</artifactId>
+          <configuration>
+            <gradleEnterprise>
+              <normalization>
+                <runtimeClassPath>
+                  <propertiesNormalizations>
+                    <propertiesNormalization>
+                      <path>**/git.properties</path>
+                      <ignoredProperties>
+                        <ignore>git.build.time</ignore>
+                      </ignoredProperties>
+                    </propertiesNormalization>
+                  </propertiesNormalizations>
+                </runtimeClassPath>
+              </normalization>
+            </gradleEnterprise>
+          </configuration>
+        </plugin>
       </plugins>
     </pluginManagement>
   </build>

--- a/pom.xml
+++ b/pom.xml
@@ -301,6 +301,11 @@
             <exclude>**/*IT*</exclude>
             <exclude>**/*CucumberTest*</exclude>
           </excludes>
+          <!--          <systemPropertyVariables>-->
+          <!--            <junit.platform.listeners.uid.tracking.output.dir>-->
+          <!--              ${junit.platform.listeners.uid.tracking.output.dir}-->
+          <!--            </junit.platform.listeners.uid.tracking.output.dir>-->
+          <!--          </systemPropertyVariables>-->
         </configuration>
       </plugin>
 
@@ -708,6 +713,11 @@
           <configuration>
             <gradleEnterprise>
               <normalization>
+                <systemProperties>
+                  <ignoredKeys>
+                    <ignore>junit.platform.listeners.uid.tracking.output.dir</ignore>
+                  </ignoredKeys>
+                </systemProperties>
                 <runtimeClassPath>
                   <propertiesNormalizations>
                     <propertiesNormalization>
@@ -719,19 +729,20 @@
                   </propertiesNormalizations>
                 </runtimeClassPath>
               </normalization>
-              <plugins>
-                <plugin>
-                  <artifactId>maven-surefire-plugin</artifactId>
-                  <outputs>
-                    <directories>
-                      <directory>
-                        <name>target/test-ids</name>
-                      </directory>
-                    </directories>
-                    <cacheableBecause>same content if nothing has changed</cacheableBecause>
-                  </outputs>
-                </plugin>
-              </plugins>
+              <!--              <plugins>-->
+              <!--                <plugin>-->
+              <!--                  <groupId>org.apache.maven.plugins</groupId>-->
+              <!--                  <artifactId>maven-surefire-plugin</artifactId>-->
+              <!--                  <outputs>-->
+              <!--                    <directories>-->
+              <!--                      <directory>-->
+              <!--                        <name>test-ids</name>-->
+              <!--                        <path>${junit.platform.listeners.uid.tracking.output.dir}</path>-->
+              <!--                      </directory>-->
+              <!--                    </directories>-->
+              <!--                  </outputs>-->
+              <!--                </plugin>-->
+              <!--              </plugins>-->
             </gradleEnterprise>
           </configuration>
         </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -726,6 +726,20 @@
               </normalization>
               <plugins>
                 <plugin>
+                  <groupId>com.github.eirslett</groupId>
+                  <artifactId>frontend-maven-plugin</artifactId>
+                  <execution>
+                    <executions>
+                      <id>build front</id>
+                      <cacheableBecause>just need to build in case source or deps have changed</cacheableBecause>
+                    </executions>
+                    <executions>
+                      <id>front test</id>
+                      <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
+                    </executions>
+                  </execution>
+                </plugin>
+                <plugin>
                   <groupId>org.apache.maven.plugins</groupId>
                   <artifactId>maven-compiler-plugin</artifactId>
                   <executions>


### PR DESCRIPTION
This PR adds leverages our own [gradle develocity ](https://ge.jhipster.tech/) to have build scans and build cache support for CI/CD and on local developer machines. @jdubois already added the needed secret to have write access from our github runners to gradle develocity. Anyone can read from the remote cache and of course use the local build cache. 

If you would like to know more about develocity or would like to have an own user account just give me a ping.

We should squash the commits :) 