### PR TITLE
Sonar: Use concise character class syntax '\d' instead of '[0-9]'

### DIFF
--- a/src/main/resources/generator/server/javatool/base/test/ReplaceCamelCase.java.mustache
+++ b/src/main/resources/generator/server/javatool/base/test/ReplaceCamelCase.java.mustache
@@ -12,7 +12,7 @@ public class ReplaceCamelCase extends DisplayNameGenerator.Standard {
 
   private String replaceCapitals(String name) {
     name = name.replaceAll("([A-Z])", " $1");
-    name = name.replaceAll("([0-9]+)", " $1");
+    name = name.replaceAll("(\\d+)", " $1");
     name = name.toLowerCase();
     return name;
   }

--- a/src/test/java/tech/jhipster/lite/ReplaceCamelCase.java
+++ b/src/test/java/tech/jhipster/lite/ReplaceCamelCase.java
@@ -12,7 +12,7 @@ public class ReplaceCamelCase extends DisplayNameGenerator.Standard {
 
   private String replaceCapitals(String name) {
     name = name.replaceAll("([A-Z])", " $1");
-    name = name.replaceAll("([0-9]+)", " $1");
+    name = name.replaceAll("(\\d+)", " $1");
     name = name.toLowerCase();
     return name;
   }


### PR DESCRIPTION
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/fefd4127-56d7-49bc-b971-8feb641ee1c0)
