### PR TITLE
Prettier config improvements

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,5 +1,3 @@
-node_modules/
 target/
 package-lock.json
-.git/
 template-infinitest.filters

--- a/src/main/resources/generator/prettier/.prettierignore
+++ b/src/main/resources/generator/prettier/.prettierignore
@@ -1,6 +1,5 @@
 target
 build
 package-lock.json
-.mvn
 gradle
 .gradle

--- a/src/main/resources/generator/prettier/.prettierignore
+++ b/src/main/resources/generator/prettier/.prettierignore
@@ -1,8 +1,6 @@
-node_modules
 target
 build
 package-lock.json
-.git
 .mvn
 gradle
 .gradle

--- a/src/main/resources/generator/prettier/.prettierrc.mustache
+++ b/src/main/resources/generator/prettier/.prettierrc.mustache
@@ -4,7 +4,7 @@ printWidth: 140
 singleQuote: true
 tabWidth: {{indentSize}}
 useTabs: false
-endOfLine: "{{endOfLine}}"
+endOfLine: '{{endOfLine}}'
 
 plugins:
   - '@prettier/plugin-xml'

--- a/src/test/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactoryTest.java
@@ -33,7 +33,7 @@ class PrettierModuleFactoryTest {
       .and()
       .hasFile(".prettierrc")
       .containing("tabWidth: 4")
-      .containing("endOfLine: \"crlf\"")
+      .containing("endOfLine: 'crlf'")
       .containing("@prettier/plugin-xml")
       .containing("prettier-plugin-gherkin")
       .containing("prettier-plugin-java")


### PR DESCRIPTION
- node_modules and version control systems directories are already ignored by default: https://prettier.io/docs/en/ignore.html#ignoring-files-prettierignore
- there's no particular reason for ignoring .mvn folder
- use correct formating for .prettierrc