### PR TITLE
chore(gradle): remove tricks for enabling gradle in ci for the main branch

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -166,8 +166,6 @@ jobs:
         run: npm ci
       - name: 'Lint: check'
         run: npm run lint:ci
-      - name: 'TEMP: enable gradle build tool slug'
-        run: sed -i '/- gradle-java/d' src/main/resources/config/application.yml
       - name: 'Build application JAR'
         run: |
           chmod +x mvnw


### PR DESCRIPTION
This reverts commit 0d7d49c018119d27b9bda489a158fac37a518e3f.