### PR TITLE
UI: hide minimap by default

### DIFF
--- a/src/main/webapp/app/module/primary/landscape-minimap/LandscapeMiniMap.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-minimap/LandscapeMiniMap.component.ts
@@ -14,7 +14,7 @@ export default defineComponent({
     const minimapHTML = ref('');
     const realScale = ref(1);
 
-    const isMiniMapOpen = ref(true);
+    const isMiniMapOpen = ref(false);
 
     const minimapContainer = ref<HTMLElement>(document.createElement('div'));
     const minimapSize = ref<HTMLElement>(document.createElement('div'));
@@ -37,6 +37,8 @@ export default defineComponent({
 
       landscapeContainer.addEventListener('scroll', trackScroll);
       window.addEventListener('resize', setupDimensions);
+
+      closeMiniMap();
     });
 
     const removeDataSelectorAttrs = (data: string): string => {

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeMiniMapComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeMiniMapComponent.spec.ts
@@ -83,23 +83,21 @@ describe('MiniMap component', () => {
     expect(landscapeContainer.addEventListener).toBeCalled();
   });
 
-  it('should close and reopen the minimap', async () => {
+  it('should open and close the minimap', async () => {
     const landscapeContainer = buildLandscapeContainer();
 
     const wrapper = mount(LandscapeMiniMapVue, {
       props: { landscapeContainer: landscapeContainer },
     });
 
-    await wrapper.find(wrappedElement('hide-minimap-btn')).trigger('click');
-    await wrapper.vm.$nextTick();
-
-    expect(wrapper.find(wrappedElement('show-minimap-btn')).exists()).toBeTruthy();
-    expect(wrapper.find(wrappedElement('hide-minimap-btn')).exists()).toBeFalsy();
-
     await wrapper.find(wrappedElement('show-minimap-btn')).trigger('click');
     await wrapper.vm.$nextTick();
-
     expect(wrapper.find(wrappedElement('show-minimap-btn')).exists()).toBeFalsy();
     expect(wrapper.find(wrappedElement('hide-minimap-btn')).exists()).toBeTruthy();
+
+    await wrapper.find(wrappedElement('hide-minimap-btn')).trigger('click');
+    await wrapper.vm.$nextTick();
+    expect(wrapper.find(wrappedElement('show-minimap-btn')).exists()).toBeTruthy();
+    expect(wrapper.find(wrappedElement('hide-minimap-btn')).exists()).toBeFalsy();
   });
 });


### PR DESCRIPTION
I'd prefer to hide the minimap as it hides the init module when we open the UI:

![image](https://github.com/jhipster/jhipster-lite/assets/9156882/1aff470b-aae3-4865-b5ab-07dbe5f8e91c)
