### PR TITLE
fix: OutOfMemory when try to indent pom.xml without default size

### DIFF
--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/maven/MavenCommandHandlerTest.java
@@ -55,6 +55,41 @@ class MavenCommandHandlerTest {
       .contains("    </properties>");
   }
 
+  @Test
+  void shouldFormatXmlCorrectly() throws IOException {
+    Path pom = projectWithPom("src/test/resources/projects/maven-indent/pom.xml");
+    MavenCommandHandler mavenCommandHandler = new MavenCommandHandler(Indentation.from(4), pom);
+    mavenCommandHandler.handle(new AddJavaDependencyManagement(springBootDependencyManagement()));
+
+    assertThat(contentNormalizingNewLines(pom)).contains(
+      """
+          <dependencyManagement>
+              <dependencies>
+                  <dependency>
+                      <groupId>org.springdoc</groupId>
+                      <artifactId>springdoc-openapi-ui</artifactId>
+                      <version>${springdoc-openapi.version}</version>
+                  </dependency>
+                  <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-dependencies</artifactId>
+                      <version>${spring-boot.version}</version>
+                      <scope>import</scope>
+                      <type>pom</type>
+                  </dependency>
+                  <dependency>
+                      <groupId>org.springframework.boot</groupId>
+                      <artifactId>spring-boot-dependencies</artifactId>
+                      <version>${spring-boot.version}</version>
+                      <type>pom</type>
+                      <scope>import</scope>
+                  </dependency>
+              </dependencies>
+          </dependencyManagement>
+      """
+    );
+  }
+
   @Nested
   class HandleSetVersion {
 

--- a/src/test/resources/projects/maven-indent/pom.xml
+++ b/src/test/resources/projects/maven-indent/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<project
+  xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd"
+>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>jhlite-test-maven-project</artifactId>
+  <version>0.0.1</version>
+  <name>Test project</name>
+  <packaging>pom</packaging>
+
+  <properties>
+    <json-web-token.version>0.11.5</json-web-token.version>
+    <logstash-logback-encoder.version>7.2</logstash-logback-encoder.version>
+    <spring-boot.version>2.7.1</spring-boot.version>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.springdoc</groupId>
+        <artifactId>springdoc-openapi-ui</artifactId>
+        <version>${springdoc-openapi.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-dependencies</artifactId>
+        <version>${spring-boot.version}</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <dependencies>
+    <dependency>
+      <groupId>net.logstash.logback</groupId>
+      <artifactId>logstash-logback-encoder</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.jsonwebtoken</groupId>
+      <artifactId>jjwt-api</artifactId>
+      <version>${json-web-token.version}</version>
+      <classifier>classif</classifier>
+      <scope>test</scope>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+      </plugin>
+    </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.springframework.boot</groupId>
+          <artifactId>spring-boot-maven-plugin</artifactId>
+          <version>${spring-boot.version}</version>
+          <executions>
+            <execution>
+              <goals>
+                <goal>repackage</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <mainClass>${start-class}</mainClass>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+</project>


### PR DESCRIPTION
If you add many modules and change the indentation size to 4, when newer dependencies are added to pom.xml the current indentation algorithm causes a loop that increase memory exponentially by each dependency, to avoid this we changed to use a XML formatter.

fix #10129