### PR TITLE
Sonar-React: Rename this constant name to match the regular expression

### DIFF
--- a/src/test/java/tech/jhipster/lite/generator/client/react/i18n/domain/ReactI18nModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/react/i18n/domain/ReactI18nModuleFactoryTest.java
@@ -11,7 +11,7 @@ import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
 @UnitTest
 class ReactI18nModuleFactoryTest {
 
-  private static final String HomePage_TSX = "src/main/webapp/app/home/infrastructure/primary/HomePage.tsx";
+  private static final String HOME_PAGE_TSX = "src/main/webapp/app/home/infrastructure/primary/HomePage.tsx";
 
   private final ReactI18nModuleFactory factory = new ReactI18nModuleFactory();
 
@@ -34,7 +34,7 @@ class ReactI18nModuleFactoryTest {
       .hasFile("src/main/webapp/app/index.tsx")
       .containing("import './i18n'")
       .and()
-      .hasFile("src/main/webapp/app/home/infrastructure/primary/HomePage.tsx")
+      .hasFile(HOME_PAGE_TSX)
       .containing("import { useTranslation } from 'react-i18next")
       .containing("const { t } = useTranslation();")
       .containing("{t('translationEnabled')}")
@@ -48,7 +48,7 @@ class ReactI18nModuleFactoryTest {
   }
 
   private ModuleFile app() {
-    return file("src/test/resources/projects/react-app/HomePage.tsx", HomePage_TSX);
+    return file("src/test/resources/projects/react-app/HomePage.tsx", HOME_PAGE_TSX);
   }
 
   private ModuleFile appTest() {


### PR DESCRIPTION
Fix
<img width="938" alt="image" src="https://github.com/user-attachments/assets/4745115b-5ebe-4f2d-85f0-111bdc52fb4c">
https://sonarcloud.io/project/issues?impactSoftwareQualities=MAINTAINABILITY&issueStatuses=OPEN%2CCONFIRMED&id=jhipster_jhipster-lite&open=AZJEisVVQWZSD2tyJXsD

cc @pascalgrimaud 