### PR TITLE
OAuth2 module: improve custom name, instead of using jhipster

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/domain/OAuth2ModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/domain/OAuth2ModuleFactory.java
@@ -1,6 +1,6 @@
 package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.core.domain;
 
-import static tech.jhipster.lite.generator.server.springboot.mvc.security.common.domain.AuthenticationModulesFactory.authenticationModuleBuilder;
+import static tech.jhipster.lite.generator.server.springboot.mvc.security.common.domain.AuthenticationModulesFactory.*;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 
 import java.util.regex.Pattern;
@@ -81,8 +81,10 @@ public class OAuth2ModuleFactory {
     builder
       .files()
       .add(DOCKER_SOURCE.template("keycloak.yml"), DOCKER_DESTINATION.append("keycloak.yml"))
-      .batch(DOCKER_SOURCE, DOCKER_DESTINATION.append("keycloak-realm-config"))
-      .addTemplate("jhipster-realm.json");
+      .add(
+        DOCKER_SOURCE.template("jhipster-realm.json"),
+        DOCKER_DESTINATION.append("keycloak-realm-config").append(realmName + "-realm.json")
+      );
   }
 
   private static void appendJavaFiles(JHipsterModuleBuilder builder, JHipsterModuleProperties properties) {

--- a/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/docker/jhipster-realm.json.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/docker/jhipster-realm.json.mustache
@@ -1,5 +1,5 @@
 {
-  "id": "jhipster",
+  "id": "{{realmName}}",
   "realm": "{{realmName}}",
   "notBefore": 0,
   "defaultSignatureAlgorithm": "RS256",
@@ -51,7 +51,7 @@
         "description": "{{projectName}} administrator role",
         "composite": false,
         "clientRole": false,
-        "containerId": "jhipster",
+        "containerId": "{{realmName}}",
         "attributes": {}
       },
       {
@@ -60,7 +60,7 @@
         "description": "${role_offline-access}",
         "composite": false,
         "clientRole": false,
-        "containerId": "jhipster",
+        "containerId": "{{realmName}}",
         "attributes": {}
       },
       {
@@ -69,12 +69,12 @@
         "description": "{{projectName}} user role",
         "composite": false,
         "clientRole": false,
-        "containerId": "jhipster",
+        "containerId": "{{realmName}}",
         "attributes": {}
       },
       {
         "id": "d2b73e7b-a2d7-40e9-8ebc-2af00454e8aa",
-        "name": "default-roles-jhipster",
+        "name": "default-roles-{{realmName}}",
         "description": "${role_default-roles}",
         "composite": true,
         "composites": {
@@ -84,7 +84,7 @@
           }
         },
         "clientRole": false,
-        "containerId": "jhipster",
+        "containerId": "{{realmName}}",
         "attributes": {}
       },
       {
@@ -93,7 +93,7 @@
         "description": "${role_uma_authorization}",
         "composite": false,
         "clientRole": false,
-        "containerId": "jhipster",
+        "containerId": "{{realmName}}",
         "attributes": {}
       }
     ],
@@ -306,7 +306,6 @@
           "attributes": {}
         }
       ],
-      "jhipster-control-center": [],
       "security-admin-console": [],
       "web_app": [],
       "admin-cli": [],
@@ -421,11 +420,11 @@
   ],
   "defaultRole": {
     "id": "d2b73e7b-a2d7-40e9-8ebc-2af00454e8aa",
-    "name": "default-roles-jhipster",
+    "name": "default-roles-{{realmName}}",
     "description": "${role_default-roles}",
     "composite": true,
     "clientRole": false,
-    "containerId": "jhipster"
+    "containerId": "{{realmName}}"
   },
   "requiredCredentials": ["password"],
   "otpPolicyType": "totp",
@@ -759,49 +758,6 @@
         }
       ],
       "defaultClientScopes": ["web-origins", "roles", "profile", "email"],
-      "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
-    },
-    {
-      "id": "1acf7ad0-68cb-46a6-a3e4-8b2f2abecb85",
-      "clientId": "jhipster-control-center",
-      "rootUrl": "http://localhost:7419",
-      "adminUrl": "http://localhost:7419",
-      "surrogateAuthRequired": false,
-      "enabled": true,
-      "alwaysDisplayInConsole": false,
-      "clientAuthenticatorType": "client-secret",
-      "secret": "jhipster-control-center",
-      "redirectUris": ["dev.localhost.ionic:*", "http://127.0.0.1:*", "http://localhost:*", "https://127.0.0.1:*", "https://localhost:*"],
-      "webOrigins": ["*"],
-      "notBefore": 0,
-      "bearerOnly": false,
-      "consentRequired": false,
-      "standardFlowEnabled": true,
-      "implicitFlowEnabled": true,
-      "directAccessGrantsEnabled": false,
-      "serviceAccountsEnabled": false,
-      "publicClient": true,
-      "frontchannelLogout": false,
-      "protocol": "openid-connect",
-      "attributes": {
-        "saml.assertion.signature": "false",
-        "saml.force.post.binding": "false",
-        "saml.multivalued.roles": "false",
-        "saml.encrypt": "false",
-        "saml.server.signature": "false",
-        "saml.server.signature.keyinfo.ext": "false",
-        "exclude.session.state.from.auth.response": "false",
-        "saml_force_name_id_format": "false",
-        "saml.client.signature": "false",
-        "tls.client.certificate.bound.access.tokens": "false",
-        "saml.authnstatement": "false",
-        "display.on.consent.screen": "false",
-        "saml.onetimeuse.condition": "false"
-      },
-      "authenticationFlowBindingOverrides": {},
-      "fullScopeAllowed": true,
-      "nodeReRegistrationTimeout": -1,
-      "defaultClientScopes": ["web-origins", "{{clientScopeName}}", "roles", "profile", "email"],
       "optionalClientScopes": ["address", "phone", "offline_access", "microprofile-jwt"]
     },
     {

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/domain/OAuth2ModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/mvc/security/oauth2/core/domain/OAuth2ModuleFactoryTest.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.mvc.security.oauth2.core.
 import static org.mockito.Mockito.when;
 import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -27,11 +28,12 @@ class OAuth2ModuleFactoryTest {
   private OAuth2ModuleFactory factory;
 
   @Test
+  @DisplayName("should create OAuth2 module")
   void shouldCreateOAuth2Module() {
     JHipsterModuleProperties properties = JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
       .basePackage("com.jhipster.test")
       .projectBaseName("myapp")
-      .put("keycloakRealmName", "my-test-realm")
+      .put("keycloakRealmName", "beer")
       .build();
 
     when(dockerImages.get("quay.io/keycloak/keycloak")).thenReturn(new DockerImageVersion("quay.io/keycloak/keycloak", "1.1.1"));
@@ -82,7 +84,7 @@ class OAuth2ModuleFactoryTest {
       .hasFile("src/main/docker/keycloak.yml")
       .containing("quay.io/keycloak/keycloak:1.1.1")
       .and()
-      .hasFile("src/main/docker/keycloak-realm-config/jhipster-realm.json")
+      .hasFile("src/main/docker/keycloak-realm-config/beer-realm.json")
       .containing("1.1.1")
       .and()
       .hasFile("src/main/java/com/jhipster/test/shared/authentication/package-info.java")
@@ -107,7 +109,7 @@ class OAuth2ModuleFactoryTest {
               client:
                 provider:
                   oidc:
-                    issuer-uri: http://localhost:9080/realms/my-test-realm
+                    issuer-uri: http://localhost:9080/realms/beer
                 registration:
                   oidc:
                     client-id: web_app
@@ -128,7 +130,7 @@ class OAuth2ModuleFactoryTest {
               client:
                 provider:
                   oidc:
-                    issuer-uri: http://DO_NOT_CALL:9080/realms/my-test-realm
+                    issuer-uri: http://DO_NOT_CALL:9080/realms/beer
         """
       )
       .and()


### PR DESCRIPTION
fix https://github.com/jhipster/jhipster-lite/issues/9964

Some improvement for generated realm file:
- less hard coded jhipster
- removed jhipster-control-center as the project is deprecated and not maintained anymore

Following https://github.com/jhipster/jhipster-lite/pull/9366