### PR TITLE
Sonar: This assertion is unnecessary since it does not change the type of the expression

### DIFF
--- a/src/test/webapp/unit/module/primary/landscape/LandscapePresetConfigurationComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapePresetConfigurationComponent.spec.ts
@@ -77,7 +77,7 @@ describe('LandscapePresetConfigurationComponent', () => {
     await select.trigger('change');
 
     expect(wrapper.emitted('selected')).toBeTruthy();
-    expect(wrapper.emitted('selected')![0]![0]).toEqual(null);
+    expect(wrapper.emitted('selected')![0][0]).toEqual(null);
   });
 
   it('should close preset configuration when clicking on the hide preset configuration button', async () => {


### PR DESCRIPTION
<img width="623" alt="Capture d’écran 2024-08-12 à 18 11 46" src="https://github.com/user-attachments/assets/ca3d6e3a-cd51-4ee7-8397-297f711bb5a6">
