### PR TITLE
Remove gradle checkstyle workaround fix

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/checkstyle/domain/CheckstyleModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/checkstyle/domain/CheckstyleModuleFactory.java
@@ -61,13 +61,6 @@ public class CheckstyleModuleFactory {
           configFile = rootProject.file("checkstyle.xml")
           toolVersion = libs.versions.%s.get()
         }
-
-        // Workaround for https://github.com/gradle/gradle/issues/27035
-        configurations.checkstyle {
-          resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
-            select("com.google.guava:guava:0")
-          }
-        }
         """.formatted(toolVersionSlug.slug())
       )
       .build();

--- a/src/test/java/tech/jhipster/lite/generator/server/javatool/checkstyle/domain/CheckstyleModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/javatool/checkstyle/domain/CheckstyleModuleFactoryTest.java
@@ -77,16 +77,6 @@ class CheckstyleModuleFactoryTest {
         }
         """
       )
-      .containing(
-        """
-        // Workaround for https://github.com/gradle/gradle/issues/27035
-        configurations.checkstyle {
-          resolutionStrategy.capabilitiesResolution.withCapability("com.google.collections:google-collections") {
-            select("com.google.guava:guava:0")
-          }
-        }
-        """
-      )
       .and()
       .hasFile("gradle/libs.versions.toml")
       .containing("checkstyle = \"")


### PR DESCRIPTION
It doesn't seem necessary anymore with version 10.14.2 of checkstyle