### PR TITLE
Disable virtual threads by default on generated Spring app 

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -78,7 +78,6 @@ public class SpringBootCoreModuleFactory {
         .and()
       .springMainProperties()
         .set(propertyKey("spring.application.name"), propertyValue(baseName))
-        .set(propertyKey("spring.threads.virtual.enabled"), propertyValue(true))
         .set(propertyKey(basePackageLoggingLevel), propertyValue("INFO"))
         .and()
       .springLocalProperties()

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
@@ -156,9 +156,6 @@ class SpringBootCoreModuleFactoryTest {
           spring:
             application:
               name: Myapp
-            threads:
-              virtual:
-                enabled: true
           """
         )
         .and()


### PR DESCRIPTION
- Removed `spring.threads.virtual.enabled` property from `SpringBootCoreModuleFactory` and `SpringBootCoreModuleFactoryTest`.
- Fixes #10474 