### PR TITLE
Remove maven-failsafe-plugin double execution

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -319,20 +319,6 @@
             <include>**/*CucumberTest*</include>
           </includes>
         </configuration>
-        <executions>
-          <execution>
-            <id>integration-test</id>
-            <goals>
-              <goal>integration-test</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>verify</id>
-            <goals>
-              <goal>verify</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
Parent project (spring-boot-starter-parent) already defines a "default" execution for maven-failsafe-plugin with goals `integration-test` and `verify`.
 By redefining 2 additional executions, each goal is executed twice.

![image](https://github.com/jhipster/jhipster-lite/assets/155828/481b1c21-d6b5-4e32-8154-5d7003da7041)


![image](https://github.com/jhipster/jhipster-lite/assets/155828/cc9bbcdd-7f15-450d-a71a-3ec2e1d3174c)
