### PR TITLE
Sonar configuration: ignore src test resources

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -17,7 +17,17 @@ sonar.testExecutionReportPaths=target/test-results/TESTS-results-sonar.xml
 sonar.javascript.lcov.reportPaths=target/test-results/lcov.info
 
 sonar.sourceEncoding=UTF-8
-sonar.exclusions=src/main/webapp/main.ts, src/main/webapp/app/main.ts, src/main/webapp/content/**/*.*, src/main/webapp/i18n/*.js, target/classes/static/**/*.*, src/main/resources/**, src/main/webapp/app/router/index.ts, src/main/glyph/css/**, src/main/webapp/app/common/primary/applicationlistener/WindowApplicationListener.ts
+sonar.exclusions=\
+  src/main/resources/**,\
+  src/test/resources/**,\
+  src/main/webapp/main.ts,\
+  src/main/webapp/app/main.ts,\
+  src/main/webapp/content/**/*.*,\
+  src/main/webapp/i18n/*.js,\
+  target/classes/static/**/*.*,\
+  src/main/glyph/css/**,\
+  src/main/webapp/app/router/index.ts,\
+  src/main/webapp/app/common/primary/applicationlistener/WindowApplicationListener.ts
 
 sonar.typescript.tsconfigPath=tsconfig.json
 
@@ -99,5 +109,6 @@ sonar.issue.ignore.multicriteria.S4649.ruleKey=css:S4649
 # Ignore duplication for Arguments replacer (rule is deprecated)
 sonar.issue.ignore.multicriteria.duplicated.resourceKey=src/main/java/**
 sonar.issue.ignore.multicriteria.duplicated.ruleKey=common-java:DuplicatedBlocks
-sonar.cpd.exclusions=src/main/java/tech/jhipster/lite/error/infrastructure/primary/ArgumentsReplacer.java,src/main/java/tech/jhipster/lite/module/domain/file/ArgumentsReplacer.java
-
+sonar.cpd.exclusions=\
+  src/main/java/tech/jhipster/lite/error/infrastructure/primary/ArgumentsReplacer.java,\
+  src/main/java/tech/jhipster/lite/module/domain/file/ArgumentsReplacer.java


### PR DESCRIPTION
It's to ignore these 6 code smells:

![image](https://github.com/user-attachments/assets/91150427-4cfb-412d-b916-e73b14cb471a)
