### PR TITLE
Archunit rules for wire packages

### DIFF
--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -25,6 +25,7 @@ class HexagonalArchTest {
 
   private static final String ROOT_PACKAGE = "{{packageName}}";
   private static final String GENERATION_SHARED_KERNEL_PACKAGES = ROOT_PACKAGE.concat(".shared.generation..");
+  private static final String WIRE_PACKAGES = ROOT_PACKAGE.concat(".wire..");
 
   private static final JavaClasses classes = new ClassFileImporter()
     .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -257,7 +258,7 @@ class HexagonalArchTest {
     void shouldNotDependOnBoundedContextsOrSharedKernels() {
       noClasses()
         .that()
-        .resideInAPackage("..wire..")
+        .resideInAPackage(WIRE_PACKAGES)
         .should()
         .dependOnClassesThat()
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
@@ -272,7 +273,7 @@ class HexagonalArchTest {
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
         .should()
         .dependOnClassesThat()
-        .resideInAPackage("..wire..")
+        .resideInAPackage(WIRE_PACKAGES)
         .because("Business contexts and shared kernel should not depend on wire")
         .check(classes);
     }
@@ -286,7 +287,7 @@ class HexagonalArchTest {
 
     @Test
     void shouldNotHavePublicClasses() {
-      noClasses().that().resideInAnyPackage("..wire..").should().bePublic().check(classes);
+      noClasses().that().resideInAnyPackage(WIRE_PACKAGES).should().bePublic().check(classes);
     }
   }
 }

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -24,6 +24,7 @@ import org.springframework.stereotype.Controller;
 class HexagonalArchTest {
 
   private static final String ROOT_PACKAGE = "{{packageName}}";
+  private static final String GENERATION_SHARED_KERNEL_PACKAGES = ROOT_PACKAGE.concat(".shared.generation..");
 
   private static final JavaClasses classes = new ClassFileImporter()
     .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -259,13 +260,13 @@ class HexagonalArchTest {
         .resideInAPackage("..wire..")
         .should()
         .dependOnClassesThat()
-        .resideInAnyPackage(businessContextsPackages.toArray(String[]::new))
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
         .because("Wire should not depend on business contexts or shared kernel should not depend")
         .check(classes);
     }
 
     @Test
-    void boundedContextsOrSharedKernelsShouldNotDependOnWire() {
+    void boundedContextsAndSharedKernelsShouldNotDependOnWire() {
       noClasses()
         .that()
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
@@ -277,7 +278,10 @@ class HexagonalArchTest {
     }
 
     private static String[] businessContextsOrSharedKernelsPackages() {
-      return Stream.of(businessContextsPackages, sharedKernelsPackages).flatMap(Collection::stream).toArray(String[]::new);
+      return Stream.of(businessContextsPackages, sharedKernelsPackages)
+        .flatMap(Collection::stream)
+        .filter(not(GENERATION_SHARED_KERNEL_PACKAGES::equals))
+        .toArray(String[]::new);
     }
 
     @Test

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -30,6 +30,7 @@ class HexagonalArchTest {
     .importPackages(ROOT_PACKAGE);
 
   private static final Collection<String> businessContexts = packagesWithAnnotation(BusinessContext.class);
+  private static final Collection<String> businessContextsPackages = buildPackagesPatterns(businessContexts);
 
   private static final Collection<String> sharedKernels = packagesWithAnnotation(SharedKernel.class);
   private static final Collection<String> sharedKernelsPackages = buildPackagesPatterns(sharedKernels);
@@ -245,6 +246,43 @@ class HexagonalArchTest {
             .because("Secondary should not loop to its own context's primary")
             .check(classes);
         });
+    }
+  }
+
+  @Nested
+  class Wire {
+
+    @Test
+    void shouldNotDependOnBoundedContextsOrSharedKernels() {
+      noClasses()
+        .that()
+        .resideInAPackage("..wire..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .because("Wire should not depend on business contexts or shared kernel should not depend")
+        .check(classes);
+    }
+
+    @Test
+    void boundedContextsOrSharedKernelsShouldNotDependOnWire() {
+      noClasses()
+        .that()
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..wire..")
+        .because("Business contexts and shared kernel should not depend on wire")
+        .check(classes);
+    }
+
+    private static String[] businessContextsOrSharedKernelsPackages() {
+      return Stream.of(businessContextsPackages, sharedKernelsPackages).flatMap(Collection::stream).toArray(String[]::new);
+    }
+
+    @Test
+    void shouldNotHavePublicClasses() {
+      noClasses().that().resideInAnyPackage("..wire..").should().bePublic().check(classes);
     }
   }
 }

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -253,6 +253,23 @@ class HexagonalArchTest {
   }
 
   @Nested
+  class SharedKernels {
+
+    @Test
+    void sharedPackageShouldOnlyContainSharedKernels() {
+      classes()
+        .that()
+        .haveSimpleName("package-info")
+        .and()
+        .resideInAPackage(ROOT_PACKAGE.concat(".shared.."))
+        .should()
+        .beMetaAnnotatedWith(SharedKernel.class)
+        .because(ROOT_PACKAGE + ".shared package should only contain shared kernels")
+        .check(classes);
+    }
+  }
+
+  @Nested
   class Wire {
 
     @Test

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -259,7 +259,7 @@ class HexagonalArchTest {
         .resideInAPackage("..wire..")
         .should()
         .dependOnClassesThat()
-        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .resideInAnyPackage(businessContextsPackages.toArray(String[]::new))
         .because("Wire should not depend on business contexts or shared kernel should not depend")
         .check(classes);
     }

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -1,6 +1,7 @@
 package {{packageName}};
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static java.util.function.Predicate.*;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;

--- a/src/main/resources/generator/server/springboot/async/src/AsyncConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/async/src/AsyncConfiguration.java.mustache
@@ -7,4 +7,4 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 @Configuration
 @EnableAsync
 @EnableScheduling
-public class AsyncConfiguration {}
+class AsyncConfiguration {}

--- a/src/main/resources/generator/server/springboot/cache/ehcache/main/EhcacheProperties.java.mustache
+++ b/src/main/resources/generator/server/springboot/cache/ehcache/main/EhcacheProperties.java.mustache
@@ -5,7 +5,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "application.cache.ehcache")
-public class EhcacheProperties {
+class EhcacheProperties {
 
   public static final int DEFAULT_MAX_ENTRIES = 100;
   public static final int DEFAULT_TTL_SECONDS = 3600;

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/main/AsyncSpringLiquibase.java.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/main/AsyncSpringLiquibase.java.mustache
@@ -22,7 +22,7 @@ import org.springframework.util.StopWatch;
  * time: <ul> <li>On a recent MacBook Pro, start-up time is down from 14 seconds to 8 seconds</li> <li>In production,
  * this can help your application run on platforms like Heroku, where it must start/restart very quickly</li> </ul>
  */
-public class AsyncSpringLiquibase extends DataSourceClosingSpringLiquibase {
+class AsyncSpringLiquibase extends DataSourceClosingSpringLiquibase {
 
   // named "logger" because there is already a field called "log" in "SpringLiquibase"
   private final Logger logger = LoggerFactory.getLogger(AsyncSpringLiquibase.class);

--- a/src/main/resources/generator/server/springboot/dbmigration/liquibase/main/SpringLiquibaseUtil.java.mustache
+++ b/src/main/resources/generator/server/springboot/dbmigration/liquibase/main/SpringLiquibaseUtil.java.mustache
@@ -18,7 +18,7 @@ import org.springframework.core.env.Environment;
  * It follows implementation of
  * <a href="https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/liquibase/LiquibaseAutoConfiguration.java">LiquibaseAutoConfiguration</a>.
  */
-public final class SpringLiquibaseUtil {
+final class SpringLiquibaseUtil {
 
   private SpringLiquibaseUtil() {}
 

--- a/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpConfiguration.java.mustache
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnProperty(name = "application.logging.logstash.tcp.enabled", havingValue = "true")
-public class LogstashTcpConfiguration {
+class LogstashTcpConfiguration {
 
   public static final String FIELD_APP_NAME = "app_name";
   public static final String FIELD_APP_PORT = "app_port";

--- a/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpLifeCycle.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpLifeCycle.java.mustache
@@ -15,7 +15,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.SmartLifecycle;
 
-public class LogstashTcpLifeCycle implements SmartLifecycle {
+class LogstashTcpLifeCycle implements SmartLifecycle {
 
   public static final String ASYNC_LOGSTASH_APPENDER_NAME = "ASYNC_LOGSTASH_TCP";
 

--- a/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpProperties.java.mustache
+++ b/src/main/resources/generator/server/springboot/logging/logstash/main/LogstashTcpProperties.java.mustache
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 
 @Configuration
 @ConfigurationProperties(prefix = "application.logging.logstash.tcp")
-public class LogstashTcpProperties {
+class LogstashTcpProperties {
 
   /**
    * Enable or disable Logstash

--- a/src/main/resources/generator/server/springboot/mvc/web/main/cors/CorsFilterConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/web/main/cors/CorsFilterConfiguration.java.mustache
@@ -10,7 +10,7 @@ import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 import org.springframework.web.filter.CorsFilter;
 
 @Configuration
-public class CorsFilterConfiguration {
+class CorsFilterConfiguration {
 
   private final Logger log = LoggerFactory.getLogger(CorsFilterConfiguration.class);
 

--- a/src/main/resources/generator/server/springboot/mvc/web/main/cors/CorsProperties.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/web/main/cors/CorsProperties.java.mustache
@@ -6,7 +6,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.web.cors.CorsConfiguration;
 
 @Configuration
-public class CorsProperties {
+class CorsProperties {
 
   @Bean
   @ConfigurationProperties(prefix = "application.cors", ignoreUnknownFields = false)

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -254,7 +254,7 @@ class HexagonalArchTest {
         .resideInAPackage("..wire..")
         .should()
         .dependOnClassesThat()
-        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .resideInAnyPackage(businessContextsPackages.toArray(String[]::new))
         .because("Wire should not depend on business contexts or shared kernel should not depend")
         .check(classes);
     }

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
+import static java.util.function.Predicate.*;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -24,6 +25,7 @@ import org.springframework.stereotype.Controller;
 class HexagonalArchTest {
 
   private static final String ROOT_PACKAGE = "tech.jhipster.lite";
+  private static final String GENERATION_SHARED_KERNEL_PACKAGES = ROOT_PACKAGE.concat(".shared.generation..");
 
   private static final JavaClasses classes = new ClassFileImporter()
     .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -254,7 +256,7 @@ class HexagonalArchTest {
         .resideInAPackage("..wire..")
         .should()
         .dependOnClassesThat()
-        .resideInAnyPackage(businessContextsPackages.toArray(String[]::new))
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
         .because("Wire should not depend on business contexts or shared kernel should not depend")
         .check(classes);
     }
@@ -272,7 +274,10 @@ class HexagonalArchTest {
     }
 
     private static String[] businessContextsOrSharedKernelsPackages() {
-      return Stream.of(businessContextsPackages, sharedKernelsPackages).flatMap(Collection::stream).toArray(String[]::new);
+      return Stream.of(businessContextsPackages, sharedKernelsPackages)
+        .flatMap(Collection::stream)
+        .filter(not(GENERATION_SHARED_KERNEL_PACKAGES::equals))
+        .toArray(String[]::new);
     }
 
     @Test

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -262,7 +262,7 @@ class HexagonalArchTest {
     }
 
     @Test
-    void boundedContextsOrSharedKernelsShouldNotDependOnWire() {
+    void boundedContextsAndSharedKernelsShouldNotDependOnWire() {
       noClasses()
         .that()
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -30,6 +30,7 @@ class HexagonalArchTest {
     .importPackages(ROOT_PACKAGE);
 
   private static final Collection<String> businessContexts = packagesWithAnnotation(BusinessContext.class);
+  private static final Collection<String> businessContextsPackages = buildPackagesPatterns(businessContexts);
 
   private static final Collection<String> sharedKernels = packagesWithAnnotation(SharedKernel.class);
   private static final Collection<String> sharedKernelsPackages = buildPackagesPatterns(sharedKernels);
@@ -240,6 +241,43 @@ class HexagonalArchTest {
             .because("Secondary should not loop to its own context's primary")
             .check(classes)
       );
+    }
+  }
+
+  @Nested
+  class Wire {
+
+    @Test
+    void shouldNotDependOnBoundedContextsOrSharedKernels() {
+      noClasses()
+        .that()
+        .resideInAPackage("..wire..")
+        .should()
+        .dependOnClassesThat()
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .because("Wire should not depend on business contexts or shared kernel should not depend")
+        .check(classes);
+    }
+
+    @Test
+    void boundedContextsOrSharedKernelsShouldNotDependOnWire() {
+      noClasses()
+        .that()
+        .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
+        .should()
+        .dependOnClassesThat()
+        .resideInAPackage("..wire..")
+        .because("Business contexts and shared kernel should not depend on wire")
+        .check(classes);
+    }
+
+    private static String[] businessContextsOrSharedKernelsPackages() {
+      return Stream.of(businessContextsPackages, sharedKernelsPackages).flatMap(Collection::stream).toArray(String[]::new);
+    }
+
+    @Test
+    void shouldNotHavePublicClasses() {
+      noClasses().that().resideInAnyPackage("..wire..").should().bePublic().check(classes);
     }
   }
 }

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -248,6 +248,23 @@ class HexagonalArchTest {
   }
 
   @Nested
+  class SharedKernels {
+
+    @Test
+    void sharedPackageShouldOnlyContainSharedKernels() {
+      classes()
+        .that()
+        .haveSimpleName("package-info")
+        .and()
+        .resideInAPackage(ROOT_PACKAGE.concat(".shared.."))
+        .should()
+        .beMetaAnnotatedWith(SharedKernel.class)
+        .because(ROOT_PACKAGE + ".shared package should only contain shared kernels")
+        .check(classes);
+    }
+  }
+
+  @Nested
   class Wire {
 
     @Test

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -26,6 +26,7 @@ class HexagonalArchTest {
 
   private static final String ROOT_PACKAGE = "tech.jhipster.lite";
   private static final String GENERATION_SHARED_KERNEL_PACKAGES = ROOT_PACKAGE.concat(".shared.generation..");
+  private static final String WIRE_PACKAGES = ROOT_PACKAGE.concat(".wire..");
 
   private static final JavaClasses classes = new ClassFileImporter()
     .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
@@ -253,7 +254,7 @@ class HexagonalArchTest {
     void shouldNotDependOnBoundedContextsOrSharedKernels() {
       noClasses()
         .that()
-        .resideInAPackage("..wire..")
+        .resideInAPackage(WIRE_PACKAGES)
         .should()
         .dependOnClassesThat()
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
@@ -268,7 +269,7 @@ class HexagonalArchTest {
         .resideInAnyPackage(businessContextsOrSharedKernelsPackages())
         .should()
         .dependOnClassesThat()
-        .resideInAPackage("..wire..")
+        .resideInAPackage(WIRE_PACKAGES)
         .because("Business contexts and shared kernel should not depend on wire")
         .check(classes);
     }
@@ -282,7 +283,7 @@ class HexagonalArchTest {
 
     @Test
     void shouldNotHavePublicClasses() {
-      noClasses().that().resideInAnyPackage("..wire..").should().bePublic().check(classes);
+      noClasses().that().resideInAnyPackage(WIRE_PACKAGES).should().bePublic().check(classes);
     }
   }
 }


### PR DESCRIPTION
Wire packages should not be used by code from business contexts or shared kernels, and vice versa 