### PR TITLE
Sonar: declare properties-maven-plugin configuration in the pluginManagement section

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactory.java
@@ -56,7 +56,8 @@ public class SonarQubeModulesFactory {
         .gradle("clean build sonar --info")
         .and()
       .mavenPlugins()
-        .plugin(propertiesPlugin())
+        .pluginManagement(propertiesPlugin())
+        .plugin(propertiesPluginBuilder().build())
         .pluginManagement(sonarPlugin())
         .and()
       .gradlePlugins()
@@ -69,13 +70,12 @@ public class SonarQubeModulesFactory {
   }
 
   private MavenPlugin propertiesPlugin() {
-    return MavenPlugin.builder()
-      .groupId("org.codehaus.mojo")
-      .artifactId("properties-maven-plugin")
+    return propertiesPluginBuilder()
       .versionSlug("properties-maven-plugin")
       .addExecution(
         pluginExecution()
           .goals("read-project-properties")
+          .id("default-cli")
           .phase(INITIALIZE)
           .configuration(
             """
@@ -86,6 +86,10 @@ public class SonarQubeModulesFactory {
           )
       )
       .build();
+  }
+
+  private static MavenPlugin.MavenPluginOptionalBuilder propertiesPluginBuilder() {
+    return MavenPlugin.builder().groupId("org.codehaus.mojo").artifactId("properties-maven-plugin");
   }
 
   private MavenPlugin sonarPlugin() {

--- a/src/main/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactory.java
@@ -44,26 +44,28 @@ public class SonarQubeModulesFactory {
   private JHipsterModuleBuilder commonModuleFiles(JHipsterModuleProperties properties) {
     Assert.notNull("properties", properties);
 
+    //@formatter:off
     return moduleBuilder(properties)
       .context()
-      .put("sonarqubeDockerImage", dockerImages.get(SONARQUBE).fullName())
-      .and()
+        .put("sonarqubeDockerImage", dockerImages.get(SONARQUBE).fullName())
+        .and()
       .documentation(documentationTitle("sonar"), SOURCE.template("sonar.md"))
       .startupCommands()
-      .dockerCompose("src/main/docker/sonar.yml")
-      .maven("clean verify sonar:sonar")
-      .gradle("clean build sonar --info")
-      .and()
+        .dockerCompose("src/main/docker/sonar.yml")
+        .maven("clean verify sonar:sonar")
+        .gradle("clean build sonar --info")
+        .and()
       .mavenPlugins()
-      .plugin(propertiesPlugin())
-      .pluginManagement(sonarPlugin())
-      .and()
+        .plugin(propertiesPlugin())
+        .pluginManagement(sonarPlugin())
+        .and()
       .gradlePlugins()
-      .plugin(gradleSonarPlugin())
-      .and()
+        .plugin(gradleSonarPlugin())
+        .and()
       .files()
-      .add(SOURCE.template("sonar.yml"), toSrcMainDocker().append("sonar.yml"))
-      .and();
+        .add(SOURCE.template("sonar.yml"), toSrcMainDocker().append("sonar.yml"))
+        .and();
+    //@formatter:on
   }
 
   private MavenPlugin propertiesPlugin() {

--- a/src/test/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/sonarqube/domain/SonarQubeModulesFactoryTest.java
@@ -65,25 +65,36 @@ class SonarQubeModulesFactoryTest {
       return assertThatModuleWithFiles(module, pomFile(), readmeFile())
         .hasFile("pom.xml")
         .containing(
+          // language=xml
           """
                 <plugin>
                   <groupId>org.codehaus.mojo</groupId>
                   <artifactId>properties-maven-plugin</artifactId>
-                  <version>${properties-maven-plugin.version}</version>
-                  <executions>
-                    <execution>
-                      <phase>initialize</phase>
-                      <goals>
-                        <goal>read-project-properties</goal>
-                      </goals>
-                      <configuration>
-                        <files>
-                          <file>sonar-project.properties</file>
-                        </files>
-                      </configuration>
-                    </execution>
-                  </executions>
                 </plugin>
+          """
+        )
+        .containing(
+          // language=xml
+          """
+                  <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>properties-maven-plugin</artifactId>
+                    <version>${properties-maven-plugin.version}</version>
+                    <executions>
+                      <execution>
+                        <id>default-cli</id>
+                        <phase>initialize</phase>
+                        <goals>
+                          <goal>read-project-properties</goal>
+                        </goals>
+                        <configuration>
+                          <files>
+                            <file>sonar-project.properties</file>
+                          </files>
+                        </configuration>
+                      </execution>
+                    </executions>
+                  </plugin>
           """
         )
         .containing(


### PR DESCRIPTION
And define a default execution id
This allows running sonar analysis directly with the command `mvn properties:read-project-properties sonar:sonar`