### PR TITLE
rename cucumber authentication package

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/application/CucumberAuthenticationApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/application/CucumberAuthenticationApplicationService.java
@@ -1,7 +1,7 @@
-package tech.jhipster.lite.generator.server.springboot.cucumberauthentication.application;
+package tech.jhipster.lite.generator.server.springboot.cucumber_authentication.application;
 
 import org.springframework.stereotype.Service;
-import tech.jhipster.lite.generator.server.springboot.cucumberauthentication.domain.CucumberAuthenticationModuleFactory;
+import tech.jhipster.lite.generator.server.springboot.cucumber_authentication.domain.CucumberAuthenticationModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/domain/CucumberAuthenticationModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/domain/CucumberAuthenticationModuleFactory.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.generator.server.springboot.cucumberauthentication.domain;
+package tech.jhipster.lite.generator.server.springboot.cucumber_authentication.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/infrastructure/primary/CucumberAuthenticationModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/infrastructure/primary/CucumberAuthenticationModuleConfiguration.java
@@ -1,11 +1,11 @@
-package tech.jhipster.lite.generator.server.springboot.cucumberauthentication.infrastructure.primary;
+package tech.jhipster.lite.generator.server.springboot.cucumber_authentication.infrastructure.primary;
 
 import static tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug.*;
 import static tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug.*;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import tech.jhipster.lite.generator.server.springboot.cucumberauthentication.application.CucumberAuthenticationApplicationService;
+import tech.jhipster.lite.generator.server.springboot.cucumber_authentication.application.CucumberAuthenticationApplicationService;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
 import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
 import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumber_authentication/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.cucumber_authentication;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/package-info.java
@@ -1,2 +1,0 @@
-@tech.jhipster.lite.BusinessContext
-package tech.jhipster.lite.generator.server.springboot.cucumberauthentication;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/domain/CucumberAuthenticationModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/cucumberauthentication/domain/CucumberAuthenticationModuleFactoryTest.java
@@ -5,6 +5,7 @@ import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModules
 import org.junit.jupiter.api.Test;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.generator.server.springboot.cucumber_authentication.domain.CucumberAuthenticationModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;


### PR DESCRIPTION
rename cucumber authentication package to match naming convention

fix #10435

delete this