### PR TITLE
Sonar: Fields that are only assigned in the constructor should be 'readonly'

### DIFF
--- a/src/main/resources/generator/client/vue/webapp/app/common/secondary/ConsoleLogger.ts.mustache
+++ b/src/main/resources/generator/client/vue/webapp/app/common/secondary/ConsoleLogger.ts.mustache
@@ -2,7 +2,7 @@ import { Logger } from '@/common/domain/Logger';
 import { Message } from '@/common/domain/Message';
 
 export default class ConsoleLogger implements Logger {
-  constructor(private logger: Console) {}
+  constructor(private readonly logger: Console) {}
 
   error(message: Message, error: Error) {
     this.logger.error(`${message}\n`, error);

--- a/src/main/webapp/app/common/secondary/ConsoleLogger.ts
+++ b/src/main/webapp/app/common/secondary/ConsoleLogger.ts
@@ -2,7 +2,7 @@ import { Logger } from '@/common/domain/Logger';
 import { Message } from '@/common/domain/Message';
 
 export default class ConsoleLogger implements Logger {
-  constructor(private logger: Console) {}
+  constructor(private readonly logger: Console) {}
 
   error(message: Message, error: Error) {
     this.logger.error(`${message}\n`, error);


### PR DESCRIPTION
Related to #10214 