### PR TITLE
Sonar: Fix <em role='img' />

### DIFF
--- a/src/main/style/atom/icon/icon.mixin.pug
+++ b/src/main/style/atom/icon/icon.mixin.pug
@@ -1,2 +1,2 @@
 mixin jhlite-icon(icon)
-  em.jhlite-icon(class=`jhlite-icon-${icon}`, role='img', aria-label=`Icon ${icon}`)
+  em.jhlite-icon(class=`jhlite-icon-${icon}`, aria-label=`Icon ${icon}`)

--- a/src/main/webapp/app/common/primary/icon/Icon.vue
+++ b/src/main/webapp/app/common/primary/icon/Icon.vue
@@ -1,6 +1,5 @@
 <template>
   <em
-    role="img"
     class="jhlite-icon"
     :class="`jhlite-icon-${name}`"
     :aria-hidden="ariaHidden"


### PR DESCRIPTION
Fix: https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&resolved=false&id=jhipster_jhipster-lite&open=AY8KyTGBADMkkF4M9RVl&tab=code

Maybe it fixes without breaking our CSS based on `<em>`