### PR TITLE
Sonar: Functions should not be nested too deeply

### DIFF
--- a/src/test/javascript/spec/common/domain/Optional.spec.ts
+++ b/src/test/javascript/spec/common/domain/Optional.spec.ts
@@ -102,7 +102,10 @@ describe('Optional', () => {
     });
 
     it('should get supplied error when present', () => {
-      expect(() => Optional.empty().orElseThrow(() => new Error('Supplied error'))).toThrow(new Error('Supplied error'));
+      const throwSuppliedError = () => {
+        throw new Error('Supplied error');
+      };
+      expect(() => Optional.empty().orElseThrow(throwSuppliedError)).toThrow(new Error('Supplied error'));
     });
   });
 


### PR DESCRIPTION
Fix
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/1834972e-ecf1-4dcc-bef3-2afd4c3e4f03)
