### PR TITLE
allow empty in css stylelint

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,6 +1,6 @@
 export default {
   '*.{js,cjs,ts,tsx,vue}': ['eslint --fix', 'prettier --write'],
-  '*.{css,scss}': ['stylelint --fix', 'prettier --write'],
+  '*.{css,scss}': ['stylelint --fix --allow-empty-input', 'prettier --write'],
   '*.pug': ['eslint --fix', 'prettier --write'],
   '*.{md,json,yml,html,java,xml,feature,sh}': ['prettier --write'],
 };


### PR DESCRIPTION
in order to be able to move files css files without changing the content --allow-empty is needed. Otherwise it leads to commit errors

Fix #11011