### PR TITLE
Cypress: Use recommanded ESLint rules

### DIFF
--- a/src/test/javascript/cypress/.eslintrc.cjs
+++ b/src/test/javascript/cypress/.eslintrc.cjs
@@ -1,6 +1,6 @@
 module.exports = {
   parser: '@typescript-eslint/parser',
-  extends: ['eslint:recommended', '@vue/eslint-config-typescript', 'prettier'],
+  extends: ['eslint:recommended', '@vue/eslint-config-typescript', 'prettier', 'plugin:cypress/recommended'],
   root: true,
   plugins: ['cypress', '@typescript-eslint'],
   env: {

--- a/src/test/javascript/cypress/integration/Patch.spec.ts
+++ b/src/test/javascript/cypress/integration/Patch.spec.ts
@@ -61,7 +61,8 @@ describe('Patch', () => {
       }).as('spring-test-creation');
 
       cy.visit('/patches');
-      cy.get(dataSelector('folder-path-field')).clear().type('test');
+      cy.get(dataSelector('folder-path-field')).clear();
+      cy.get(dataSelector('folder-path-field')).type('test');
       cy.get(dataSelector('module-spring-test-application-button')).click();
 
       cy.wait('@spring-test-creation').should(xhr => {
@@ -86,7 +87,8 @@ describe('Patch', () => {
       cy.visit('/patches');
 
       cy.get(dataSelector('spring-cucumber-module-content')).click();
-      cy.get(dataSelector('folder-path-field')).clear().type('test');
+      cy.get(dataSelector('folder-path-field')).clear();
+      cy.get(dataSelector('folder-path-field')).type('test');
       cy.get(dataSelector('parameter-baseName-field')).type('jhipster');
       cy.get(dataSelector('parameter-optionalBoolean-field')).select('true');
       cy.get(dataSelector('parameter-optionalInteger-field')).type('42');


### PR DESCRIPTION
Fix `It is unsafe to chain further commands that rely on the subject after this command. It is best to split the chain, chaining again from cy in a next command line` => rule: `cypress/unsafe-to-chain-command`