### PR TITLE
fix(jqassistant): execute maven plugin on verify phase

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/documentation/jqassistant/domain/JQAssistantModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/documentation/jqassistant/domain/JQAssistantModuleFactory.java
@@ -64,7 +64,7 @@ public class JQAssistantModuleFactory {
   private static MavenPlugin jQAssistantPluginManagement() {
     return jQAssistantPluginBuilder()
       .versionSlug("jqassistant")
-      .addExecution(pluginExecution().goals("scan", "analyze").id("default-cli"))
+      .addExecution(pluginExecution().goals("scan", "analyze").phase(VERIFY).id("default-cli"))
       .build();
   }
 

--- a/src/test/java/tech/jhipster/lite/generator/server/documentation/jqassistant/domain/JQAssistantModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/documentation/jqassistant/domain/JQAssistantModuleFactoryTest.java
@@ -42,6 +42,7 @@ class JQAssistantModuleFactoryTest {
                   <executions>
                     <execution>
                       <id>default-cli</id>
+                      <phase>verify</phase>
                       <goals>
                         <goal>scan</goal>
                         <goal>analyze</goal>


### PR DESCRIPTION
That ways jqassistant won't scan the project if there are failing integration tests