### PR TITLE
Sonar configuration: use sonar.test.exclusions properties

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -19,7 +19,6 @@ sonar.javascript.lcov.reportPaths=target/test-results/lcov.info
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=\
   src/main/resources/**,\
-  src/test/resources/projects/**/*.*,\
   src/main/webapp/main.ts,\
   src/main/webapp/app/main.ts,\
   src/main/webapp/content/**/*.*,\
@@ -28,6 +27,7 @@ sonar.exclusions=\
   src/main/glyph/css/**,\
   src/main/webapp/app/router/index.ts,\
   src/main/webapp/app/common/primary/applicationlistener/WindowApplicationListener.ts
+sonar.test.exclusions=src/test/resources/**
 
 sonar.typescript.tsconfigPath=tsconfig.json
 


### PR DESCRIPTION
Following https://github.com/jhipster/jhipster-lite/pull/10263

It should ignore the 6 code smells now