### PR TITLE
Renovate config tweaking

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,6 +4,7 @@
     "config:recommended",
     "npm:unpublishSafe",
     "schedule:daily",
+    ":maintainLockFilesWeekly",
     ":disableDependencyDashboard",
     ":automergeMinor",
     ":automergePr",

--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended",
     "npm:unpublishSafe",
+    "schedule:daily",
     ":disableDependencyDashboard",
     ":automergeMinor",
     ":automergePr",

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "npm:unpublishSafe",
     ":disableDependencyDashboard",
     ":automergeMinor",
     ":automergePr",

--- a/src/main/resources/generator/ci/renovate/renovate.json.mustache
+++ b/src/main/resources/generator/ci/renovate/renovate.json.mustache
@@ -2,6 +2,9 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    "npm:unpublishSafe",
+    "schedule:daily",
+    ":maintainLockFilesWeekly",
     ":disableDependencyDashboard",
     ":automergeMinor",
     ":automergePr",


### PR DESCRIPTION
- Adjust schedule so it runs daily, and not continuously
- Wait until a npm package is three days old before raising the update, in order to deal with [npm Unpublish Policy](https://docs.npmjs.com/policies/unpublish)
- Weekly bump transitional dependencies