### PR TITLE
chore: use a dedicated typescript version for Angular

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
@@ -61,7 +61,7 @@ public class AngularModuleFactory {
         .addDevDependency(packageName("ts-jest"), COMMON)
         .addDevDependency(packageName("jest-preset-angular"), ANGULAR)
         .addDevDependency(packageName("jest-sonar-reporter"), ANGULAR)
-        .addDevDependency(packageName("typescript"), COMMON)
+        .addDevDependency(packageName("typescript"), ANGULAR)
         .addScript(scriptKey("ng"), scriptCommand("ng"))
         .addScript(scriptKey("start"), scriptCommand("ng serve"))
         .addScript(scriptKey("build"), scriptCommand("ng build"))

--- a/src/main/resources/generator/dependencies/angular/package.json
+++ b/src/main/resources/generator/dependencies/angular/package.json
@@ -20,6 +20,7 @@
     "@angular/compiler-cli": "18.0.5",
     "jest-environment-jsdom": "29.7.0",
     "jest-preset-angular": "14.1.1",
-    "jest-sonar-reporter": "2.0.0"
+    "jest-sonar-reporter": "2.0.0",
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
Angular has a strict enforcement policy on supported typescript versions. It should not prevent other client framework to use latest typescript version.