### PR TITLE
Improve element replacers API

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/angular/security/jwt/domain/AngularJwtModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/security/jwt/domain/AngularJwtModuleFactory.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.client.angular.security.jwt.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
 
 import java.util.regex.Pattern;
 import tech.jhipster.lite.module.domain.JHipsterModule;
@@ -8,15 +9,14 @@ import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.ElementReplacer;
-import tech.jhipster.lite.module.domain.replacement.RegexReplacer;
 import tech.jhipster.lite.module.domain.replacement.TextNeedleBeforeReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class AngularJwtModuleFactory {
 
   private static final Pattern PROVIDE_HTTP_CLIENT_PATTERN = Pattern.compile("provideHttpClient\\(\\),");
-  private static final ElementReplacer EXISTING_PROVIDE_HTTP_CLIENT_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> PROVIDE_HTTP_CLIENT_PATTERN.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer EXISTING_PROVIDE_HTTP_CLIENT_NEEDLE = regex(
+    notMatchingRegex(PROVIDE_HTTP_CLIENT_PATTERN),
     PROVIDE_HTTP_CLIENT_PATTERN
   );
 

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/security/oauth2/domain/AngularOauth2ModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/security/oauth2/domain/AngularOauth2ModuleFactory.java
@@ -2,6 +2,7 @@ package tech.jhipster.lite.generator.client.angular.security.oauth2.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.ANGULAR;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
 
 import java.util.regex.Pattern;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -10,14 +11,13 @@ import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.ElementReplacer;
-import tech.jhipster.lite.module.domain.replacement.RegexReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class AngularOauth2ModuleFactory {
 
   private static final Pattern PROVIDE_HTTP_CLIENT = Pattern.compile("provideHttpClient\\(\\),");
-  private static final ElementReplacer EXISTING_PROVIDE_HTTP_CLIENT_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> PROVIDE_HTTP_CLIENT.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer EXISTING_PROVIDE_HTTP_CLIENT_NEEDLE = regex(
+    notMatchingRegex(PROVIDE_HTTP_CLIENT),
     PROVIDE_HTTP_CLIENT
   );
 
@@ -32,22 +32,22 @@ public class AngularOauth2ModuleFactory {
     """;
 
   private static final Pattern EMPTY_ALLOWED_COMMON_DEPENDENCIES_PATTERN = Pattern.compile("(\"allowedCommonJsDependencies\": *\\[\\s*)]");
-  private static final ElementReplacer EMPTY_ALLOWED_COMMON_DEPENDENCIES_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> EMPTY_ALLOWED_COMMON_DEPENDENCIES_PATTERN.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer EMPTY_ALLOWED_COMMON_DEPENDENCIES_NEEDLE = regex(
+    notMatchingRegex(EMPTY_ALLOWED_COMMON_DEPENDENCIES_PATTERN),
     EMPTY_ALLOWED_COMMON_DEPENDENCIES_PATTERN
   );
 
   private static final Pattern FILLED_ALLOWED_COMMON_DEPENDENCIES_PATTERN = Pattern.compile(
     "(\"allowedCommonJsDependencies\": *\\[[^]]+)]"
   );
-  private static final ElementReplacer FILLED_ALLOWED_COMMON_DEPENDENCIES_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> FILLED_ALLOWED_COMMON_DEPENDENCIES_PATTERN.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer FILLED_ALLOWED_COMMON_DEPENDENCIES_NEEDLE = regex(
+    notMatchingRegex(FILLED_ALLOWED_COMMON_DEPENDENCIES_PATTERN),
     FILLED_ALLOWED_COMMON_DEPENDENCIES_PATTERN
   );
 
   private static final Pattern FILLED_STANDALONE_PATTERN = Pattern.compile("(imports: *\\[[^]]+)]");
-  private static final ElementReplacer FILLED_STANDALONE_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> FILLED_STANDALONE_PATTERN.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer FILLED_STANDALONE_NEEDLE = regex(
+    notMatchingRegex(FILLED_STANDALONE_PATTERN),
     FILLED_STANDALONE_PATTERN
   );
 

--- a/src/main/java/tech/jhipster/lite/generator/client/react/security/jwt/domain/ReactJwtModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/security/jwt/domain/ReactJwtModuleFactory.java
@@ -13,8 +13,6 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class ReactJwtModuleFactory {
 
-  private static final String APP = "<App />";
-
   private static final JHipsterSource ROOT = from("client/react/security/jwt");
 
   private static final JHipsterSource SOURCE = ROOT.append("src");
@@ -86,9 +84,14 @@ public class ReactJwtModuleFactory {
           .and()
         .in(path("src/main/webapp/app/index.tsx"))
           .add(lineBeforeText("import { createRoot } from 'react-dom/client';"), "import { NextUIProvider } from '@nextui-org/react';")
-          .add(lineBeforeText(APP), properties.indentation().times(2) + "<NextUIProvider>")
-          .add(lineBeforeText("</React.StrictMode>,"), properties.indentation().times(2) + "</NextUIProvider>")
-          .add(text(APP), properties.indentation().times(1) + APP)
+          .add(regex("\\s+<App />"),
+                """
+
+              \t\t<NextUIProvider>
+              \t\t\t<App />
+              \t\t</NextUIProvider>\
+              """.replace("\t", properties.indentation().spaces())
+          )
           .and()
         .in(path("src/main/webapp/app/index.css"))
           .add(lineBeforeText("body {"), "@tailwind base;" + LINE_BREAK + "@tailwind components;" + LINE_BREAK + "@tailwind utilities;" + LINE_BREAK)

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
@@ -3,7 +3,6 @@ package tech.jhipster.lite.generator.client.vue.core.domain;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.COMMON;
 import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.VUE;
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notContainingReplacement;
 
 import java.util.function.Consumer;
 import tech.jhipster.lite.module.domain.Indentation;
@@ -12,7 +11,6 @@ import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.MandatoryReplacer;
-import tech.jhipster.lite.module.domain.replacement.TextReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class VueModulesFactory {
@@ -142,7 +140,7 @@ public class VueModulesFactory {
           .add(text("@tsconfig/recommended/tsconfig.json"), "@vue/tsconfig/tsconfig.dom.json")
           .add(tsConfigCompilerOption("sourceMap", true, properties.indentation()))
           .add(tsConfigCompilerOption("allowJs", true, properties.indentation()))
-          .add(new TextReplacer(notContainingReplacement(), "\"types\": ["), "\"types\": [\"vite/client\", ")
+          .add(text("\"types\": ["), "\"types\": [\"vite/client\", ")
           .and()
         .and();
     //@formatter:on
@@ -159,7 +157,7 @@ public class VueModulesFactory {
       .mandatoryReplacements()
         .in(path("vitest.config.ts"))
           .add(lineAfterRegex("from 'vitest/config';"), "import vue from '@vitejs/plugin-vue';")
-          .add(new TextReplacer(notContainingReplacement(), "plugins: ["), "plugins: [vue(), ")
+          .add(text("plugins: ["), "plugins: [vue(), ")
           .add(text("environment: 'node',"), "environment: 'jsdom',")
           .add(vitestCoverageExclusion(properties,"src/main/webapp/**/*.component.ts"))
           .add(vitestCoverageExclusion(properties,"src/main/webapp/app/router.ts"))

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.generator.server.springboot.core.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notContaining;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
@@ -8,9 +9,7 @@ import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.gradleplugin.GradleMainBuildPlugin;
 import tech.jhipster.lite.module.domain.javabuild.GroupId;
 import tech.jhipster.lite.module.domain.javabuild.VersionSlug;
-import tech.jhipster.lite.module.domain.javadependency.JavaDependency;
-import tech.jhipster.lite.module.domain.javadependency.JavaDependencyScope;
-import tech.jhipster.lite.module.domain.javadependency.JavaDependencyType;
+import tech.jhipster.lite.module.domain.javadependency.*;
 import tech.jhipster.lite.module.domain.mavenplugin.MavenPlugin;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.TextNeedleBeforeReplacer;
@@ -29,7 +28,7 @@ public class SpringBootCoreModuleFactory {
   private static final VersionSlug SPRING_BOOT_VERSION_SLUG = versionSlug("spring-boot");
 
   private static final TextNeedleBeforeReplacer DEFAULT_GOAL_REPLACER = new TextNeedleBeforeReplacer(
-    (contentBeforeReplacement, replacement) -> !contentBeforeReplacement.contains("<defaultGoal>"),
+    notContaining("<defaultGoal>"),
     "</build>"
   );
 

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/locale_profile/domain/LocalProfileModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/locale_profile/domain/LocalProfileModuleFactory.java
@@ -1,14 +1,12 @@
 package tech.jhipster.lite.generator.server.springboot.locale_profile.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notContainingReplacement;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.buildproperties.PropertyKey;
 import tech.jhipster.lite.module.domain.buildproperties.PropertyValue;
 import tech.jhipster.lite.module.domain.mavenplugin.MavenPlugin;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
-import tech.jhipster.lite.module.domain.replacement.TextReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class LocalProfileModuleFactory {
@@ -58,12 +56,12 @@ public class LocalProfileModuleFactory {
         .and()
       .optionalReplacements()
         .in(path(".github/workflows/github-actions.yml"))
-          .add(new TextReplacer(notContainingReplacement(), "./mvnw clean verify"), "./mvnw clean verify -P'!local'")
-          .add(new TextReplacer(notContainingReplacement(), "./gradlew clean integrationTest --no-daemon"), "./gradlew clean integrationTest -Pprofile=local --no-daemon")
+          .add(text("./mvnw clean verify"), "./mvnw clean verify -P'!local'")
+          .add(text("./gradlew clean integrationTest --no-daemon"), "./gradlew clean integrationTest -Pprofile=local --no-daemon")
           .and()
         .in(path(".gitlab-ci.yml"))
-          .add(new TextReplacer(notContainingReplacement(), "./mvnw clean verify"), "./mvnw clean verify -P'!local'")
-      .add(new TextReplacer(notContainingReplacement(), "./gradlew clean integrationTest $GRADLE_CLI_OPTS"), "./gradlew clean integrationTest -Pprofile=local $GRADLE_CLI_OPTS")
+          .add(text("./mvnw clean verify"), "./mvnw clean verify -P'!local'")
+      .add(text("./gradlew clean integrationTest $GRADLE_CLI_OPTS"), "./gradlew clean integrationTest -Pprofile=local $GRADLE_CLI_OPTS")
           .and()
         .and()
       .build();

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/thymeleaf/template/domain/ThymeleafTemplateModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/thymeleaf/template/domain/ThymeleafTemplateModuleFactory.java
@@ -2,6 +2,7 @@ package tech.jhipster.lite.generator.server.springboot.thymeleaf.template.domain
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.COMMON;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
 
 import java.util.regex.Pattern;
 import tech.jhipster.lite.module.domain.JHipsterModule;
@@ -10,7 +11,6 @@ import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.ElementReplacer;
-import tech.jhipster.lite.module.domain.replacement.RegexReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class ThymeleafTemplateModuleFactory {
@@ -38,8 +38,8 @@ public class ThymeleafTemplateModuleFactory {
   private static final Pattern WELCOME_THYMELEAF_MESSAGE_PATTERN = Pattern.compile(
     "<div>Welcome to your Spring Boot with Thymeleaf project!</div>"
   );
-  private static final ElementReplacer EXISTING_WELCOME_THYMELEAF_MESSAGE_NEEDLE = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> WELCOME_THYMELEAF_MESSAGE_PATTERN.matcher(contentBeforeReplacement).find(),
+  private static final ElementReplacer EXISTING_WELCOME_THYMELEAF_MESSAGE_NEEDLE = regex(
+    notMatchingRegex(WELCOME_THYMELEAF_MESSAGE_PATTERN),
     WELCOME_THYMELEAF_MESSAGE_PATTERN
   );
 

--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
@@ -1,6 +1,5 @@
 package tech.jhipster.lite.module.domain;
 
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.always;
 import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notContainingReplacement;
 
 import java.nio.file.Paths;
@@ -250,11 +249,11 @@ public final class JHipsterModule {
   }
 
   public static TextReplacer text(String text) {
-    return new TextReplacer(always(), text);
+    return new TextReplacer(notContainingReplacement(), text);
   }
 
   public static RegexReplacer regex(String regex) {
-    return new RegexReplacer(always(), regex);
+    return new RegexReplacer(notContainingReplacement(), regex);
   }
 
   public static FileStartReplacer fileStart() {

--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModule.java
@@ -253,7 +253,15 @@ public final class JHipsterModule {
   }
 
   public static RegexReplacer regex(String regex) {
-    return new RegexReplacer(notContainingReplacement(), regex);
+    return regex(notContainingReplacement(), regex);
+  }
+
+  public static RegexReplacer regex(ReplacementCondition condition, String regex) {
+    return new RegexReplacer(condition, regex);
+  }
+
+  public static RegexReplacer regex(ReplacementCondition condition, Pattern pattern) {
+    return new RegexReplacer(condition, pattern);
   }
 
   public static FileStartReplacer fileStart() {

--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModuleShortcuts.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModuleShortcuts.java
@@ -1,6 +1,7 @@
 package tech.jhipster.lite.module.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
 
 import java.util.regex.Pattern;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
@@ -24,15 +25,8 @@ final class JHipsterModuleShortcuts {
   private static final Pattern MODULE_EXPORT = Pattern.compile("module.exports = \\{");
   private static final Pattern DEFAULT_ES_LINT = Pattern.compile("\\s*'\\*': \\[], //default configuration, replace with your own");
 
-  private static final ElementReplacer EXISTING_ESLINT_CONFIGURATION = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> MODULE_EXPORT.matcher(contentBeforeReplacement).find(),
-    MODULE_EXPORT
-  );
-
-  private static final ElementReplacer DEFAULT_ES_LINT_CONFIGURATION = new RegexReplacer(
-    (contentBeforeReplacement, replacement) -> DEFAULT_ES_LINT.matcher(contentBeforeReplacement).find(),
-    DEFAULT_ES_LINT
-  );
+  private static final ElementReplacer EXISTING_ESLINT_CONFIGURATION = regex(notMatchingRegex(MODULE_EXPORT), MODULE_EXPORT);
+  private static final ElementReplacer DEFAULT_ES_LINT_CONFIGURATION = regex(notMatchingRegex(DEFAULT_ES_LINT), DEFAULT_ES_LINT);
 
   private final JHipsterModuleBuilder builder;
 

--- a/src/main/java/tech/jhipster/lite/module/domain/JHipsterModuleShortcuts.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/JHipsterModuleShortcuts.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.module.domain;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.always;
 
 import java.util.regex.Pattern;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
@@ -22,11 +22,7 @@ final class JHipsterModuleShortcuts {
   private static final JHipsterProjectFilePath SPRING_TEST_LOG_FILE = path("src/test/resources/logback.xml");
   private static final TextNeedleBeforeReplacer JHIPSTER_LOGGER_NEEDLE = lineBeforeText("<!-- jhipster-needle-logback-add-log -->");
 
-  private static final Pattern MODULE_EXPORT = Pattern.compile("module.exports = \\{");
-  private static final Pattern DEFAULT_ES_LINT = Pattern.compile("\\s*'\\*': \\[], //default configuration, replace with your own");
-
-  private static final ElementReplacer EXISTING_ESLINT_CONFIGURATION = regex(notMatchingRegex(MODULE_EXPORT), MODULE_EXPORT);
-  private static final ElementReplacer DEFAULT_ES_LINT_CONFIGURATION = regex(notMatchingRegex(DEFAULT_ES_LINT), DEFAULT_ES_LINT);
+  private static final Pattern DEFAULT_LINTSTAGED_CONFIGURATION_ENTRY = Pattern.compile("\\s*'\\*': \\[\\s*].*");
 
   private final JHipsterModuleBuilder builder;
 
@@ -104,16 +100,13 @@ final class JHipsterModuleShortcuts {
     Assert.notNull("stagedFilesFilter", stagedFilesFilter);
     Assert.notNull("preCommitCommands", preCommitCommands);
 
-    String esLintReplacement =
-      "module.exports = \\{" +
-      LINE_BREAK +
-      builder.properties().indentation().times(1) +
-      "'%s': %s,".formatted(stagedFilesFilter.get(), preCommitCommands.get());
+    String newLintStagedConfigurationEntry =
+      "%s'%s': %s,".formatted(builder.properties().indentation().times(1), stagedFilesFilter, preCommitCommands);
 
     builder
       .optionalReplacements()
       .in(path(".lintstagedrc.cjs"))
-      .add(DEFAULT_ES_LINT_CONFIGURATION, "")
-      .add(EXISTING_ESLINT_CONFIGURATION, esLintReplacement);
+      .add(regex(always(), DEFAULT_LINTSTAGED_CONFIGURATION_ENTRY), "")
+      .add(lineAfterRegex("module.exports = \\{"), newLintStagedConfigurationEntry);
   }
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/PreCommitCommands.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/PreCommitCommands.java
@@ -37,4 +37,9 @@ public record PreCommitCommands(String commands) {
   public String get() {
     return commands;
   }
+
+  @Override
+  public String toString() {
+    return commands;
+  }
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/StagedFilesFilter.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/StagedFilesFilter.java
@@ -7,7 +7,8 @@ public record StagedFilesFilter(String filter) {
     Assert.notBlank("filter", filter);
   }
 
-  public String get() {
-    return filter();
+  @Override
+  public String toString() {
+    return filter;
   }
 }

--- a/src/main/java/tech/jhipster/lite/module/domain/replacement/ReplacementCondition.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/replacement/ReplacementCondition.java
@@ -1,5 +1,7 @@
 package tech.jhipster.lite.module.domain.replacement;
 
+import java.util.regex.Pattern;
+
 public interface ReplacementCondition {
   boolean needReplacement(String contentBeforeReplacement, String replacement);
 
@@ -9,5 +11,13 @@ public interface ReplacementCondition {
 
   static ReplacementCondition notContainingReplacement() {
     return (contentBeforeReplacement, replacement) -> !contentBeforeReplacement.contains(replacement);
+  }
+
+  static ReplacementCondition notContaining(String text) {
+    return (contentBeforeReplacement, replacement) -> !contentBeforeReplacement.contains(text);
+  }
+
+  static ReplacementCondition notMatchingRegex(Pattern pattern) {
+    return (contentBeforeReplacement, replacement) -> pattern.matcher(contentBeforeReplacement).find();
   }
 }

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/javadependency/gradle/GradleCommandHandler.java
@@ -1,23 +1,21 @@
 package tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle;
 
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
-import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.*;
-import static tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle.VersionsCatalog.*;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.always;
+import static tech.jhipster.lite.module.domain.replacement.ReplacementCondition.notMatchingRegex;
+import static tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle.VersionsCatalog.libraryAlias;
+import static tech.jhipster.lite.module.infrastructure.secondary.javadependency.gradle.VersionsCatalog.pluginAlias;
 
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Optional;
+import java.util.*;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import tech.jhipster.lite.module.domain.Indentation;
-import tech.jhipster.lite.module.domain.JHipsterModuleContext;
-import tech.jhipster.lite.module.domain.JHipsterProjectFilePath;
+import tech.jhipster.lite.module.domain.*;
 import tech.jhipster.lite.module.domain.buildproperties.BuildProperty;
 import tech.jhipster.lite.module.domain.buildproperties.PropertyKey;
 import tech.jhipster.lite.module.domain.file.*;
@@ -334,13 +332,7 @@ public class GradleCommandHandler implements JavaDependenciesCommandHandler {
       "val %s by extra\\(\"(.*?)\"\\)".formatted(toCamelCasedKotlinVariable(property.key())),
       Pattern.MULTILINE
     );
-    return new MandatoryReplacer(
-      new RegexReplacer(
-        (contentBeforeReplacement, replacement) -> propertyLinePattern.matcher(contentBeforeReplacement).find(),
-        propertyLinePattern
-      ),
-      convertToKotlinFormat(property)
-    );
+    return new MandatoryReplacer(regex(notMatchingRegex(propertyLinePattern), propertyLinePattern), convertToKotlinFormat(property));
   }
 
   private static MandatoryReplacer addNewPropertyReplacer(BuildProperty property) {


### PR DESCRIPTION
- breaking: change behavior of text() and regex() methods in JHipsterModule to not always do the replacement
The previous behavior was a bit unexpected since other replacers shortcuts were doing the replacements conditionally.

- feat(generator): add helper methods in ReplacementCondition to simplify writing replacements