### PR TITLE
Migration from gradle enterprise to develocity

### DIFF
--- a/.mvn/develocity.xml
+++ b/.mvn/develocity.xml
@@ -1,12 +1,12 @@
-<gradleEnterprise>
+<develocity>
   <server>
     <url>https://ge.jhipster.tech</url>
   </server>
   <buildScan>
     <capture>
-      <goalInputFiles>true</goalInputFiles>
+      <fileFingerprints>true</fileFingerprints>
     </capture>
-    <publish>ALWAYS</publish>
+    <publishing>ALWAYS</publishing>
     <backgroundBuildScanUpload>#{env['CI'] == null}</backgroundBuildScanUpload>
     <publishIfAuthenticated>true</publishIfAuthenticated>
     <obfuscation>
@@ -22,4 +22,4 @@
       <storeEnabled>#{isTrue(env['GITHUB_ACTIONS']) and isTrue(env['GRADLE_ENTERPRISE_ACCESS_KEY'])}</storeEnabled>
     </remote>
   </buildCache>
-</gradleEnterprise>
+</develocity>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -2,7 +2,7 @@
   <extension>
     <groupId>com.gradle</groupId>
     <artifactId>gradle-enterprise-maven-extension</artifactId>
-    <version>1.20.1</version>
+    <version>1.21.2</version>
   </extension>
   <extension>
     <groupId>com.gradle</groupId>

--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -1,7 +1,7 @@
 <extensions>
   <extension>
     <groupId>com.gradle</groupId>
-    <artifactId>gradle-enterprise-maven-extension</artifactId>
+    <artifactId>develocity-maven-extension</artifactId>
     <version>1.21.2</version>
   </extension>
   <extension>

--- a/pom.xml
+++ b/pom.xml
@@ -713,9 +713,9 @@
         </plugin>
         <plugin>
           <groupId>com.gradle</groupId>
-          <artifactId>gradle-enterprise-maven-extension</artifactId>
+          <artifactId>develocity-maven-extension</artifactId>
           <configuration>
-            <gradleEnterprise>
+            <develocity>
               <normalization>
                 <systemProperties>
                   <ignoredKeys>
@@ -1078,7 +1078,7 @@
                   </executions>
                 </plugin>
               </plugins>
-            </gradleEnterprise>
+            </develocity>
           </configuration>
         </plugin>
       </plugins>


### PR DESCRIPTION
gradle-enterprise-maven-extension is now deprecated in favor of develocity-maven-extension