### PR TITLE
fix: lazily run npm install when applying 'prettier' and client modules

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/application/AngularApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/application/AngularApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.client.angular.core.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.client.angular.core.domain.AngularModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class AngularApplicationService {
 
   private final AngularModuleFactory factory;
 
-  public AngularApplicationService() {
-    factory = new AngularModuleFactory();
+  public AngularApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    factory = new AngularModuleFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildInitModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactory.java
@@ -17,6 +17,7 @@ import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.COMMON
 import tech.jhipster.lite.module.domain.Indentation;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.packagejson.PackageName;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
@@ -26,6 +27,11 @@ public class AngularModuleFactory {
 
   private static final String ENGINES_NEEDLE = "  \"engines\":";
   private static final PackageName ANGULAR_CORE_PACKAGE = packageName("@angular/core");
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public AngularModuleFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
     //@formatter:off
@@ -81,6 +87,9 @@ public class AngularModuleFactory {
         .addScript(scriptKey("test:coverage"), scriptCommand("ng test --coverage"))
         .addScript(scriptKey("watch:test"), scriptCommand("ng test --watch"))
         .addScript(scriptKey("lint"), scriptCommand("eslint ."))
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
         .and()
       .files()
         .add(SOURCE.template("angular.json"), to("angular.json"))

--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/application/ReactCoreApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/application/ReactCoreApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.client.react.core.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.client.react.core.domain.ReactCoreModulesFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class ReactCoreApplicationService {
 
   private final ReactCoreModulesFactory factory;
 
-  public ReactCoreApplicationService() {
-    factory = new ReactCoreModulesFactory();
+  public ReactCoreApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    factory = new ReactCoreModulesFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
@@ -23,6 +23,7 @@ import tech.jhipster.lite.module.domain.Indentation;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.MandatoryReplacer;
 
@@ -46,6 +47,12 @@ public class ReactCoreModulesFactory {
 
   private static final String TEST_PRIMARY = "src/test/webapp/unit/home/infrastructure/primary";
   private static final String DEFAULT_TSCONFIG_PATH = "\"@/*\": [\"src/main/webapp/app/*\"]";
+
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public ReactCoreModulesFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
     //@formatter:off
@@ -74,7 +81,10 @@ public class ReactCoreModulesFactory {
         .addScript(scriptKey("build:vite"), scriptCommand("vite build --emptyOutDir"))
         .addScript(scriptKey("preview"), scriptCommand("vite preview"))
         .addScript(scriptKey("start"), scriptCommand("vite"))
-      .and()
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
+        .and()
       .files()
         .batch(SOURCE, to("."))
           .addTemplate("vite.config.ts")

--- a/src/main/java/tech/jhipster/lite/generator/client/svelte/core/application/SvelteApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/svelte/core/application/SvelteApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.client.svelte.core.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.client.svelte.core.domain.SvelteModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class SvelteApplicationService {
 
   private final SvelteModuleFactory factory;
 
-  public SvelteApplicationService() {
-    this.factory = new SvelteModuleFactory();
+  public SvelteApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    this.factory = new SvelteModuleFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildModule(JHipsterModuleProperties project) {

--- a/src/main/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactory.java
@@ -17,6 +17,7 @@ import tech.jhipster.lite.module.domain.Indentation;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
@@ -32,6 +33,12 @@ public class SvelteModuleFactory {
 
   private static final JHipsterSource PRIMARY_TEST_SOURCE = SOURCE.append("src/test/unit/common/primary/app");
   private static final JHipsterDestination PRIMARY_TEST_DESTINATION = to("src/test/webapp/unit/common/primary/app");
+
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public SvelteModuleFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
 
   public JHipsterModule buildSvelteModule(JHipsterModuleProperties properties) {
     Assert.notNull("properties", properties);
@@ -82,6 +89,9 @@ public class SvelteModuleFactory {
         .addScript(scriptKey("test"), scriptCommand("npm run test:watch"))
         .addScript(scriptKey("test:coverage"), scriptCommand("vitest run --coverage"))
         .addScript(scriptKey("test:watch"), scriptCommand("vitest --"))
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
         .and()
       .optionalReplacements()
         .in(path("package.json"))

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/application/VueApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/application/VueApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.client.vue.core.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.client.vue.core.domain.VueModulesFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class VueApplicationService {
 
   private final VueModulesFactory factory;
 
-  public VueApplicationService() {
-    factory = new VueModulesFactory();
+  public VueApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    factory = new VueModulesFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildVueModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactory.java
@@ -22,6 +22,7 @@ import tech.jhipster.lite.module.domain.Indentation;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.module.domain.replacement.MandatoryReplacer;
 import tech.jhipster.lite.shared.error.domain.Assert;
@@ -51,6 +52,12 @@ public class VueModulesFactory {
     app.use(pinia);
     """;
 
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public VueModulesFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
+
   public JHipsterModule buildVueModule(JHipsterModuleProperties properties) {
     //@formatter:off
     return moduleBuilder(properties)
@@ -79,6 +86,9 @@ public class VueModulesFactory {
         .addScript(scriptKey("preview"), scriptCommand("vite preview"))
         .addScript(scriptKey("start"), scriptCommand("vite"))
         .addScript(scriptKey("watch:tsc"), scriptCommand("npm run build:tsc -- --watch"))
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
         .and()
       .files()
         .add(SOURCE.file("tsconfig.build.json"), to("tsconfig.build.json"))

--- a/src/main/java/tech/jhipster/lite/generator/prettier/application/PrettierApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/prettier/application/PrettierApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.prettier.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.prettier.domain.PrettierModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class PrettierApplicationService {
 
   private final PrettierModuleFactory factory;
 
-  public PrettierApplicationService() {
-    factory = new PrettierModuleFactory();
+  public PrettierApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    this.factory = new PrettierModuleFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {

--- a/src/main/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactory.java
@@ -13,12 +13,19 @@ import static tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource.COMMON
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterDestination;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 public class PrettierModuleFactory {
 
   private static final JHipsterSource SOURCE = from("prettier");
   private static final JHipsterDestination DESTINATION = to(".");
+
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public PrettierModuleFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
     //@formatter:off
@@ -42,6 +49,9 @@ public class PrettierModuleFactory {
         .addDevDependency(packageName("prettier-plugin-packagejson"), COMMON)
         .addScript(scriptKey("prettier:check"), scriptCommand("prettier --check ."))
         .addScript(scriptKey("prettier:format"), scriptCommand("prettier --write ."))
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
         .and()
       .preCommitActions(stagedFilesFilter("*.{md,json,yml,html,css,scss,java,xml,feature}"), preCommitCommands("['prettier --write']"))
       .build();

--- a/src/main/java/tech/jhipster/lite/generator/typescript/core/application/TypescriptApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/typescript/core/application/TypescriptApplicationService.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.typescript.core.application;
 import org.springframework.stereotype.Service;
 import tech.jhipster.lite.generator.typescript.core.domain.TypescriptModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @Service
@@ -10,8 +11,8 @@ public class TypescriptApplicationService {
 
   private final TypescriptModuleFactory factory;
 
-  public TypescriptApplicationService() {
-    this.factory = new TypescriptModuleFactory();
+  public TypescriptApplicationService(NpmLazyInstaller npmLazyInstaller) {
+    this.factory = new TypescriptModuleFactory(npmLazyInstaller);
   }
 
   public JHipsterModule buildModule(JHipsterModuleProperties project) {

--- a/src/main/java/tech/jhipster/lite/generator/typescript/core/domain/TypescriptModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/typescript/core/domain/TypescriptModuleFactory.java
@@ -11,12 +11,18 @@ import static tech.jhipster.lite.module.domain.packagejson.NodeModuleFormat.MODU
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class TypescriptModuleFactory {
 
   private static final JHipsterSource SOURCE = from("typescript");
+  private final NpmLazyInstaller npmLazyInstaller;
+
+  public TypescriptModuleFactory(NpmLazyInstaller npmLazyInstaller) {
+    this.npmLazyInstaller = npmLazyInstaller;
+  }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
     Assert.notNull("properties", properties);
@@ -44,6 +50,9 @@ public class TypescriptModuleFactory {
         .addScript(scriptKey("watch"), scriptCommand("npm-run-all --parallel watch:*"))
         .addScript(scriptKey("watch:tsc"), scriptCommand("tsc --noEmit --watch"))
         .addScript(scriptKey("watch:test"), scriptCommand("vitest --"))
+        .and()
+      .postActions()
+        .add(context -> npmLazyInstaller.runInstallIn(context.projectFolder()))
         .and()
       .files()
         .batch(SOURCE, to("."))

--- a/src/main/java/tech/jhipster/lite/module/domain/npm/NpmLazyInstaller.java
+++ b/src/main/java/tech/jhipster/lite/module/domain/npm/NpmLazyInstaller.java
@@ -1,0 +1,10 @@
+package tech.jhipster.lite.module.domain.npm;
+
+import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
+
+/**
+ * Run npm install if a previous npm install has already been done.
+ */
+public interface NpmLazyInstaller {
+  void runInstallIn(JHipsterProjectFolder folder);
+}

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/FileSystemNpmLazyInstaller.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/FileSystemNpmLazyInstaller.java
@@ -1,0 +1,92 @@
+package tech.jhipster.lite.module.infrastructure.secondary.npm;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.TimeUnit;
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
+import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
+import tech.jhipster.lite.shared.error.domain.Assert;
+import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
+import tech.jhipster.lite.shared.npmdetector.infrastructure.secondary.NpmInstallationReader;
+import tech.jhipster.lite.shared.npmdetector.infrastructure.secondary.NpmInstallationType;
+
+/**
+ * Launches npm install if the npm command is detected and if an existing package-lock.json is present.
+ */
+@Service
+@ExcludeFromGeneratedCodeCoverage(reason = "Hard to test, requires npm installed")
+class FileSystemNpmLazyInstaller implements NpmLazyInstaller {
+
+  private static final Logger log = LoggerFactory.getLogger(FileSystemNpmLazyInstaller.class);
+  private final NpmInstallationReader npmInstallationReader = new NpmInstallationReader();
+
+  public void runInstallIn(JHipsterProjectFolder folder) {
+    Assert.notNull("folder", folder);
+
+    if (!folder.fileExists("package-lock.json")) {
+      log.info("No package-lock.json found, npm install skipped");
+      return;
+    }
+
+    NpmInstallationType npmInstallationType = npmInstallationReader.get();
+    switch (npmInstallationType) {
+      case UNIX:
+        execute(folder, "npm", "install");
+        break;
+      case WINDOWS:
+        execute(folder, "npm.cmd", "install");
+        break;
+      case NONE:
+        log.info("No npm installed, can't install npm dependencies");
+        break;
+    }
+  }
+
+  private void execute(JHipsterProjectFolder path, String... commands) {
+    try {
+      Process process = new ProcessBuilder(commands).directory(folderFile(path)).start();
+
+      if (failedExecution(process)) {
+        throw new NpmInstallException("Error during installation of npm dependencies, process failed");
+      }
+
+      traceProcess(String.join(" ", commands), process);
+    } catch (IOException e) {
+      throw new NpmInstallException("Error during installation of npm dependencies: " + e.getMessage(), e);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+
+      throw new NpmInstallException("Error during installation of npm dependencies: " + e.getMessage(), e);
+    }
+  }
+
+  private File folderFile(JHipsterProjectFolder path) {
+    return new File(path.get());
+  }
+
+  private boolean failedExecution(Process process) throws InterruptedException {
+    return !process.waitFor(1, TimeUnit.MINUTES);
+  }
+
+  private void traceProcess(String command, Process process) throws IOException {
+    if (log.isTraceEnabled()) {
+      log.trace("{}: {}", command, read(process.getInputStream()));
+    }
+
+    String errors = read(process.getErrorStream());
+
+    if (StringUtils.isNotBlank(errors)) {
+      log.error("Error during {}: {}", command, errors);
+    }
+  }
+
+  private String read(InputStream stream) throws IOException {
+    return new String(stream.readAllBytes(), StandardCharsets.UTF_8).intern();
+  }
+}

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NpmErrorKey.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NpmErrorKey.java
@@ -1,0 +1,18 @@
+package tech.jhipster.lite.module.infrastructure.secondary.npm;
+
+import tech.jhipster.lite.shared.error.domain.ErrorKey;
+
+enum NpmErrorKey implements ErrorKey {
+  INSTALL_ERROR("install-error");
+
+  private final String key;
+
+  NpmErrorKey(String key) {
+    this.key = key;
+  }
+
+  @Override
+  public String get() {
+    return key;
+  }
+}

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NpmInstallException.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NpmInstallException.java
@@ -1,0 +1,16 @@
+package tech.jhipster.lite.module.infrastructure.secondary.npm;
+
+import tech.jhipster.lite.shared.error.domain.GeneratorException;
+import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCoverage;
+
+@ExcludeFromGeneratedCodeCoverage
+class NpmInstallException extends GeneratorException {
+
+  public NpmInstallException(String message) {
+    super(internalServerError(NpmErrorKey.INSTALL_ERROR).message(message));
+  }
+
+  public NpmInstallException(String message, Throwable cause) {
+    super(internalServerError(NpmErrorKey.INSTALL_ERROR).message(message).cause(cause));
+  }
+}

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmInstallationType.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/NpmInstallationType.java
@@ -1,7 +1,0 @@
-package tech.jhipster.lite.project.infrastructure.secondary;
-
-enum NpmInstallationType {
-  NONE,
-  UNIX,
-  WINDOWS,
-}

--- a/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfiguration.java
@@ -5,6 +5,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ImportRuntimeHints;
+import tech.jhipster.lite.shared.npmdetector.infrastructure.secondary.NpmInstallationReader;
 
 @Configuration
 @ImportRuntimeHints(NativeHints.class)

--- a/src/main/java/tech/jhipster/lite/shared/npmdetector/infrastructure/secondary/NpmInstallationReader.java
+++ b/src/main/java/tech/jhipster/lite/shared/npmdetector/infrastructure/secondary/NpmInstallationReader.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.project.infrastructure.secondary;
+package tech.jhipster.lite.shared.npmdetector.infrastructure.secondary;
 
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
@@ -9,7 +9,7 @@ import tech.jhipster.lite.shared.generation.domain.ExcludeFromGeneratedCodeCover
 
 @Service
 @ExcludeFromGeneratedCodeCoverage(reason = "Cases can only be tested by using different computers")
-class NpmInstallationReader {
+public class NpmInstallationReader {
 
   private static final Logger log = LoggerFactory.getLogger(NpmInstallationReader.class);
 

--- a/src/main/java/tech/jhipster/lite/shared/npmdetector/infrastructure/secondary/NpmInstallationType.java
+++ b/src/main/java/tech/jhipster/lite/shared/npmdetector/infrastructure/secondary/NpmInstallationType.java
@@ -1,0 +1,7 @@
+package tech.jhipster.lite.shared.npmdetector.infrastructure.secondary;
+
+public enum NpmInstallationType {
+  NONE,
+  UNIX,
+  WINDOWS,
+}

--- a/src/main/java/tech/jhipster/lite/shared/npmdetector/package-info.java
+++ b/src/main/java/tech/jhipster/lite/shared/npmdetector/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.SharedKernel
+package tech.jhipster.lite.shared.npmdetector;

--- a/src/main/resources/messages/errors/generator-errors-messages.properties
+++ b/src/main/resources/messages/errors/generator-errors-messages.properties
@@ -103,3 +103,6 @@ error.unknown-slug.title=Unknown slug
 
 error.unmappable-enum.detail=Can't map enum value
 error.unmappable-enum.title=Unmappable enum
+
+error.install-error.detail=An error happened while installing npm dependencies
+error.install-error.title=Error while installing npm dependencies

--- a/src/main/resources/messages/errors/generator-errors-messages_fr.properties
+++ b/src/main/resources/messages/errors/generator-errors-messages_fr.properties
@@ -103,3 +103,6 @@ error.unknown-slug.title=Slug inconnu
 
 error.unmappable-enum.detail=Valeur d'enum non mappable
 error.unmappable-enum.title=Enum in-mappable
+
+error.install-error.detail=Une erreur s'est produite lors de l'installation des dépendances npm
+error.install-error.title=Erreur lors de l'installation des dépendances npm

--- a/src/test/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/angular/core/domain/AngularModuleFactoryTest.java
@@ -1,18 +1,33 @@
 package tech.jhipster.lite.generator.client.angular.core.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.lintStagedConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeScript;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class AngularModuleFactoryTest {
 
-  private static final AngularModuleFactory factory = new AngularModuleFactory();
+  @InjectMocks
+  private AngularModuleFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldCreateAngularModule() {
@@ -104,6 +119,7 @@ class AngularModuleFactoryTest {
         "environment.spec.ts"
       )
       .hasPrefixedFiles("src/main/webapp", "index.html", "main.ts", "styles.css");
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactoryTest.java
@@ -1,23 +1,42 @@
 package tech.jhipster.lite.generator.client.react.core.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.eslintConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.lintStagedConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.tsConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.vitestConfigFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class ReactCoreModulesFactoryTest {
 
-  private static final ReactCoreModulesFactory factory = new ReactCoreModulesFactory();
+  @InjectMocks
+  private ReactCoreModulesFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldBuildModuleWithStyle() {
-    JHipsterModule module = factory.buildModule(
-      JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest()).projectBaseName("jhipster").build()
-    );
+    JHipsterModuleProperties properties = JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
+      .projectBaseName("jhipster")
+      .build();
+    JHipsterModule module = factory.buildModule(properties);
 
     assertThatModuleWithFiles(module, packageJsonFile(), lintStagedConfigFile(), eslintConfigFile(), tsConfigFile(), vitestConfigFile())
       .hasFile("package.json")
@@ -72,6 +91,8 @@ class ReactCoreModulesFactoryTest {
       .and()
       .hasFiles("src/main/webapp/app/home/infrastructure/primary/HomePage.css")
       .hasPrefixedFiles("src/main/webapp/assets", "ReactLogo.png", "JHipster-Lite-neon-blue.png");
+
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/svelte/core/domain/SvelteModuleFactoryTest.java
@@ -1,18 +1,33 @@
 package tech.jhipster.lite.generator.client.svelte.core.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.lintStagedConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeScript;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class SvelteModuleFactoryTest {
 
-  private static final SvelteModuleFactory factory = new SvelteModuleFactory();
+  @InjectMocks
+  private SvelteModuleFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldCreateSvelteModule() {
@@ -74,5 +89,6 @@ class SvelteModuleFactoryTest {
       .hasPrefixedFiles("src/main/webapp/assets", "JHipster-Lite-neon-orange.png")
       .hasPrefixedFiles("src/main/webapp/assets", "svelte-logo.png");
     // @formatter:on
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 }

--- a/src/test/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/client/vue/core/domain/VueModulesFactoryTest.java
@@ -1,18 +1,37 @@
 package tech.jhipster.lite.generator.client.vue.core.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.ModuleFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.eslintConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.lintStagedConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeScript;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.tsConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.vitestConfigFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class VueModulesFactoryTest {
 
-  private static final VueModulesFactory factory = new VueModulesFactory();
+  @InjectMocks
+  private VueModulesFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldCreateVueModule() {
@@ -80,6 +99,7 @@ class VueModulesFactoryTest {
       .hasFiles("src/test/webapp/unit/shared/http/infrastructure/secondary/AxiosStub.ts")
       .hasFiles("src/test/webapp/unit/router/infrastructure/primary/HomeRouter.spec.ts");
     //@formatter:on
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/prettier/domain/PrettierModuleFactoryTest.java
@@ -1,15 +1,23 @@
 package tech.jhipster.lite.generator.prettier.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.emptyLintStagedConfigFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.lintStagedConfigFileWithoutPrettier;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeScript;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
+import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
@@ -18,6 +26,9 @@ class PrettierModuleFactoryTest {
 
   @InjectMocks
   private PrettierModuleFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldBuildModuleWithoutPrettierLintStaged() {
@@ -56,6 +67,8 @@ class PrettierModuleFactoryTest {
       .containing(nodeDependency("prettier-plugin-packagejson"))
       .containing(nodeScript("prettier:check", "prettier --check ."))
       .containing(nodeScript("prettier:format", "prettier --write ."));
+
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 
   @Test

--- a/src/test/java/tech/jhipster/lite/generator/typescript/domain/core/TypescriptModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/typescript/domain/core/TypescriptModuleFactoryTest.java
@@ -1,19 +1,33 @@
 package tech.jhipster.lite.generator.typescript.domain.core;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static org.mockito.Mockito.verify;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeDependency;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.nodeScript;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.packageJsonFile;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 import tech.jhipster.lite.TestFileUtils;
 import tech.jhipster.lite.UnitTest;
 import tech.jhipster.lite.generator.typescript.core.domain.TypescriptModuleFactory;
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
+@ExtendWith(MockitoExtension.class)
 class TypescriptModuleFactoryTest {
 
-  private static final TypescriptModuleFactory factory = new TypescriptModuleFactory();
+  @InjectMocks
+  private TypescriptModuleFactory factory;
+
+  @Mock
+  private NpmLazyInstaller npmLazyInstaller;
 
   @Test
   void shouldCreateTypescriptModule() {
@@ -44,5 +58,6 @@ class TypescriptModuleFactoryTest {
       .containing(nodeScript("lint", "eslint ."))
       .and()
       .hasPrefixedFiles("", "eslint.config.js", "tsconfig.json");
+    verify(npmLazyInstaller).runInstallIn(properties.projectFolder());
   }
 }

--- a/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NoopNpmLazyInstaller.java
+++ b/src/test/java/tech/jhipster/lite/module/infrastructure/secondary/npm/NoopNpmLazyInstaller.java
@@ -1,0 +1,16 @@
+package tech.jhipster.lite.module.infrastructure.secondary.npm;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import tech.jhipster.lite.module.domain.npm.NpmLazyInstaller;
+import tech.jhipster.lite.module.domain.properties.JHipsterProjectFolder;
+
+public class NoopNpmLazyInstaller implements NpmLazyInstaller {
+
+  private static final Logger logs = LoggerFactory.getLogger(NoopNpmLazyInstaller.class);
+
+  @Override
+  public void runInstallIn(JHipsterProjectFolder folder) {
+    logs.info("Simulating installation of npm dependencies");
+  }
+}

--- a/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfigurationTest.java
+++ b/src/test/java/tech/jhipster/lite/project/infrastructure/secondary/ProjectFormatterConfigurationTest.java
@@ -1,7 +1,7 @@
 package tech.jhipster.lite.project.infrastructure.secondary;
 
-import static org.assertj.core.api.Assertions.*;
-import static org.mockito.Mockito.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 import ch.qos.logback.classic.Level;
 import org.junit.jupiter.api.Test;
@@ -12,6 +12,8 @@ import tech.jhipster.lite.Logs;
 import tech.jhipster.lite.LogsSpy;
 import tech.jhipster.lite.LogsSpyExtension;
 import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.shared.npmdetector.infrastructure.secondary.NpmInstallationReader;
+import tech.jhipster.lite.shared.npmdetector.infrastructure.secondary.NpmInstallationType;
 
 @UnitTest
 @ExtendWith({ MockitoExtension.class, LogsSpyExtension.class })


### PR DESCRIPTION
If a package-lock.json is detected, and npm command is present, run npm install.

Fixes #11106

If we agree on the solution, we should do the same with any module that touches prettier or eslint configuration:
- [x] typescript
- [x] react-core
- [x] angular-core
- [x] svelte