### PR TITLE
fix(git): don't init git repository in existing repository

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepository.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepository.java
@@ -2,10 +2,10 @@ package tech.jhipster.lite.module.infrastructure.secondary.git;
 
 import java.io.File;
 import java.io.IOException;
-import java.nio.file.Files;
 import org.eclipse.jgit.api.Git;
 import org.eclipse.jgit.api.errors.GitAPIException;
 import org.eclipse.jgit.api.errors.JGitInternalException;
+import org.eclipse.jgit.storage.file.FileRepositoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Repository;
@@ -37,7 +37,10 @@ class JGitGitRepository implements GitRepository {
   }
 
   private boolean isGit(JHipsterProjectFolder folder) {
-    return Files.exists(folder.filePath(".git"));
+    FileRepositoryBuilder repositoryBuilder = new FileRepositoryBuilder();
+    repositoryBuilder.findGitDir(folderFile(folder));
+
+    return repositoryBuilder.getGitDir() != null;
   }
 
   @Override

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
@@ -1,25 +1,19 @@
 package tech.jhipster.lite.module.infrastructure.secondary.git;
 
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import ch.qos.logback.classic.Level;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.nio.file.*;
 import java.nio.file.attribute.PosixFilePermission;
 import java.util.Set;
-import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.condition.EnabledOnOs;
 import org.junit.jupiter.api.condition.OS;
 import org.junit.jupiter.api.extension.ExtendWith;
-import tech.jhipster.lite.Logs;
-import tech.jhipster.lite.LogsSpy;
-import tech.jhipster.lite.LogsSpyExtension;
-import tech.jhipster.lite.TestFileUtils;
-import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.*;
 import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
 
 @UnitTest

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/git/JGitGitRepositoryTest.java
@@ -32,8 +32,7 @@ class JGitGitRepositoryTest {
   private LogsSpy logs;
 
   @Nested
-  @DisplayName("init")
-  class JGitGitRepositoryInitTest {
+  class Init {
 
     @Test
     @EnabledOnOs(OS.LINUX)
@@ -68,11 +67,21 @@ class JGitGitRepositoryTest {
 
       logs.shouldHave(Level.TRACE, "already");
     }
+
+    @Test
+    void shouldNotInitInSubfolderOfAlreadyInitializedGitRepository() throws IOException {
+      Path gitDirectory = gitInit();
+      Path subFolder = gitDirectory.resolve("subFolder");
+      Files.createDirectories(subFolder);
+
+      git.init(new JHipsterProjectFolder(subFolder.toString()));
+
+      logs.shouldHave(Level.TRACE, "already");
+    }
   }
 
   @Nested
-  @DisplayName("Commit all")
-  class JGitGitRepositoryCommitTest {
+  class CommitAll {
 
     @Test
     void shouldHandleCommitErrors() {


### PR DESCRIPTION
Better detection of a git repository, that works when you generate your jhlite application in a subfolder of your git repository