### PR TITLE
Simplify HexagonalArchTest: compute rootPackagePath on the fly from root package name constant

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactory.java
@@ -13,7 +13,6 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class ArchUnitModuleFactory {
 
-  private static final String QUOTE = "\"";
   private static final JHipsterSource SOURCE = from("server/javatool/archunit/test");
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactory.java
@@ -2,8 +2,6 @@ package tech.jhipster.lite.generator.server.javatool.archunit.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.LogLevel;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
@@ -26,9 +24,6 @@ public class ArchUnitModuleFactory {
 
     //@formatter:off
     return moduleBuilder(properties)
-      .context()
-        .put("packageWalkPath", packageWalkPath(packagePath))
-        .and()
       .files()
         .add(SOURCE.template("archunit.properties"), to("src/test/resources/archunit.properties"))
         .add(SOURCE.template("AnnotationArchTest.java"), testDestination.append("AnnotationArchTest.java"))
@@ -40,10 +35,6 @@ public class ArchUnitModuleFactory {
       .springTestLogger("com.tngtech.archunit", LogLevel.WARN)
       .build();
     //@formatter:on
-  }
-
-  private String packageWalkPath(String packagePath) {
-    return Stream.of(packagePath.split("/")).map(folder -> QUOTE + folder + QUOTE).collect(Collectors.joining(", "));
   }
 
   private JavaDependency archUnitDependency() {

--- a/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/archunit/test/HexagonalArchTest.java.mustache
@@ -48,8 +48,7 @@ class HexagonalArchTest {
 
   private static Collection<String> packagesWithAnnotation(Class<? extends Annotation> annotationClass) throws AssertionError {
     try {
-      return Files
-        .walk(Paths.get("src", "main", "java", {{packageWalkPath}}))
+      return Files.walk(rootPackagePath())
         .filter(path -> path.toString().endsWith("package-info.java"))
         .map(toPackageName())
         .map(path -> path.replaceAll("[\\/]", "."))
@@ -62,6 +61,10 @@ class HexagonalArchTest {
     } catch (IOException e) {
       throw new AssertionError(e);
     }
+  }
+
+  private static Path rootPackagePath() {
+    return Stream.of(ROOT_PACKAGE.split("\\.")).map(Paths::get).reduce(Paths.get("src", "main", "java"), Path::resolve);
   }
 
   private static Function<Path, String> toPackageName() {

--- a/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
+++ b/src/test/java/tech/jhipster/lite/HexagonalArchTest.java
@@ -1,7 +1,6 @@
 package tech.jhipster.lite;
 
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.*;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
@@ -49,7 +48,7 @@ class HexagonalArchTest {
 
   private static Collection<String> packagesWithAnnotation(Class<? extends Annotation> annotationClass) throws AssertionError {
     try {
-      return Files.walk(Paths.get("src", "main", "java", "tech", "jhipster", "lite"))
+      return Files.walk(rootPackagePath())
         .filter(path -> path.toString().endsWith("package-info.java"))
         .map(toPackageName())
         .map(path -> path.replaceAll("[\\/]", "."))
@@ -62,6 +61,10 @@ class HexagonalArchTest {
     } catch (IOException e) {
       throw new AssertionError(e);
     }
+  }
+
+  private static Path rootPackagePath() {
+    return Stream.of(ROOT_PACKAGE.split("\\.")).map(Paths::get).reduce(Paths.get("src", "main", "java"), Path::resolve);
   }
 
   private static Function<Path, String> toPackageName() {

--- a/src/test/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/javatool/archunit/domain/ArchUnitModuleFactoryTest.java
@@ -24,9 +24,6 @@ class ArchUnitModuleFactoryTest {
 
     assertThatModuleWithFiles(module, pomFile(), testLogbackFile())
       .hasFiles("src/test/resources/archunit.properties", "src/test/java/com/jhipster/test/AnnotationArchTest.java")
-      .hasFile("src/test/java/com/jhipster/test/HexagonalArchTest.java")
-      .containing("\"src\", \"main\", \"java\", \"com\", \"jhipster\", \"test\"")
-      .and()
       .hasFile("pom.xml")
       .containing("<artifactId>archunit-junit5-api</artifactId>")
       .and()


### PR DESCRIPTION
That way it's easier to change root package on generated code, and it also simplifies the generator that don't need anymore to compute walk paths