### PR TITLE
fix: move gitignore configuration for buildSrc from spring-boot-local-profile module to gradle-java module

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/buildtool/gradle/domain/GradleModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/gradle/domain/GradleModuleFactory.java
@@ -25,6 +25,8 @@ public class GradleModuleFactory {
         .comment("Gradle")
         .pattern("/.gradle/")
         .pattern("/build/")
+        .pattern("./buildSrc/.gradle/")
+        .pattern("./buildSrc/build/")
         .and()
       .files()
         .batch(SOURCE, to("."))

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/localeprofile/domain/LocalProfileModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/localeprofile/domain/LocalProfileModuleFactory.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.localeprofile.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.*;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notContainingReplacement;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.buildproperties.PropertyKey;
@@ -21,11 +21,6 @@ public class LocalProfileModuleFactory {
 
     //@formatter:off
     return moduleBuilder(properties)
-      .gitIgnore()
-        .comment("Gradle")
-        .pattern("./buildSrc/.gradle/")
-        .pattern("./buildSrc/build/")
-        .and()
       .javaBuildProperties()
         .set(new PropertyKey(SPRING_PROFILES_ACTIVE), new PropertyValue(""))
         .and()

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/gradle/domain/GradleModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/gradle/domain/GradleModuleFactoryTest.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.buildtool.gradle.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModule;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
 
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
@@ -29,7 +30,9 @@ class GradleModuleFactoryTest {
         """
         # Gradle
         /.gradle/
-        /build/\
+        /build/
+        ./buildSrc/.gradle/
+        ./buildSrc/build/\
         """
       )
       .and()

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/localeprofile/domain/LocalProfileModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/localeprofile/domain/LocalProfileModuleFactoryTest.java
@@ -109,15 +109,6 @@ class LocalProfileModuleFactoryTest {
       JHipsterModule module = factory.buildModule(properties);
 
       assertThatModuleWithFiles(module, gradleBuildFile(), gradleLibsVersionFile())
-        .hasFile(".gitignore")
-        .containing(
-          """
-          # Gradle
-          ./buildSrc/.gradle/
-          ./buildSrc/build/\
-          """
-        )
-        .and()
         .hasFile("build.gradle.kts")
         .containing(
           """


### PR DESCRIPTION
Otherwise gradle gitignore configuration is added to maven projects with spring-boot-local-profile applied:
![image](https://github.com/jhipster/jhipster-lite/assets/155828/ea9a4725-2afa-4a1f-8df7-1a175383edc0)