### PR TITLE
(fix) Missing output directory for npm run test in via gradle enterprise plugin configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -912,6 +912,12 @@
                         </fileSets>
                       </inputs>
                       <outputs>
+                        <directories>
+                          <directory>
+                            <name>target-test-results</name>
+                            <path>${project.basedir}/target/test-results</path>
+                          </directory>
+                        </directories>
                         <cacheableBecause>just need to test in case source or deps have changed</cacheableBecause>
                       </outputs>
                     </execution>


### PR DESCRIPTION
Following #9239
Because of that Sonar execution was failing because it could not find `target/test-results/TESTS-results-sonar.xml`
