### PR TITLE
fix: StatisticsCriteria should use the more abstract JHipsterModuleSlug

### DIFF
--- a/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
+++ b/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
@@ -1,7 +1,10 @@
 package tech.jhipster.lite.statistic.domain.criteria;
 
+import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
+
 import java.time.Instant;
 import java.util.Optional;
+import org.apache.commons.lang3.builder.ToStringBuilder;
 import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
 
 /**
@@ -63,5 +66,14 @@ public final class StatisticsCriteria {
     public StatisticsCriteria build() {
       return new StatisticsCriteria(this);
     }
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, SHORT_PREFIX_STYLE)
+      .append("startTime", startTime.map(Instant::toString).orElse(""))
+      .append("endTime", endTime.map(Instant::toString).orElse(""))
+      .append("moduleSlug", moduleSlug.map(JHLiteModuleSlug::get).orElse(""))
+      .toString();
   }
 }

--- a/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
+++ b/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
@@ -5,7 +5,7 @@ import static org.apache.commons.lang3.builder.ToStringStyle.SHORT_PREFIX_STYLE;
 import java.time.Instant;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
-import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
+import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
 
 /**
  * Criteria class for {@link tech.jhipster.lite.statistic.domain.Statistics}.
@@ -14,12 +14,12 @@ public final class StatisticsCriteria {
 
   private final Optional<Instant> startTime;
   private final Optional<Instant> endTime;
-  private final Optional<JHLiteModuleSlug> moduleSlug;
+  private final Optional<JHipsterModuleSlug> moduleSlug;
 
   private StatisticsCriteria(StatisticsCriteriaBuilder builder) {
     this.startTime = Optional.ofNullable(builder.startTime);
     this.endTime = Optional.ofNullable(builder.endTime);
-    this.moduleSlug = JHLiteModuleSlug.fromString(builder.moduleSlug);
+    this.moduleSlug = Optional.ofNullable(builder.moduleSlug).map(JHipsterModuleSlug::new);
   }
 
   public boolean isAnyCriteriaApplied() {
@@ -38,7 +38,7 @@ public final class StatisticsCriteria {
     return endTime;
   }
 
-  public Optional<JHLiteModuleSlug> moduleSlug() {
+  public Optional<JHipsterModuleSlug> moduleSlug() {
     return moduleSlug;
   }
 
@@ -73,7 +73,7 @@ public final class StatisticsCriteria {
     return new ToStringBuilder(this, SHORT_PREFIX_STYLE)
       .append("startTime", startTime.map(Instant::toString).orElse(""))
       .append("endTime", endTime.map(Instant::toString).orElse(""))
-      .append("moduleSlug", moduleSlug.map(JHLiteModuleSlug::get).orElse(""))
+      .append("moduleSlug", moduleSlug.map(JHipsterModuleSlug::get).orElse(""))
       .toString();
   }
 }

--- a/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
+++ b/src/main/java/tech/jhipster/lite/statistic/domain/criteria/StatisticsCriteria.java
@@ -30,15 +30,15 @@ public final class StatisticsCriteria {
     return new StatisticsCriteriaBuilder();
   }
 
-  public Optional<Instant> getStartTime() {
+  public Optional<Instant> startTime() {
     return startTime;
   }
 
-  public Optional<Instant> getEndTime() {
+  public Optional<Instant> endTime() {
     return endTime;
   }
 
-  public Optional<JHLiteModuleSlug> getModuleSlug() {
+  public Optional<JHLiteModuleSlug> moduleSlug() {
     return moduleSlug;
   }
 

--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
@@ -31,9 +31,9 @@ class InMemoryStatisticsRepository implements StatisticsRepository {
     if (criteria.isAnyCriteriaApplied()) {
       appliedModulesCount = appliedModules
         .stream()
-        .filter(isAfter(criteria.getStartTime()))
-        .filter(isBefore(criteria.getEndTime()))
-        .filter(hasModuleSlug(criteria.getModuleSlug()))
+        .filter(isAfter(criteria.startTime()))
+        .filter(isBefore(criteria.endTime()))
+        .filter(hasModuleSlug(criteria.moduleSlug()))
         .count();
     }
     return new Statistics(appliedModulesCount);

--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/InMemoryStatisticsRepository.java
@@ -5,7 +5,7 @@ import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Predicate;
 import org.springframework.stereotype.Repository;
-import tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug;
+import tech.jhipster.lite.module.domain.JHipsterModuleSlug;
 import tech.jhipster.lite.shared.error.domain.Assert;
 import tech.jhipster.lite.statistic.domain.*;
 import tech.jhipster.lite.statistic.domain.criteria.StatisticsCriteria;
@@ -47,8 +47,8 @@ class InMemoryStatisticsRepository implements StatisticsRepository {
     return appliedModule -> (endTime.isEmpty() || appliedModule.date().isBefore(endTime.get()));
   }
 
-  private static Predicate<AppliedModule> hasModuleSlug(Optional<JHLiteModuleSlug> moduleSlug) {
-    return appliedModule -> moduleSlug.map(JHLiteModuleSlug::get).map(slug -> appliedModule.module().slug().equals(slug)).orElse(true);
+  private static Predicate<AppliedModule> hasModuleSlug(Optional<JHipsterModuleSlug> moduleSlug) {
+    return appliedModule -> moduleSlug.map(JHipsterModuleSlug::get).map(slug -> appliedModule.module().slug().equals(slug)).orElse(true);
   }
 
   void clear() {

--- a/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepository.java
+++ b/src/main/java/tech/jhipster/lite/statistic/infrastructure/secondary/MongoDBStatisticsRepository.java
@@ -8,9 +8,7 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Repository;
 import tech.jhipster.lite.shared.error.domain.Assert;
-import tech.jhipster.lite.statistic.domain.AppliedModule;
-import tech.jhipster.lite.statistic.domain.Statistics;
-import tech.jhipster.lite.statistic.domain.StatisticsRepository;
+import tech.jhipster.lite.statistic.domain.*;
 import tech.jhipster.lite.statistic.domain.criteria.StatisticsCriteria;
 
 @WithMongoDB
@@ -45,9 +43,9 @@ class MongoDBStatisticsRepository implements StatisticsRepository {
 
   private Query generateQuery(@NotNull StatisticsCriteria criteria) {
     List<Criteria> criteriaList = new ArrayList<>();
-    criteria.getStartTime().ifPresent(startTime -> criteriaList.add(Criteria.where("date").gte(startTime)));
-    criteria.getEndTime().ifPresent(endTime -> criteriaList.add(Criteria.where("date").lte(endTime)));
-    criteria.getModuleSlug().ifPresent(moduleSlug -> criteriaList.add(Criteria.where("moduleSlug").is(moduleSlug.get())));
+    criteria.startTime().ifPresent(startTime -> criteriaList.add(Criteria.where("date").gte(startTime)));
+    criteria.endTime().ifPresent(endTime -> criteriaList.add(Criteria.where("date").lte(endTime)));
+    criteria.moduleSlug().ifPresent(moduleSlug -> criteriaList.add(Criteria.where("moduleSlug").is(moduleSlug.get())));
 
     return new Query(new Criteria().andOperator(criteriaList.toArray(new Criteria[0])));
   }


### PR DESCRIPTION
JHipsterModuleSlug is the value object defined and used by the module context, that is specifically implemented in jhlite generators by JHLiteModuleSlug.
Previous code would have prevented filtering module slugs provided by extension of jhlite (such as custom or private modules)