### PR TITLE
Preset: improvements of default

### DIFF
--- a/src/main/resources/preset.json
+++ b/src/main/resources/preset.json
@@ -1,31 +1,50 @@
 {
   "presets": [
     {
-      "name": "maven wrapper + prettier",
+      "name": "Java Library with Maven",
       "modules": [
         "init",
         "application-service-hexagonal-architecture-documentation",
         "maven-java",
+        "maven-wrapper",
         "prettier",
         "java-base",
-        "maven-wrapper"
+        "checkstyle",
+        "jacoco-with-min-coverage-check"
       ]
     },
     {
-      "name": "angular + spring boot",
+      "name": "Webapp: Vue + Spring Boot",
       "modules": [
         "init",
         "application-service-hexagonal-architecture-documentation",
         "maven-java",
-        "prettier",
-        "angular-core",
-        "java-base",
         "maven-wrapper",
+        "prettier",
+        "vue-core",
+        "java-base",
+        "checkstyle",
+        "jacoco-with-min-coverage-check",
         "spring-boot",
         "spring-boot-mvc-empty",
         "logs-spy",
         "spring-boot-tomcat",
         "frontend-maven-plugin"
+      ]
+    },
+    {
+      "name": "JHLite Extension with Maven",
+      "modules": [
+        "init",
+        "application-service-hexagonal-architecture-documentation",
+        "maven-java",
+        "maven-wrapper",
+        "prettier",
+        "java-base",
+        "checkstyle",
+        "jacoco-with-min-coverage-check",
+        "spring-boot",
+        "custom-jhlite"
       ]
     }
   ]

--- a/src/main/style/atom/select/select.mixin.pug
+++ b/src/main/style/atom/select/select.mixin.pug
@@ -2,5 +2,6 @@ mixin jhlite-select(opts)
   - const { disabled } = opts || {};
   select.jhlite-select(disabled=disabled)
     option(value='') Select a preset...
-    option(value='preset.name') maven wrapper + prettier
-    option(value='preset.name') angular + spring boot
+    option(value='preset.name') Java Library with Maven
+    option(value='preset.name') Webapp: Vue + Spring Boot
+    option(value='preset.name') JHLite Extension with Maven

--- a/src/main/style/organism/landscape-preset-configuration/landscape-preset-configuration.mixin.pug
+++ b/src/main/style/organism/landscape-preset-configuration/landscape-preset-configuration.mixin.pug
@@ -5,5 +5,6 @@ mixin jhlite-landscape-preset-configuration
     .jhlite-landscape-preset-configuration--field
       select#preset-configuration.jhlite-select(@change='handlePresetChange', :value='selectedPresetName')
         option(value='') Select a preset...
-        option(value='preset.name') maven wrapper + prettier
-        option(value='preset.name') angular + spring boot
+        option(value='preset.name') Java Library with Maven
+        option(value='preset.name') Webapp: Vue + Spring Boot
+        option(value='preset.name') JHLite Extension with Maven


### PR DESCRIPTION
Some changes:
- rename `maven wrapper + prettier` to `Java Library with Maven` as it's more explicit

- add following modules to keep quality:
  - `checkstyle` and `jacoco-with-min-coverage-check` (but it can be discussed)

- rename `angular + spring boot` to `Webapp: Vue + Spring Boot`
  - I switch from Angular to Vue, as Vue is used by JHLite and I'd prefer having it as default one (same, it can be discussed)

- add new preset config `JHLite Extension with Maven` for helping to create a new JHLite Extension