### PR TITLE
chore(deps): allow node 22 that is now the LTS version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -20,7 +20,7 @@
   "packageRules": [
     {
       "matchPackageNames": ["node"],
-      "allowedVersions": "<21.0.0"
+      "allowedVersions": "<23.0.0"
     }
   ]
 }


### PR DESCRIPTION
See #11247 and 
![image](https://github.com/user-attachments/assets/2406e7d9-3ed0-414f-b7e6-f54e3259870e)
