### PR TITLE
Fix invalid if condition in Github Actions

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -371,7 +371,7 @@ jobs:
       - name: 'Test: list ${{ matrix.app }}'
         if: |
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
-          ${{ matrix.java-build-tool }} == 'maven'
+          matrix.java-build-tool == 'maven'
         id: cache_maven_md5sum
         working-directory: /tmp/jhlite/${{ matrix.app }}/
         run: |
@@ -382,7 +382,7 @@ jobs:
       - name: 'Init: cache local Maven repository'
         if: |
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
-          ${{ matrix.java-build-tool }} == 'maven'
+          matrix.java-build-tool == 'maven'
         uses: actions/cache@v4
         with:
           path: ~/.m2/repository
@@ -392,7 +392,7 @@ jobs:
       - name: 'Test: list ${{ matrix.app }}'
         if: |
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
-          ${{ matrix.java-build-tool }} == 'gradle'
+          matrix.java-build-tool == 'gradle'
         id: cache_gradle_md5sum
         working-directory: /tmp/jhlite/${{ matrix.app }}/
         run: |
@@ -408,7 +408,7 @@ jobs:
       - name: 'Init: cache local Gradle repository'
         if: |
           steps.tests-requirement-check.outputs.execute_tests == 'true' &&
-          ${{ matrix.java-build-tool }} == 'gradle'
+          matrix.java-build-tool == 'gradle'
         uses: actions/cache@v4
         with:
           path: |
@@ -520,13 +520,13 @@ jobs:
       pull-requests: write
       contents: write
     runs-on: ubuntu-latest
-    if: ${{ github.repository == 'jhipster/jhipster-lite' && github.ref != 'refs/heads/main' && github.event.pull_request.user.login == 'dependabot[bot]' }}
+    if: github.repository == 'jhipster/jhipster-lite' && github.ref != 'refs/heads/main' && github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Dependabot metadata
         id: dependabot-metadata
         uses: dependabot/fetch-metadata@v2.2.0
       - name: Enable auto-merge for Dependabot PRs
-        if: ${{ steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major' }}
+        if: steps.dependabot-metadata.outputs.update-type != 'version-update:semver-major'
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}

--- a/.github/workflows/publish-jvm-docker-image.yml
+++ b/.github/workflows/publish-jvm-docker-image.yml
@@ -27,7 +27,7 @@ jobs:
           images: ${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Login to Docker Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         uses: docker/login-action@v3.3.0

--- a/.github/workflows/publish-native-docker-image.yml
+++ b/.github/workflows/publish-native-docker-image.yml
@@ -50,7 +50,7 @@ jobs:
         run: ./start_docker_container.sh ${{ env.DOCKER_IMAGE_NAME }}
 
       - name: Login to Docker Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
         uses: docker/login-action@v3.3.0
@@ -60,7 +60,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Tag the native (GraalVM) Docker image and push it
-        if: ${{ startsWith(github.ref, 'refs/tags/v') }}
+        if: startsWith(github.ref, 'refs/tags/v')
         run: |
           docker tag ${{ env.DOCKER_IMAGE_NAME }} ${{ env.DOCKER_IMAGE_NAME }}:latest
           docker tag ${{ env.DOCKER_IMAGE_NAME }} ${{ env.DOCKER_IMAGE_NAME }}:${{  github.ref_name }}


### PR DESCRIPTION
The value of an `if:` entry is already an expression block, so usage of `${{ }}` is not necessary, except in one rare case (https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution).
However, it is easy to accidentally create an invalid condition:
`${{ matrix.java-build-tool }} == 'maven'` will always evaluate to true, due to a quirk of how nested expression context are evaluated.
Correct is either
- `${{ matrix.java-build-tool  == 'maven' }}`
- `matrix.java-build-tool == 'maven'`

I've choosen to use the latter as it is simpler. 
I've also cleaned up unnecessary use of `${{ }}` in other if blocks.