### PR TITLE
Sonar: Fields that are only assigned in the constructor should be 'readonly'

### DIFF
--- a/src/main/resources/generator/client/vue/webapp/app/http/AxiosHttp.ts.mustache
+++ b/src/main/resources/generator/client/vue/webapp/app/http/AxiosHttp.ts.mustache
@@ -3,7 +3,7 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 export type AxiosHttpResponse<T> = AxiosResponse<T>;
 
 export class AxiosHttp {
-  constructor(private axiosInstance: AxiosInstance) {}
+  constructor(private readonly axiosInstance: AxiosInstance) {}
 
   async get<Result>(uri: string, config = {}): Promise<AxiosResponse<Result>> {
     return this.axiosInstance.get<Result>(uri, config);

--- a/src/main/webapp/app/http/AxiosHttp.ts
+++ b/src/main/webapp/app/http/AxiosHttp.ts
@@ -3,7 +3,7 @@ import { AxiosInstance, AxiosRequestConfig, AxiosResponse } from 'axios';
 export type AxiosHttpResponse<T> = AxiosResponse<T>;
 
 export class AxiosHttp {
-  constructor(private axiosInstance: AxiosInstance) {}
+  constructor(private readonly axiosInstance: AxiosInstance) {}
 
   async get<Result>(uri: string, config = {}): Promise<AxiosResponse<Result>> {
     return this.axiosInstance.get<Result>(uri, config);


### PR DESCRIPTION
![image](https://github.com/jhipster/jhipster-lite/assets/9989211/36307d5f-9e1b-42f5-9953-28eb2b114509)
