### PR TITLE
Disable develocity remote build cache when building docker images

### DIFF
--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -43,7 +43,7 @@ jobs:
 
       - name: Build application with Buildpacks
         run: |
-          ./mvnw -Pnative -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }}
+          ./mvnw -Pnative -DskipTests clean spring-boot:build-image -Dspring-boot.build-image.imageName=${{ env.DOCKER_IMAGE_NAME }} -Ddevelocity.cache.remote.enabled=false
 
       - name: Test native image
         working-directory: tests-ci

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM openjdk:21-slim AS build
 COPY . /code/jhipster-app/
 WORKDIR /code/jhipster-app/
-RUN chmod +x mvnw && ./mvnw package -B -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip
+RUN chmod +x mvnw && ./mvnw package -B -DskipTests -Dmaven.javadoc.skip=true -Dmaven.source.skip -Ddevelocity.cache.remote.enabled=false
 RUN mv /code/jhipster-app/target/*-exec.jar /code/
 
 FROM openjdk:21-slim


### PR DESCRIPTION
Workaround for recent systematic build failures on some branches