### PR TITLE
Generate a package.json requiring only the recent major node.js version, not the latest patch version

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/init/domain/InitModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/init/domain/InitModuleFactory.java
@@ -27,7 +27,7 @@ public class InitModuleFactory {
     return moduleBuilder(properties)
       .context()
         .put("dasherizedBaseName", properties.projectBaseName().kebabCase())
-        .put("nodeVersion", npmVersions.getNodeVersion())
+        .put("nodeMajorVersion", npmVersions.nodeVersion().majorVersion())
         .put("endOfLine", endOfLine(properties))
         .and()
       .files()

--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendMavenModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendMavenModuleFactory.java
@@ -36,7 +36,7 @@ public class FrontendMavenModuleFactory {
     //@formatter:off
     return moduleBuilder(properties)
       .javaBuildProperties()
-        .set(buildPropertyKey("node.version"), buildPropertyValue("v" + npmVersions.getNodeVersion()))
+        .set(buildPropertyKey("node.version"), buildPropertyValue("v" + npmVersions.nodeVersion().get()))
         .set(buildPropertyKey("npm.version"), buildPropertyValue(npmVersions.get("npm", NpmVersionSource.COMMON).get()))
         .and()
       .mavenPlugins()

--- a/src/main/java/tech/jhipster/lite/module/domain/npm/NpmPackageVersion.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/npm/NpmPackageVersion.java
@@ -10,4 +10,8 @@ public record NpmPackageVersion(String version) {
   public String get() {
     return version();
   }
+
+  public String majorVersion() {
+    return version().split("\\.")[0];
+  }
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/npm/NpmVersions.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/npm/NpmVersions.java
@@ -42,9 +42,9 @@ public interface NpmVersions {
   }
 
   /**
-   * @return The version of the NodeJS.
+   * @return The version of Node.js.
    */
-  default String getNodeVersion() {
-    return get("node", NpmVersionSource.COMMON).get();
+  default NpmPackageVersion nodeVersion() {
+    return get("node", NpmVersionSource.COMMON);
   }
 }

--- a/src/main/resources/generator/init/package.json.mustache
+++ b/src/main/resources/generator/init/package.json.mustache
@@ -5,6 +5,6 @@
   "description": "{{projectName}}",
   "license": "UNLICENSED",
   "engines": {
-    "node": ">={{nodeVersion}}"
+    "node": ">={{nodeMajorVersion}}"
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/init/domain/InitModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/init/domain/InitModuleFactoryTest.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.init.domain;
 
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
 
 import org.junit.jupiter.api.Test;
@@ -12,6 +12,7 @@ import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmPackageVersion;
 import tech.jhipster.lite.module.domain.npm.NpmVersions;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
@@ -29,7 +30,7 @@ class InitModuleFactoryTest {
   void shouldBuildModule() {
     String folder = TestFileUtils.tmpDirForTest();
     JHipsterModuleProperties properties = properties(folder);
-    when(npmVersions.getNodeVersion()).thenReturn("16.0.0");
+    when(npmVersions.nodeVersion()).thenReturn(new NpmPackageVersion("16.0.0"));
 
     JHipsterModule module = factory.buildModule(properties);
 
@@ -45,7 +46,7 @@ class InitModuleFactoryTest {
       .hasFile("package.json")
       .containing("test-project")
       .containing("Test Project")
-      .containing("\"node\": \">=16.0.0\"")
+      .containing("\"node\": \">=16\"")
       .notContaining("scripts");
   }
 

--- a/src/test/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendMavenModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendMavenModuleFactoryTest.java
@@ -1,8 +1,7 @@
 package tech.jhipster.lite.generator.server.javatool.frontendmaven.domain;
 
-import static org.mockito.Mockito.when;
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.pomFile;
+import static org.mockito.Mockito.*;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +35,7 @@ class FrontendMavenModuleFactoryTest {
       .build();
 
     when(npmVersions.get("npm", NpmVersionSource.COMMON)).thenReturn(new NpmPackageVersion("4.0.0"));
-    when(npmVersions.getNodeVersion()).thenReturn("16.0.0");
+    when(npmVersions.nodeVersion()).thenReturn(new NpmPackageVersion("16.0.0"));
 
     JHipsterModule module = factory.buildModule(properties);
 


### PR DESCRIPTION
Following #9407, applying the same logic on generated application