### PR TITLE
Use the same maven cache when building native image as other builds

### DIFF
--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -32,7 +32,14 @@ jobs:
           distribution: 'oracle'
           java-version: '21'
           check-latest: false
-          cache: 'maven'
+
+      - name: Cache local Maven repository
+        uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
 
       - name: Build application with Buildpacks
         run: |


### PR DESCRIPTION
Othewise cache key differs: 
setup-java-Linux-maven-XXXX
vs
Linux-maven-XXXX