### PR TITLE
chore: use vite-tsconfig-paths to simplify generated vite and vitest configuration

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
@@ -47,7 +47,7 @@ public class ReactCoreModulesFactory {
         .addDevDependency(packageName("typescript"), COMMON)
         .addDevDependency(packageName("ts-node"), REACT)
         .addDevDependency(packageName("vite"), COMMON)
-        .addDevDependency(packageName("vite-tsconfig-paths"), REACT)
+        .addDevDependency(packageName("vite-tsconfig-paths"), COMMON)
         .addDevDependency(packageName("vitest"), COMMON)
         .addDevDependency(packageName("vitest-sonar-reporter"), COMMON)
         .addDependency(packageName("react"), REACT)

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
@@ -60,6 +60,7 @@ public class VueModulesFactory {
         .addDevDependency(packageName("jsdom"), COMMON)
         .addDevDependency(packageName("typescript"), COMMON)
         .addDevDependency(packageName("vite"), COMMON)
+        .addDevDependency(packageName("vite-tsconfig-paths"), COMMON)
         .addDevDependency(packageName("vitest"), COMMON)
         .addDevDependency(packageName("vitest-sonar-reporter"), COMMON)
         .addDevDependency(packageName("vue-tsc"), VUE)

--- a/src/main/resources/generator/client/react/vite.config.ts.mustache
+++ b/src/main/resources/generator/client/react/vite.config.ts.mustache
@@ -1,17 +1,11 @@
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 
 export default defineConfig({
-  plugins: [react()],
+  plugins: [react(), tsconfigPaths()],
   build: {
     outDir: '../../../{{projectBuildDirectory}}/classes/static',
-  },
-  resolve: {
-    alias: [
-      { find: '@', replacement: path.resolve(__dirname, 'src/main/webapp/app') },
-      { find: '@assets', replacement: path.resolve('src/main/webapp/assets') },
-    ],
   },
   root: 'src/main/webapp',
   server: {

--- a/src/main/resources/generator/client/react/vitest.config.ts.mustache
+++ b/src/main/resources/generator/client/react/vitest.config.ts.mustache
@@ -3,13 +3,9 @@
 import { defineConfig } from 'vite';
 import tsconfigPaths from 'vite-tsconfig-paths';
 import react from '@vitejs/plugin-react';
-import path from 'path';
 
 export default defineConfig({
   plugins: [react(), tsconfigPaths()],
-  resolve: {
-    alias: [{ find: '@', replacement: path.resolve(__dirname, 'src/main/webapp/app') }],
-  },
   test: {
     reporters: ['verbose', 'vitest-sonar-reporter'],
     outputFile: {

--- a/src/main/resources/generator/client/vue/tsconfig.json
+++ b/src/main/resources/generator/client/vue/tsconfig.json
@@ -7,6 +7,7 @@
     "strict": true,
     "jsx": "preserve",
     "skipLibCheck": true,
+    "allowJs": true,
     "sourceMap": true,
     "resolveJsonModule": true,
     "esModuleInterop": true,
@@ -22,7 +23,8 @@
     "src/main/webapp/**/*.d.ts",
     "src/main/webapp/**/*.tsx",
     "src/main/webapp/**/*.vue",
-    "src/test/javascript/spec/**/*.ts"
+    "src/test/javascript/spec/**/*.ts",
+    "src/test/javascript/spec/**/*.vue"
   ],
   "exclude": ["./node_modules"]
 }

--- a/src/main/resources/generator/client/vue/vite.config.ts.mustache
+++ b/src/main/resources/generator/client/vue/vite.config.ts.mustache
@@ -1,15 +1,10 @@
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
 
 // https://vitejs.dev/config/
 export default defineConfig({
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src/main/webapp/app'),
-    },
-  },
-  plugins: [vue()],
+  plugins: [vue(), tsconfigPaths()],
   build: {
     outDir: '../../../{{projectBuildDirectory}}/classes/static',
   },

--- a/src/main/resources/generator/client/vue/vitest.config.ts.mustache
+++ b/src/main/resources/generator/client/vue/vitest.config.ts.mustache
@@ -1,14 +1,11 @@
 /// <reference types="vitest" />
 
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import vue from '@vitejs/plugin-vue';
-import path from 'path';
 
 export default defineConfig({
-  plugins: [vue()],
-  resolve: {
-    alias: [{ find: '@', replacement: path.resolve(__dirname, 'src/main/webapp/app') }],
-  },
+  plugins: [vue(), tsconfigPaths()],
   test: {
     reporters: ['verbose', 'vitest-sonar-reporter'],
     outputFile: {

--- a/src/main/resources/generator/dependencies/common/package.json
+++ b/src/main/resources/generator/dependencies/common/package.json
@@ -43,6 +43,7 @@
     "ts-jest": "29.2.3",
     "typescript": "5.5.4",
     "vite": "5.3.5",
+    "vite-tsconfig-paths": "4.3.2",
     "vitest": "2.0.4",
     "vitest-sonar-reporter": "2.0.0"
   }

--- a/src/main/resources/generator/dependencies/react/package.json
+++ b/src/main/resources/generator/dependencies/react/package.json
@@ -20,7 +20,6 @@
     "eslint-plugin-react": "7.35.0",
     "react-scripts": "5.0.1",
     "sass": "1.77.8",
-    "ts-node": "10.9.2",
-    "vite-tsconfig-paths": "4.3.2"
+    "ts-node": "10.9.2"
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactoryTest.java
@@ -39,6 +39,7 @@ class VueModulesFactoryTest {
         .containing(nodeDependency("jsdom"))
         .containing(nodeDependency("typescript"))
         .containing(nodeDependency("vite"))
+        .containing(nodeDependency("vite-tsconfig-paths"))
         .containing(nodeDependency("vitest"))
         .containing(nodeDependency("vitest-sonar-reporter"))
         .containing(nodeDependency("vue-tsc"))


### PR DESCRIPTION
This avoids the duplication of declaration of typescript paths, between tsconfig, vite and vitest configurations.

Preparation for https://github.com/jhipster/jhipster-lite/issues/10421