### PR TITLE
Disable virtual threads by default on generated Spring app

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -78,7 +78,7 @@ public class SpringBootCoreModuleFactory {
         .and()
       .springMainProperties()
         .set(propertyKey("spring.application.name"), propertyValue(baseName))
-        .set(propertyKey("spring.threads.virtual.enabled"), propertyValue(true))
+        .set(propertyKey("spring.threads.virtual.enabled"), propertyValue(false))
         .set(propertyKey(basePackageLoggingLevel), propertyValue("INFO"))
         .and()
       .springLocalProperties()

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -78,7 +78,7 @@ server:
 spring:
   threads:
     virtual:
-      enabled: true
+      enabled: false
   jackson:
     default-property-inclusion: non_null
   application:

--- a/src/main/resources/config/application.yml
+++ b/src/main/resources/config/application.yml
@@ -78,7 +78,7 @@ server:
 spring:
   threads:
     virtual:
-      enabled: false
+      enabled: true
   jackson:
     default-property-inclusion: non_null
   application:

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
@@ -158,7 +158,7 @@ class SpringBootCoreModuleFactoryTest {
               name: Myapp
             threads:
               virtual:
-                enabled: true
+                enabled: false
           """
         )
         .and()


### PR DESCRIPTION
- turned off virtual thread in by changing `spring.threads.virtual.enabled` to `false` in `application.yaml`
- Fixes #10474 