### PR TITLE
Sonar: Fields that are only assigned in the constructor should be 'readonly'

### DIFF
--- a/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/health/health.component.ts.mustache
+++ b/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/health/health.component.ts.mustache
@@ -20,8 +20,8 @@ export default class HealthComponent implements OnInit {
   displayedColumns: string[] = ['key', 'value', 'detail'];
   datasource: any = [];
 
-  private dialog = inject(MatDialog);
-  private healthService = inject(HealthService);
+  private readonly dialog = inject(MatDialog);
+  private readonly healthService = inject(HealthService);
 
   ngOnInit(): void {
     this.refresh();

--- a/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/health/health.service.ts.mustache
+++ b/src/main/resources/generator/client/angular/admin/src/main/webapp/app/admin/health/health.service.ts.mustache
@@ -7,8 +7,8 @@ import { Health } from './health.model';
 
 @Injectable({ providedIn: 'root' })
 export class HealthService {
-  private http = inject(HttpClient);
-  private applicationConfigService = inject(ApplicationConfigService);
+  private readonly http = inject(HttpClient);
+  private readonly applicationConfigService = inject(ApplicationConfigService);
 
   checkHealth(): Observable<Health> {
     return this.http.get<Health>(this.applicationConfigService.getEndpointFor('management/health'));

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/account.service.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/account.service.ts.mustache
@@ -8,10 +8,10 @@ import { Account } from './account.model';
 @Injectable({ providedIn: 'root' })
 export class AccountService {
   private userIdentity: Account | null = null;
-  private authenticationState = new ReplaySubject<Account | null>(1);
+  private readonly authenticationState = new ReplaySubject<Account | null>(1);
   private accountCache$?: Observable<Account> | null;
 
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
 
   authenticate(identity: Account | null): void {
     this.userIdentity = identity;

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/auth-jwt.service.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/auth/auth-jwt.service.ts.mustache
@@ -11,7 +11,7 @@ type JwtToken = {
 
 @Injectable({ providedIn: 'root' })
 export class AuthServerProvider {
-  private http = inject(HttpClient);
+  private readonly http = inject(HttpClient);
 
   login(credentials: Login): Observable<void> {
     return this.http.post<JwtToken>('api/authenticate', credentials).pipe(map(response => this.authenticateSuccess(response)));

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.component.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.component.ts.mustache
@@ -24,9 +24,9 @@ export default class LoginComponent implements OnInit {
 
   loginForm: FormGroup;
 
-  private accountService = inject(AccountService);
-  private loginService = inject(LoginService);
-  private fb = inject(FormBuilder);
+  private readonly accountService = inject(AccountService);
+  private readonly loginService = inject(LoginService);
+  private readonly fb = inject(FormBuilder);
 
   constructor() {
     this.loginForm = this.fb.nonNullable.group({

--- a/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.service.ts.mustache
+++ b/src/main/resources/generator/client/angular/security/jwt/src/main/webapp/app/login/login.service.ts.mustache
@@ -9,8 +9,8 @@ import { Login } from './login.model';
 
 @Injectable({ providedIn: 'root' })
 export class LoginService {
-  private accountService = inject(AccountService);
-  private authServerProvider = inject(AuthServerProvider);
+  private readonly accountService = inject(AccountService);
+  private readonly authServerProvider = inject(AuthServerProvider);
 
   login(credentials: Login): Observable<Account | null> {
     return this.authServerProvider.login(credentials).pipe(mergeMap(() => this.accountService.identity(true)));


### PR DESCRIPTION
Related to #10214 