### PR TITLE
Logback: improve logs during tests

### DIFF
--- a/src/main/resources/generator/server/springboot/core/test/logback.xml.mustache
+++ b/src/main/resources/generator/server/springboot/core/test/logback.xml.mustache
@@ -1,9 +1,7 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE configuration>
 <configuration scan="true">
-  <springProperty name="log.level" source="logging.level.root" defaultValue="INFO" />
-  <include resource="org/springframework/boot/logging/logback/defaults.xml" />
-  <include resource="org/springframework/boot/logging/logback/console-appender.xml" />
+  <include resource="org/springframework/boot/logging/logback/base.xml" />
 
   <logger name="{{packageName}}" level="OFF" />
 
@@ -11,8 +9,4 @@
   <logger name="com.sun" level="WARN" />
   <logger name="org.springframework" level="WARN" />
   <!-- jhipster-needle-logback-add-log -->
-
-  <root level="${log.level}">
-    <appender-ref ref="CONSOLE" />
-  </root>
 </configuration>


### PR DESCRIPTION
sync with JHLite

It's to avoid having:

```
21:46:58,882 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.5.6
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Here is a list of configurators discovered as a service, by rank: 
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 -   org.springframework.boot.logging.logback.RootLogLevelConfigurator
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - They will be invoked in order until ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY is returned.
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class org.springframework.boot.logging.logback.RootLogLevelConfigurator
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - org.springframework.boot.logging.logback.RootLogLevelConfigurator.configure() call lasted 0 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
21:46:58,890 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
21:46:58,891 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 2 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
21:46:58,891 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
21:46:58,893 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/tmp/edbe6f08-1c18-4d33-b3b9-736ed5fe481b/target/test-classes/logback.xml]
21:46:58,947 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1716925618946)
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - No 'scanPeriod' specified. Defaulting to 1 minutes
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [file:/tmp/edbe6f08-1c18-4d33-b3b9-736ed5fe481b/target/test-classes/logback.xml] 
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 1 minutes
21:46:58,955 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [springProperty] in [ch.qos.logback.classic.LoggerContext]
21:46:58,955 |-INFO in ch.qos.logback.core.joran.util.ConfigurationWatchListUtil@748741cb - Adding [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/defaults.xml] to configuration watch list.
21:46:58,955 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@3e44f2a5 - URL [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/defaults.xml] is not of type file
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word applicationName with class [org.springframework.boot.logging.logback.ApplicationNameConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word clr with class [org.springframework.boot.logging.logback.ColorConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word correlationId with class [org.springframework.boot.logging.logback.CorrelationIdConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word wex with class [org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word wEx with class [org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter]
21:46:58,963 |-INFO in ch.qos.logback.core.joran.util.ConfigurationWatchListUtil@748741cb - Adding [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/console-appender.xml] to configuration watch list.
21:46:58,963 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@3e44f2a5 - URL [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/console-appender.xml] is not of type file
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.catalina.startup.DigesterFactory] to ERROR
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.catalina.util.LifecycleBase] to ERROR
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.coyote.http11.Http11NioProtocol] to WARN
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.sshd.common.util.SecurityUtils] to WARN
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.apache.tomcat.util.net.NioSelectorPool] to WARN
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.eclipse.jetty.util.component.AbstractLifeCycle] to ERROR
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.hibernate.validator.internal.util.Version] to WARN
21:46:58,967 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.springframework.boot.actuate.endpoint.jmx] to WARN
21:46:58,967 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - Processing appender named [CONSOLE]
21:46:58,967 |-INFO in ch.qos.logback.core.model.processor.AppenderModelHandler - About to instantiate appender of type [ch.qos.logback.core.ConsoleAppender]
21:46:58,977 |-INFO in ch.qos.logback.core.model.processor.ImplicitModelHandler - Assuming default type [ch.qos.logback.classic.encoder.PatternLayoutEncoder] for [encoder] property
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.mycompany.myapp] to OFF
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [ch.qos.logback] to WARN
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [com.sun] to WARN
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.springframework] to WARN
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.LoggerModelHandler - Setting level of logger [org.springframework.web] to ERROR
21:46:59,001 |-INFO in ch.qos.logback.classic.model.processor.RootLoggerModelHandler - Setting level of ROOT logger to DEBUG
21:46:59,001 |-INFO in ch.qos.logback.core.model.processor.AppenderRefModelHandler - Attaching appender named [CONSOLE] to Logger[ROOT]
21:46:59,002 |-INFO in ch.qos.logback.core.model.processor.DefaultProcessor@295cf707 - End of configuration.
21:46:59,002 |-INFO in ch.qos.logback.classic.joran.JoranConfigurator@1130520d - Registering current configuration as safe fallback point
21:46:59,002 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - ch.qos.logback.classic.util.DefaultJoranConfigurator.configure() call lasted 111 milliseconds. ExecutionStatus=DO_NOT_INVOKE_NEXT_IF_ANY

21:46:58,882 |-INFO in ch.qos.logback.classic.LoggerContext[default] - This is logback-classic version 1.5.6
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Here is a list of configurators discovered as a service, by rank: 
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 -   org.springframework.boot.logging.logback.RootLogLevelConfigurator
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - They will be invoked in order until ExecutionStatus.DO_NOT_INVOKE_NEXT_IF_ANY is returned.
21:46:58,884 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class org.springframework.boot.logging.logback.RootLogLevelConfigurator
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - org.springframework.boot.logging.logback.RootLogLevelConfigurator.configure() call lasted 0 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Trying to configure with ch.qos.logback.classic.joran.SerializedModelConfigurator
21:46:58,889 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class ch.qos.logback.classic.joran.SerializedModelConfigurator
21:46:58,890 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.scmo]
21:46:58,891 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback.scmo]
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - ch.qos.logback.classic.joran.SerializedModelConfigurator.configure() call lasted 2 milliseconds. ExecutionStatus=INVOKE_NEXT_IF_ANY
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Trying to configure with ch.qos.logback.classic.util.DefaultJoranConfigurator
21:46:58,891 |-INFO in ch.qos.logback.classic.util.ContextInitializer@2e32ccc5 - Constructed configurator of type class ch.qos.logback.classic.util.DefaultJoranConfigurator
21:46:58,891 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Could NOT find resource [logback-test.xml]
21:46:58,893 |-INFO in ch.qos.logback.classic.LoggerContext[default] - Found resource [logback.xml] at [file:/tmp/edbe6f08-1c18-4d33-b3b9-736ed5fe481b/target/test-classes/logback.xml]
21:46:58,947 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Registering a new ReconfigureOnChangeTask ReconfigureOnChangeTask(born:1716925618946)
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - No 'scanPeriod' specified. Defaulting to 1 minutes
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Will scan for changes in [file:/tmp/edbe6f08-1c18-4d33-b3b9-736ed5fe481b/target/test-classes/logback.xml] 
21:46:58,948 |-INFO in ch.qos.logback.classic.model.processor.ConfigurationModelHandlerFull - Setting ReconfigureOnChangeTask scanning period to 1 minutes
21:46:58,955 |-WARN in ch.qos.logback.core.model.processor.ImplicitModelHandler - Ignoring unknown property [springProperty] in [ch.qos.logback.classic.LoggerContext]
21:46:58,955 |-INFO in ch.qos.logback.core.joran.util.ConfigurationWatchListUtil@748741cb - Adding [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/defaults.xml] to configuration watch list.
21:46:58,955 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@3e44f2a5 - URL [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/defaults.xml] is not of type file
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word applicationName with class [org.springframework.boot.logging.logback.ApplicationNameConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word clr with class [org.springframework.boot.logging.logback.ColorConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word correlationId with class [org.springframework.boot.logging.logback.CorrelationIdConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word wex with class [org.springframework.boot.logging.logback.WhitespaceThrowableProxyConverter]
21:46:58,959 |-INFO in ch.qos.logback.core.joran.action.ConversionRuleAction - registering conversion word wEx with class [org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter]
21:46:58,963 |-INFO in ch.qos.logback.core.joran.util.ConfigurationWatchListUtil@748741cb - Adding [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/console-appender.xml] to configuration watch list.
21:46:58,963 |-INFO in ch.qos.logback.core.joran.spi.ConfigurationWatchList@3e44f2a5 - URL [jar:file:/home/pgrimaud/.m2/repository/org/springframework/boot/spring-boot/3.3.0/spring-boot-3.3.0.jar!/org/springframework/boot/logging/logback/console-appender.xml] is not of type file
```