### PR TITLE
enh: use "release" configuration for setting java version rather than "source" and "target"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -508,7 +508,7 @@
         <artifactId>maven-javadoc-plugin</artifactId>
         <version>${maven-javadoc-plugin.version}</version>
         <configuration>
-          <source>${maven.compiler.source}</source>
+          <release>${java.version}</release>
           <quiet>true</quiet>
           <failOnWarnings>false</failOnWarnings>
           <failOnError>false</failOnError>

--- a/pom.xml
+++ b/pom.xml
@@ -283,8 +283,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
           <parameters>true</parameters>
           <annotationProcessorPaths>
             <path>

--- a/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactory.java
@@ -127,8 +127,7 @@ public class MavenModuleFactory {
       .versionSlug("compiler-plugin")
       .configuration(
         """
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
           <parameters>true</parameters>
         """
       )

--- a/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/buildtool/maven/domain/MavenModuleFactoryTest.java
@@ -44,8 +44,7 @@ class MavenModuleFactoryTest {
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>${compiler-plugin.version}</version>
                 <configuration>
-                  <source>${java.version}</source>
-                  <target>${java.version}</target>
+                  <release>${java.version}</release>
                   <parameters>true</parameters>
                 </configuration>
               </plugin>

--- a/src/test/resources/generator/buildtool/maven/pom.test.xml
+++ b/src/test/resources/generator/buildtool/maven/pom.test.xml
@@ -75,8 +75,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>

--- a/src/test/resources/projects/init-maven/pom.xml
+++ b/src/test/resources/projects/init-maven/pom.xml
@@ -104,8 +104,7 @@
         <artifactId>maven-compiler-plugin</artifactId>
         <version>${compiler-plugin.version}</version>
         <configuration>
-          <source>${java.version}</source>
-          <target>${java.version}</target>
+          <release>${java.version}</release>
         </configuration>
       </plugin>
       <plugin>


### PR DESCRIPTION
See https://maven.apache.org/plugins/maven-javadoc-plugin/jar-mojo.html#source and https://maven.apache.org/plugins/maven-compiler-plugin/examples/set-compiler-source-and-target.html