### PR TITLE
chore(clients): reduce duplicated npm dependencies for clients

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
@@ -2,6 +2,7 @@ package tech.jhipster.lite.generator.client.angular.core.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import static tech.jhipster.lite.module.domain.packagejson.VersionSource.ANGULAR;
+import static tech.jhipster.lite.module.domain.packagejson.VersionSource.COMMON;
 
 import tech.jhipster.lite.generator.client.common.domain.ClientsModulesFactory;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -14,7 +15,7 @@ public class AngularModuleFactory {
 
   private static final JHipsterSource SOURCE = from("client/angular/core");
 
-  private static final JHipsterSource COMMON = from("client/common");
+  private static final JHipsterSource SOURCE_COMMON = from("client/common");
 
   private static final String ENGINES_NEEDLE = "  \"engines\":";
   private static final PackageName ANGULAR_CORE_PACKAGE = packageName("@angular/core");
@@ -46,21 +47,21 @@ public class AngularModuleFactory {
         .addDevDependency(packageName("@angular-eslint/eslint-plugin-template"), ANGULAR)
         .addDevDependency(packageName("@angular-eslint/schematics"), ANGULAR)
         .addDevDependency(packageName("@angular-eslint/template-parser"), ANGULAR)
-        .addDevDependency(packageName("@typescript-eslint/eslint-plugin"),ANGULAR)
-        .addDevDependency(packageName("@typescript-eslint/parser"),ANGULAR)
-        .addDevDependency(packageName("eslint"),ANGULAR)
+        .addDevDependency(packageName("@typescript-eslint/eslint-plugin"), COMMON)
+        .addDevDependency(packageName("@typescript-eslint/parser"), COMMON)
+        .addDevDependency(packageName("eslint"), COMMON)
         .addDevDependency(packageName("@angular-builders/jest"), ANGULAR)
         .addDevDependency(packageName("@angular-devkit/build-angular"), ANGULAR)
         .addDevDependency(packageName("@angular/cli"), ANGULAR)
         .addDevDependency(packageName("@angular/compiler-cli"), ANGULAR, ANGULAR_CORE_PACKAGE)
-        .addDevDependency(packageName("@types/node"), ANGULAR)
-        .addDevDependency(packageName("@types/jest"), ANGULAR)
-        .addDevDependency(packageName("jest"), ANGULAR)
+        .addDevDependency(packageName("@types/node"), COMMON)
+        .addDevDependency(packageName("@types/jest"), COMMON)
+        .addDevDependency(packageName("jest"), COMMON)
         .addDevDependency(packageName("jest-environment-jsdom"), ANGULAR)
-        .addDevDependency(packageName("ts-jest"), ANGULAR)
+        .addDevDependency(packageName("ts-jest"), COMMON)
         .addDevDependency(packageName("jest-preset-angular"), ANGULAR)
         .addDevDependency(packageName("jest-sonar-reporter"), ANGULAR)
-        .addDevDependency(packageName("typescript"), ANGULAR)
+        .addDevDependency(packageName("typescript"), COMMON)
         .addScript(scriptKey("ng"), scriptCommand("ng"))
         .addScript(scriptKey("start"), scriptCommand("ng serve"))
         .addScript(scriptKey("build"), scriptCommand("ng build"))
@@ -75,7 +76,7 @@ public class AngularModuleFactory {
         .add(SOURCE.file("tsconfig.json"), to("tsconfig.json"))
         .add(SOURCE.file("tsconfig.app.json"), to("tsconfig.app.json"))
         .add(SOURCE.file(".eslintrc.json"), to(".eslintrc.json"))
-        .batch(COMMON, to("."))
+        .batch(SOURCE_COMMON, to("."))
           .addFile(".eslintignore")
           .addFile(".npmrc")
           .and()

--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.client.react.core.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+import static tech.jhipster.lite.module.domain.packagejson.VersionSource.COMMON;
 import static tech.jhipster.lite.module.domain.packagejson.VersionSource.REACT;
 
 import tech.jhipster.lite.generator.client.common.domain.ClientsModulesFactory;
@@ -12,9 +13,9 @@ import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 public class ReactCoreModulesFactory {
 
   private static final JHipsterSource SOURCE = from("client/react");
+  private static final JHipsterSource SOURCE_COMMON = from("client/common");
 
   private static final JHipsterSource WEBAPP_SOURCE = SOURCE.append("src/main/webapp");
-  private static final JHipsterSource COMMON = from("client/common");
   private static final JHipsterDestination WEBAPP_DESTINATION = to("src/main/webapp");
 
   private static final JHipsterSource APP_SOURCE = WEBAPP_SOURCE.append("app");
@@ -34,21 +35,21 @@ public class ReactCoreModulesFactory {
       .packageJson()
         .addDevDependency(packageName("@testing-library/react"), REACT)
         .addDevDependency(packageName("@testing-library/user-event"), REACT)
-        .addDevDependency(packageName("@types/node"), REACT)
+        .addDevDependency(packageName("@types/node"), COMMON)
         .addDevDependency(packageName("@types/react"), REACT)
         .addDevDependency(packageName("@types/react-dom"), REACT)
-        .addDevDependency(packageName("@typescript-eslint/eslint-plugin"), REACT)
+        .addDevDependency(packageName("@typescript-eslint/eslint-plugin"), COMMON)
         .addDevDependency(packageName("@vitejs/plugin-react"), REACT)
-        .addDevDependency(packageName("@vitest/coverage-istanbul"), REACT)
-        .addDevDependency(packageName("eslint"), REACT)
+        .addDevDependency(packageName("@vitest/coverage-istanbul"), COMMON)
+        .addDevDependency(packageName("eslint"), COMMON)
         .addDevDependency(packageName("eslint-plugin-react"), REACT)
-        .addDevDependency(packageName("jsdom"), REACT)
-        .addDevDependency(packageName("typescript"), REACT)
+        .addDevDependency(packageName("jsdom"), COMMON)
+        .addDevDependency(packageName("typescript"), COMMON)
         .addDevDependency(packageName("ts-node"), REACT)
-        .addDevDependency(packageName("vite"), REACT)
+        .addDevDependency(packageName("vite"), COMMON)
         .addDevDependency(packageName("vite-tsconfig-paths"), REACT)
-        .addDevDependency(packageName("vitest"), REACT)
-        .addDevDependency(packageName("vitest-sonar-reporter"), REACT)
+        .addDevDependency(packageName("vitest"), COMMON)
+        .addDevDependency(packageName("vitest-sonar-reporter"), COMMON)
         .addDependency(packageName("react"), REACT)
         .addDependency(packageName("react-dom"), REACT)
         .addScript(scriptKey("dev"), scriptCommand("vite"))
@@ -67,7 +68,7 @@ public class ReactCoreModulesFactory {
           .addTemplate("vitest.config.ts")
           .addFile(".eslintrc.cjs")
           .and()
-        .batch(COMMON, to("."))
+        .batch(SOURCE_COMMON, to("."))
           .addFile(".eslintignore")
           .addFile(".npmrc")
           .and()

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.client.vue.core.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+import static tech.jhipster.lite.module.domain.packagejson.VersionSource.COMMON;
 import static tech.jhipster.lite.module.domain.packagejson.VersionSource.VUE;
 
 import tech.jhipster.lite.generator.client.common.domain.ClientsModulesFactory;
@@ -18,7 +19,7 @@ public class VueModulesFactory {
   private static final JHipsterSource IMAGE_SOURCE = SOURCE.append("webapp/content/images");
   private static final JHipsterSource COMMON_PRIMARY_SOURCE = SOURCE.append("webapp/app/common/primary");
   private static final JHipsterSource COMMON_PRIMARY_TEST_SOURCE = SOURCE.append("test/spec/common/primary");
-  private static final JHipsterSource COMMON = from("client/common");
+  private static final JHipsterSource SOURCE_COMMON = from("client/common");
 
   private static final JHipsterDestination MAIN_DESTINATION = to("src/main/webapp/app");
   private static final JHipsterDestination TEST_DESTINATION = to("src/test/javascript/spec");
@@ -47,19 +48,19 @@ public class VueModulesFactory {
         .addDependency(packageName("vue"), VUE)
         .addDependency(packageName("axios"), VUE)
         .addDependency(packageName("vue-router"), VUE)
-        .addDevDependency(packageName("@typescript-eslint/parser"), VUE)
+        .addDevDependency(packageName("@typescript-eslint/parser"), COMMON)
         .addDevDependency(packageName("@vitejs/plugin-vue"), VUE)
         .addDevDependency(packageName("@vue/eslint-config-typescript"), VUE)
         .addDevDependency(packageName("@vue/eslint-config-prettier"), VUE)
         .addDevDependency(packageName("@vue/test-utils"), VUE)
-        .addDevDependency(packageName("@vitest/coverage-istanbul"), VUE)
-        .addDevDependency(packageName("eslint"), VUE)
+        .addDevDependency(packageName("@vitest/coverage-istanbul"), COMMON)
+        .addDevDependency(packageName("eslint"), COMMON)
         .addDevDependency(packageName("eslint-plugin-vue"), VUE)
-        .addDevDependency(packageName("jsdom"), VUE)
-        .addDevDependency(packageName("typescript"), VUE)
-        .addDevDependency(packageName("vite"), VUE)
-        .addDevDependency(packageName("vitest"), VUE)
-        .addDevDependency(packageName("vitest-sonar-reporter"), VUE)
+        .addDevDependency(packageName("jsdom"), COMMON)
+        .addDevDependency(packageName("typescript"), COMMON)
+        .addDevDependency(packageName("vite"), COMMON)
+        .addDevDependency(packageName("vitest"), COMMON)
+        .addDevDependency(packageName("vitest-sonar-reporter"), COMMON)
         .addDevDependency(packageName("vue-tsc"), VUE)
         .addDevDependency(packageName("@types/sinon"), VUE)
         .addDevDependency(packageName("sinon"), VUE)
@@ -81,7 +82,7 @@ public class VueModulesFactory {
           .addTemplate("vite.config.mts")
           .addTemplate("vitest.config.mts")
           .and()
-        .batch(COMMON, to("."))
+        .batch(SOURCE_COMMON, to("."))
           .addFile(".eslintignore")
           .addFile(".npmrc")
           .and()

--- a/src/main/resources/generator/dependencies/angular/package.json
+++ b/src/main/resources/generator/dependencies/angular/package.json
@@ -18,16 +18,8 @@
     "@angular-eslint/template-parser": "17.4.1",
     "@angular/cli": "17.3.7",
     "@angular/compiler-cli": "17.3.9",
-    "@types/jest": "29.5.12",
-    "@types/node": "20.12.12",
-    "@typescript-eslint/eslint-plugin": "7.11.0",
-    "@typescript-eslint/parser": "7.11.0",
-    "eslint": "8.57.0",
-    "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "jest-preset-angular": "14.1.0",
-    "jest-sonar-reporter": "2.0.0",
-    "ts-jest": "29.1.3",
-    "typescript": "5.4.5"
+    "jest-sonar-reporter": "2.0.0"
   }
 }

--- a/src/main/resources/generator/dependencies/common/package.json
+++ b/src/main/resources/generator/dependencies/common/package.json
@@ -11,6 +11,7 @@
     "@types/node": "20.12.12",
     "@typescript-eslint/eslint-plugin": "7.11.0",
     "@typescript-eslint/parser": "7.11.0",
+    "@vitest/coverage-istanbul": "1.6.0",
     "autoprefixer": "10.4.19",
     "browser-sync": "3.0.2",
     "cssnano": "7.0.1",
@@ -23,6 +24,7 @@
     "husky": "9.0.11",
     "jasmine-core": "5.1.2",
     "jest": "29.7.0",
+    "jsdom": "24.1.0",
     "lint-staged": "15.2.5",
     "mkdirp": "3.0.1",
     "node": "20.13.1",
@@ -39,6 +41,9 @@
     "recursive-copy-cli": "1.0.20",
     "tailwindcss": "3.4.3",
     "ts-jest": "29.1.3",
-    "typescript": "5.4.5"
+    "typescript": "5.4.5",
+    "vite": "5.2.11",
+    "vitest": "1.6.0",
+    "vitest-sonar-reporter": "2.0.0"
   }
 }

--- a/src/main/resources/generator/dependencies/react/package.json
+++ b/src/main/resources/generator/dependencies/react/package.json
@@ -14,25 +14,16 @@
   "devDependencies": {
     "@testing-library/react": "15.0.7",
     "@testing-library/user-event": "14.5.2",
-    "@types/node": "20.12.12",
     "@types/react": "18.3.3",
     "@types/react-dom": "18.3.0",
-    "@typescript-eslint/eslint-plugin": "7.11.0",
     "@vitejs/plugin-react": "4.3.0",
-    "@vitest/coverage-istanbul": "1.6.0",
     "autoprefixer": "10.4.19",
-    "eslint": "8.57.0",
     "eslint-plugin-react": "7.34.1",
-    "jsdom": "24.1.0",
     "postcss": "8.4.38",
     "react-scripts": "5.0.1",
     "sass": "1.77.2",
     "tailwindcss": "3.4.3",
     "ts-node": "10.9.2",
-    "typescript": "5.4.5",
-    "vite": "5.2.11",
-    "vite-tsconfig-paths": "4.3.2",
-    "vitest": "1.6.0",
-    "vitest-sonar-reporter": "2.0.0"
+    "vite-tsconfig-paths": "4.3.2"
   }
 }

--- a/src/main/resources/generator/dependencies/vue/package.json
+++ b/src/main/resources/generator/dependencies/vue/package.json
@@ -13,20 +13,12 @@
   "devDependencies": {
     "@pinia/testing": "0.1.3",
     "@types/sinon": "17.0.3",
-    "@typescript-eslint/parser": "7.11.0",
     "@vitejs/plugin-vue": "5.0.4",
-    "@vitest/coverage-istanbul": "1.6.0",
     "@vue/eslint-config-prettier": "9.0.0",
     "@vue/eslint-config-typescript": "13.0.0",
     "@vue/test-utils": "2.4.6",
-    "eslint": "8.57.0",
     "eslint-plugin-vue": "9.26.0",
-    "jsdom": "24.1.0",
     "sinon": "18.0.0",
-    "typescript": "5.4.5",
-    "vite": "5.2.11",
-    "vitest": "1.6.0",
-    "vitest-sonar-reporter": "2.0.0",
     "vue-tsc": "2.0.19"
   }
 }


### PR DESCRIPTION
By factorizing dependencies in common npm module, dependency updates by dependabot will be reduced. If at some point one client needs a distinct version from common version, we can declare it in the specialized client module