### PR TITLE
fix(module-api): VersionSource should not be required for removing dependencies from packageJson

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/domain/packagejson/JHipsterModulePackageJson.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/packagejson/JHipsterModulePackageJson.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.Collection;
 import tech.jhipster.lite.module.domain.JHipsterModule.JHipsterModuleBuilder;
 import tech.jhipster.lite.shared.error.domain.Assert;
+import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
 
 /**
  * This class represents the {@code package.json} configurations for a JHipster module.
@@ -14,17 +15,17 @@ public final class JHipsterModulePackageJson {
 
   private final Scripts scripts;
   private final PackageJsonDependencies dependencies;
-  private final PackageJsonDependencies dependenciesToRemove;
+  private final PackageNames dependenciesToRemove;
   private final PackageJsonDependencies devDependencies;
-  private final PackageJsonDependencies devDependenciesToRemove;
+  private final PackageNames devDependenciesToRemove;
   private final PackageJsonType type;
 
   private JHipsterModulePackageJson(JHipsterModulePackageJsonBuilder builder) {
     scripts = new Scripts(builder.scripts);
     dependencies = new PackageJsonDependencies(builder.dependencies);
-    dependenciesToRemove = new PackageJsonDependencies(builder.dependenciesToRemove);
+    dependenciesToRemove = new PackageNames(builder.dependenciesToRemove);
     devDependencies = new PackageJsonDependencies(builder.devDependencies);
-    devDependenciesToRemove = new PackageJsonDependencies(builder.devDependenciesToRemove);
+    devDependenciesToRemove = new PackageNames(builder.devDependenciesToRemove);
     type = new PackageJsonType(builder.type);
   }
 
@@ -54,11 +55,11 @@ public final class JHipsterModulePackageJson {
     return dependencies;
   }
 
-  public PackageJsonDependencies devDependenciesToRemove() {
+  public PackageNames devDependenciesToRemove() {
     return devDependenciesToRemove;
   }
 
-  public PackageJsonDependencies dependenciesToRemove() {
+  public PackageNames dependenciesToRemove() {
     return dependenciesToRemove;
   }
 
@@ -72,8 +73,8 @@ public final class JHipsterModulePackageJson {
     private final Collection<Script> scripts = new ArrayList<>();
     private final Collection<PackageJsonDependency> dependencies = new ArrayList<>();
     private final Collection<PackageJsonDependency> devDependencies = new ArrayList<>();
-    private final Collection<PackageJsonDependency> dependenciesToRemove = new ArrayList<>();
-    private final Collection<PackageJsonDependency> devDependenciesToRemove = new ArrayList<>();
+    private final Collection<PackageName> dependenciesToRemove = new ArrayList<>();
+    private final Collection<PackageName> devDependenciesToRemove = new ArrayList<>();
     private String type;
 
     private JHipsterModulePackageJsonBuilder(JHipsterModuleBuilder module) {
@@ -132,11 +133,25 @@ public final class JHipsterModulePackageJson {
      * Remove a dependency from the {@code package.json} dependencies section.
      *
      * @param packageName the name of the package
-     * @param versionSource the version source
+     * @param versionSource the (unused) version source
+     * @return the builder itself
+     * @deprecated use {@link #removeDependency(PackageName)} instead
+     */
+    @ExcludeFromGeneratedCodeCoverage(reason = "Deprecated")
+    @Deprecated(forRemoval = true, since = "1.15.0")
+    public JHipsterModulePackageJsonBuilder removeDependency(PackageName packageName, VersionSource versionSource) {
+      return removeDependency(packageName);
+    }
+
+    /**
+     * Remove a dependency from the {@code package.json} dependencies section.
+     *
+     * @param packageName the name of the package
      * @return the builder itself
      */
-    public JHipsterModulePackageJsonBuilder removeDependency(PackageName packageName, VersionSource versionSource) {
-      dependenciesToRemove.add(PackageJsonDependency.builder().packageName(packageName).versionSource(versionSource).build());
+    public JHipsterModulePackageJsonBuilder removeDependency(PackageName packageName) {
+      dependenciesToRemove.add(packageName);
+
       return this;
     }
 
@@ -177,11 +192,24 @@ public final class JHipsterModulePackageJson {
      * Remove a development dependency from the {@code package.json} devDependencies section.
      *
      * @param packageName the name of the package
-     * @param versionSource the version source
+     * @param versionSource the (unused) version source
+     * @return the builder itself
+     * @deprecated use {@link #removeDevDependency(PackageName)} instead
+     */
+    @ExcludeFromGeneratedCodeCoverage(reason = "Deprecated")
+    @Deprecated(forRemoval = true, since = "1.15.0")
+    public JHipsterModulePackageJsonBuilder removeDevDependency(PackageName packageName, VersionSource versionSource) {
+      return removeDevDependency(packageName);
+    }
+
+    /**
+     * Remove a development dependency from the {@code package.json} devDependencies section.
+     *
+     * @param packageName the name of the package
      * @return the builder itself
      */
-    public JHipsterModulePackageJsonBuilder removeDevDependency(PackageName packageName, VersionSource versionSource) {
-      devDependenciesToRemove.add(PackageJsonDependency.builder().packageName(packageName).versionSource(versionSource).build());
+    public JHipsterModulePackageJsonBuilder removeDevDependency(PackageName packageName) {
+      devDependenciesToRemove.add(packageName);
 
       return this;
     }

--- a/src/main/java/tech/jhipster/lite/module/domain/packagejson/PackageNames.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/packagejson/PackageNames.java
@@ -1,0 +1,19 @@
+package tech.jhipster.lite.module.domain.packagejson;
+
+import java.util.Collection;
+import java.util.stream.Stream;
+import tech.jhipster.lite.shared.collection.domain.JHipsterCollections;
+
+public record PackageNames(Collection<PackageName> packageNames) {
+  public PackageNames(Collection<PackageName> packageNames) {
+    this.packageNames = JHipsterCollections.immutable(packageNames);
+  }
+
+  public boolean isEmpty() {
+    return packageNames().isEmpty();
+  }
+
+  public Stream<PackageName> stream() {
+    return packageNames().stream();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandler.java
@@ -107,7 +107,7 @@ class FileSystemPackageJsonHandler {
       .apply();
   }
 
-  private String removeDevDependencies(Indentation indentation, PackageJsonDependencies dependenciesToRemove, String content) {
+  private String removeDevDependencies(Indentation indentation, PackageNames dependenciesToRemove, String content) {
     return JsonAction.remove()
       .blockName("devDependencies")
       .jsonContent(content)
@@ -125,7 +125,7 @@ class FileSystemPackageJsonHandler {
       .apply();
   }
 
-  private String removeDependencies(Indentation indentation, PackageJsonDependencies dependenciesToRemove, String content) {
+  private String removeDependencies(Indentation indentation, PackageNames dependenciesToRemove, String content) {
     return JsonAction.remove()
       .blockName("dependencies")
       .jsonContent(content)
@@ -138,8 +138,12 @@ class FileSystemPackageJsonHandler {
     return JsonAction.replace().blockName("type").jsonContent(content).indentation(indentation).blockValue(packageJsonType.type()).apply();
   }
 
-  private List<JsonEntry> dependenciesEntries(PackageJsonDependencies devDependencies) {
-    return devDependencies.stream().map(dependency -> new JsonEntry(dependency.packageName().get(), getNpmVersion(dependency))).toList();
+  private List<JsonEntry> dependenciesEntries(PackageJsonDependencies dependencies) {
+    return dependencies.stream().map(dependency -> new JsonEntry(dependency.packageName().get(), getNpmVersion(dependency))).toList();
+  }
+
+  private Collection<JsonEntry> dependenciesEntries(PackageNames packageNames) {
+    return packageNames.stream().map(packageName -> new JsonEntry(packageName.get(), "")).toList();
   }
 
   private String getNpmVersion(PackageJsonDependency dependency) {

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandlerTest.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemPackageJsonHandlerTest.java
@@ -3,7 +3,8 @@ package tech.jhipster.lite.module.infrastructure.secondary;
 import static org.assertj.core.api.Assertions.*;
 import static org.mockito.Mockito.*;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.*;
+import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.emptyModuleBuilder;
+import static tech.jhipster.lite.module.domain.JHipsterModulesFixture.emptyModuleContext;
 
 import java.io.IOException;
 import java.nio.file.Files;
@@ -16,9 +17,7 @@ import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.Indentation;
-import tech.jhipster.lite.module.domain.npm.NpmPackageVersion;
-import tech.jhipster.lite.module.domain.npm.NpmVersionSource;
-import tech.jhipster.lite.module.domain.npm.NpmVersions;
+import tech.jhipster.lite.module.domain.npm.*;
 import tech.jhipster.lite.module.domain.packagejson.JHipsterModulePackageJson;
 import tech.jhipster.lite.module.domain.packagejson.JHipsterModulePackageJson.JHipsterModulePackageJsonBuilder;
 import tech.jhipster.lite.module.domain.packagejson.VersionSource;
@@ -324,7 +323,7 @@ class FileSystemPackageJsonHandlerTest {
       packageJson.handle(
         Indentation.DEFAULT,
         folder,
-        packageJson(p -> p.removeDevDependency(packageName("@prettier/plugin-xml"), VersionSource.COMMON)),
+        packageJson(p -> p.removeDevDependency(packageName("@prettier/plugin-xml"))),
         emptyModuleContext()
       );
 
@@ -446,7 +445,7 @@ class FileSystemPackageJsonHandlerTest {
       packageJson.handle(
         Indentation.DEFAULT,
         folder,
-        packageJson(p -> p.removeDependency(packageName("@fortawesome/fontawesome-svg-core"), VersionSource.COMMON)),
+        packageJson(p -> p.removeDependency(packageName("@fortawesome/fontawesome-svg-core"))),
         emptyModuleContext()
       );
 


### PR DESCRIPTION
I've deprecated the previous API and introduced a simpler one without VersionSource