### PR TITLE
Sonar: Modifier static is redundant for inner enums

### DIFF
--- a/src/main/resources/generator/server/springboot/mvc/security/kipe/authorization/test/RolesAccessesFixture.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/kipe/authorization/test/RolesAccessesFixture.java.mustache
@@ -22,7 +22,7 @@ public final class RolesAccessesFixture {
     //@formatter:on
   }
 
-  public static enum TestResource implements Resource {
+  public enum TestResource implements Resource {
     USERS("test-users"),
     DATA("test-data");
 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/167dc88a-9bc5-4db7-987d-6467627a24c9)
