### PR TITLE
Angular: RouterTestingModule is deprecated since Angular 17.3

### DIFF
--- a/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/admin-routing.module.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/admin-routing.module.spec.ts.mustache
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 import AdminRoutingModule, { routes } from './admin-routing.module';
 
 describe('AdminRoutingModule', () => {
@@ -8,7 +7,7 @@ describe('AdminRoutingModule', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
+      providers: [provideRouter(routes)],
     }).compileComponents();
     router = TestBed.inject(Router);
     router.initialNavigation();

--- a/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.component.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.component.spec.ts.mustache
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -10,7 +10,7 @@ describe('App Component', () => {
   beforeEach(
     waitForAsync(() => {
       TestBed.configureTestingModule({
-        imports: [RouterTestingModule.withRoutes([])],
+        providers: [provideRouter([])],
       }).compileComponents();
     })
   );

--- a/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.route.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/core/src/main/webapp/app/app.route.spec.ts.mustache
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 import { routes } from './app.route';
 
 describe('AppRoutes', () => {
@@ -8,7 +7,7 @@ describe('AppRoutes', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
+      providers: [provideRouter(routes)],
     }).compileComponents();
     router = TestBed.inject(Router);
     router.initialNavigation();

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/account.service.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/account.service.spec.ts.mustache
@@ -1,6 +1,6 @@
-import { RouterTestingModule } from '@angular/router/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
+import { provideRouter } from '@angular/router';
 
 import { Account } from './account.model';
 
@@ -29,7 +29,8 @@ describe('Account Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
+      imports: [HttpClientTestingModule],
+      providers: [provideRouter([])],
     });
 
     service = TestBed.inject(AccountService);

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.service.spec.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.service.spec.ts.mustache
@@ -1,4 +1,4 @@
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 
@@ -15,8 +15,8 @@ describe('Login Service', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [HttpClientTestingModule, RouterTestingModule.withRoutes([])],
-      providers: [AccountService],
+      imports: [HttpClientTestingModule],
+      providers: [AccountService, provideRouter([])],
     });
 
     service = TestBed.inject(LoginService);

--- a/src/test/resources/projects/angular/app.component.spec.ts
+++ b/src/test/resources/projects/angular/app.component.spec.ts
@@ -1,5 +1,5 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
-import { RouterTestingModule } from '@angular/router/testing';
+import { provideRouter } from '@angular/router';
 
 import { AppComponent } from './app.component';
 
@@ -9,7 +9,7 @@ describe('App Component', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes([])],
+      providers: [provideRouter([])],
       declarations: [AppComponent],
     }).compileComponents();
   }));

--- a/src/test/resources/projects/angular/app.route.spec.ts
+++ b/src/test/resources/projects/angular/app.route.spec.ts
@@ -1,6 +1,5 @@
 import { TestBed } from '@angular/core/testing';
-import { Router } from '@angular/router';
-import { RouterTestingModule } from '@angular/router/testing';
+import { Router, provideRouter } from '@angular/router';
 import { routes } from './app.route';
 
 describe('AppRoutes', () => {
@@ -8,7 +7,7 @@ describe('AppRoutes', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [RouterTestingModule.withRoutes(routes)],
+      providers: [provideRouter(routes)],
     }).compileComponents();
     router = TestBed.inject(Router);
     router.initialNavigation();


### PR DESCRIPTION
https://angular.io/api/router/testing/RouterTestingModule

<img width="478" alt="image" src="https://github.com/jhipster/jhipster-lite/assets/9989211/91bc613c-bf27-4667-9682-f3900abb37f8">
