### PR TITLE
Allow using langchain4j module

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/application/LangChain4JApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/application/LangChain4JApplicationService.java
@@ -1,0 +1,20 @@
+package tech.jhipster.lite.generator.server.springboot.langchain4j.application;
+
+import org.springframework.stereotype.Service;
+import tech.jhipster.lite.generator.server.springboot.langchain4j.domain.LangChain4JModuleFactory;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@Service
+public class LangChain4JApplicationService {
+
+  private final LangChain4JModuleFactory factory;
+
+  public LangChain4JApplicationService() {
+    factory = new LangChain4JModuleFactory();
+  }
+
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
+    return factory.buildInitializationModule(properties);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/application/LangChain4JApplicationService.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/application/LangChain4JApplicationService.java
@@ -15,6 +15,6 @@ public class LangChain4JApplicationService {
   }
 
   public JHipsterModule buildModule(JHipsterModuleProperties properties) {
-    return factory.buildInitializationModule(properties);
+    return factory.buildModule(properties);
   }
 }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -3,6 +3,7 @@ package tech.jhipster.lite.generator.server.springboot.langchain4j.domain;
 import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.file.JHipsterSource;
 import tech.jhipster.lite.module.domain.javabuild.GroupId;
 import tech.jhipster.lite.module.domain.javabuild.VersionSlug;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
@@ -10,6 +11,7 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class LangChain4JModuleFactory {
 
+  private static final JHipsterSource SOURCE = from("server/springboot/langchain4j");
   private static final GroupId LANGCHAIN4J_GROUP_ID = groupId("dev.langchain4j");
   private static final VersionSlug LANGCHAIN4J_VERSION_SLUG = versionSlug("langchain4j");
 
@@ -20,6 +22,7 @@ public class LangChain4JModuleFactory {
 
     //@formatter:off
     return moduleBuilder(properties)
+      .documentation(documentationTitle("Dev tools"), SOURCE.template("langchain4j.md"))
       .javaDependencies()
       .addDependency(LANGCHAIN4J_GROUP_ID,
         artifactId("langchain4j-spring-boot-starter"),

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -4,6 +4,7 @@ import static tech.jhipster.lite.module.domain.JHipsterModule.*;
 
 import tech.jhipster.lite.module.domain.JHipsterModule;
 import tech.jhipster.lite.module.domain.file.JHipsterSource;
+import tech.jhipster.lite.module.domain.javabuild.ArtifactId;
 import tech.jhipster.lite.module.domain.javabuild.GroupId;
 import tech.jhipster.lite.module.domain.javabuild.VersionSlug;
 import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
@@ -12,8 +13,10 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 public class LangChain4JModuleFactory {
 
   private static final JHipsterSource SOURCE = from("server/springboot/langchain4j");
-  private static final GroupId LANGCHAIN4J_GROUP_ID = groupId("dev.langchain4j");
-  private static final VersionSlug LANGCHAIN4J_VERSION_SLUG = versionSlug("langchain4j");
+  private static final GroupId GROUP_ID = groupId("dev.langchain4j");
+  private static final ArtifactId ARTIFACT_ID = artifactId("langchain4j-spring-boot-starter");
+  private static final ArtifactId OPEN_AI_ARTIFACT_ID = artifactId("langchain4j-open-ai-spring-boot-starter");
+  private static final VersionSlug VERSION_SLUG = versionSlug("langchain4j");
 
   private static final String PROPERTIES = "properties";
 
@@ -24,21 +27,15 @@ public class LangChain4JModuleFactory {
     return moduleBuilder(properties)
       .documentation(documentationTitle("Dev tools"), SOURCE.template("langchain4j.md"))
       .javaDependencies()
-      .addDependency(LANGCHAIN4J_GROUP_ID,
-        artifactId("langchain4j-spring-boot-starter"),
-        LANGCHAIN4J_VERSION_SLUG)
-      .addDependency(LANGCHAIN4J_GROUP_ID,
-        artifactId("langchain4j-open-ai-spring-boot-starter"),
-        LANGCHAIN4J_VERSION_SLUG)
-      .and()
-      .files()
-      .and()
+        .addDependency(GROUP_ID, ARTIFACT_ID, VERSION_SLUG)
+        .addDependency(GROUP_ID, OPEN_AI_ARTIFACT_ID, VERSION_SLUG)
+        .and()
       .springMainProperties()
-      .set(propertyKey("langchain4j.open-ai.chat-model.api-key"), propertyValue("${OPENAI_API_KEY}"))
-      .set(propertyKey("langchain4j.open-ai.chat-model.model-name"), propertyValue("gpt-4o-mini"))
-      .set(propertyKey("langchain4j.open-ai.chat-model.log-requests"), propertyValue("true"))
-      .set(propertyKey("langchain4j.open-ai.chat-model.log-responses"), propertyValue("true"))
-      .and()
+        .set(propertyKey("langchain4j.open-ai.chat-model.api-key"), propertyValue("${OPENAI_API_KEY}"))
+        .set(propertyKey("langchain4j.open-ai.chat-model.model-name"), propertyValue("gpt-4o-mini"))
+        .set(propertyKey("langchain4j.open-ai.chat-model.log-requests"), propertyValue("true"))
+        .set(propertyKey("langchain4j.open-ai.chat-model.log-responses"), propertyValue("true"))
+        .and()
       .build();
     //@formatter:on
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -27,6 +27,9 @@ public class LangChain4JModuleFactory {
       .addDependency(LANGCHAIN4J_GROUP_ID,
         artifactId("langchain4j-spring-boot-starter"),
         LANGCHAIN4J_VERSION_SLUG)
+      .addDependency(LANGCHAIN4J_GROUP_ID,
+        artifactId("langchain4j-open-ai-spring-boot-starter"),
+        LANGCHAIN4J_VERSION_SLUG)
       .and()
       .files()
       .and()

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -12,6 +12,9 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 
 public class LangChain4JModuleFactory {
 
+  private static final String API_KEY_DEMO_COMMENT =
+    "# You can temporarily use 'demo' key, which is provided " + "for free for demonstration purposes";
+
   private static final JHipsterSource SOURCE = from("server/springboot/langchain4j");
   private static final GroupId GROUP_ID = groupId("dev.langchain4j");
   private static final ArtifactId ARTIFACT_ID = artifactId("langchain4j-spring-boot-starter");
@@ -32,6 +35,7 @@ public class LangChain4JModuleFactory {
         .and()
       .springMainProperties()
         .set(propertyKey("langchain4j.open-ai.chat-model.api-key"), propertyValue("${OPENAI_API_KEY}"))
+          .comment(propertyKey("langchain4j.open-ai.chat-model.api-key"), comment(API_KEY_DEMO_COMMENT))
         .set(propertyKey("langchain4j.open-ai.chat-model.model-name"), propertyValue("gpt-4o-mini"))
         .set(propertyKey("langchain4j.open-ai.chat-model.log-requests"), propertyValue("true"))
         .set(propertyKey("langchain4j.open-ai.chat-model.log-responses"), propertyValue("true"))

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -1,0 +1,39 @@
+package tech.jhipster.lite.generator.server.springboot.langchain4j.domain;
+
+import static tech.jhipster.lite.module.domain.JHipsterModule.*;
+
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.javabuild.GroupId;
+import tech.jhipster.lite.module.domain.javabuild.VersionSlug;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+import tech.jhipster.lite.shared.error.domain.Assert;
+
+public class LangChain4JModuleFactory {
+
+  private static final GroupId LANGCHAIN4J_GROUP_ID = groupId("dev.langchain4j");
+  private static final VersionSlug LANGCHAIN4J_VERSION_SLUG = versionSlug("langchain4j");
+
+  private static final String PROPERTIES = "properties";
+
+  public JHipsterModule buildInitializationModule(JHipsterModuleProperties properties) {
+    Assert.notNull(PROPERTIES, properties);
+
+    //@formatter:off
+    return moduleBuilder(properties)
+      .javaDependencies()
+      .addDependency(LANGCHAIN4J_GROUP_ID,
+        artifactId("langchain4j-spring-boot-starter"),
+        LANGCHAIN4J_VERSION_SLUG)
+      .and()
+      .files()
+      .and()
+      .springMainProperties()
+      .set(propertyKey("langchain4j.open-ai.chat-model.api-key"), propertyValue("${OPENAI_API_KEY}"))
+      .set(propertyKey("langchain4j.open-ai.chat-model.model-name"), propertyValue("gpt-4o-mini"))
+      .set(propertyKey("langchain4j.open-ai.chat-model.log-requests"), propertyValue("true"))
+      .set(propertyKey("langchain4j.open-ai.chat-model.log-responses"), propertyValue("true"))
+      .and()
+      .build();
+    //@formatter:on
+  }
+}

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -15,7 +15,7 @@ public class LangChain4JModuleFactory {
 
   private static final String PROPERTIES = "properties";
 
-  public JHipsterModule buildInitializationModule(JHipsterModuleProperties properties) {
+  public JHipsterModule buildModule(JHipsterModuleProperties properties) {
     Assert.notNull(PROPERTIES, properties);
 
     //@formatter:off

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -13,7 +13,7 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 public class LangChain4JModuleFactory {
 
   private static final String API_KEY_DEMO_COMMENT =
-    "You can temporarily use 'demo' key, which is provided " + "for free for demonstration purposes";
+    "You can temporarily use 'demo' key, which is provided for free for demonstration purposes";
 
   private static final JHipsterSource SOURCE = from("server/springboot/langchain4j");
   private static final GroupId GROUP_ID = groupId("dev.langchain4j");

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactory.java
@@ -13,7 +13,7 @@ import tech.jhipster.lite.shared.error.domain.Assert;
 public class LangChain4JModuleFactory {
 
   private static final String API_KEY_DEMO_COMMENT =
-    "# You can temporarily use 'demo' key, which is provided " + "for free for demonstration purposes";
+    "You can temporarily use 'demo' key, which is provided " + "for free for demonstration purposes";
 
   private static final JHipsterSource SOURCE = from("server/springboot/langchain4j");
   private static final GroupId GROUP_ID = groupId("dev.langchain4j");

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/infrastructure/primary/LangChain4JModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/infrastructure/primary/LangChain4JModuleConfiguration.java
@@ -1,4 +1,4 @@
-package tech.jhipster.lite.generator.server.springboot.langchain4j.primary;
+package tech.jhipster.lite.generator.server.springboot.langchain4j.infrastructure.primary;
 
 import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.LANGCHAIN4J;
 import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SPRING_BOOT;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/infrastructure/primary/LangChain4JModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/infrastructure/primary/LangChain4JModuleConfiguration.java
@@ -18,7 +18,7 @@ class LangChain4JModuleConfiguration {
     return JHipsterModuleResource.builder()
       .slug(LANGCHAIN4J)
       .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addProjectBaseName().addIndentation().build())
-      .apiDoc("LangChain4J", "Add LangChain4J Spring dependency")
+      .apiDoc("LangChain4J", "Add LangChain4j")
       .organization(JHipsterModuleOrganization.builder().addDependency(SPRING_BOOT).build())
       .tags("server", "spring", "spring-boot", "langchain4j")
       .factory(langChain4J::buildModule);

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/package-info.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/package-info.java
@@ -1,0 +1,2 @@
+@tech.jhipster.lite.BusinessContext
+package tech.jhipster.lite.generator.server.springboot.langchain4j;

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/primary/LangChain4JModuleConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/langchain4j/primary/LangChain4JModuleConfiguration.java
@@ -1,0 +1,26 @@
+package tech.jhipster.lite.generator.server.springboot.langchain4j.primary;
+
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.LANGCHAIN4J;
+import static tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SPRING_BOOT;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import tech.jhipster.lite.generator.server.springboot.langchain4j.application.LangChain4JApplicationService;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleOrganization;
+import tech.jhipster.lite.module.domain.resource.JHipsterModulePropertiesDefinition;
+import tech.jhipster.lite.module.domain.resource.JHipsterModuleResource;
+
+@Configuration
+class LangChain4JModuleConfiguration {
+
+  @Bean
+  JHipsterModuleResource langChain4JModule(LangChain4JApplicationService langChain4J) {
+    return JHipsterModuleResource.builder()
+      .slug(LANGCHAIN4J)
+      .propertiesDefinition(JHipsterModulePropertiesDefinition.builder().addProjectBaseName().addIndentation().build())
+      .apiDoc("LangChain4J", "Add LangChain4J Spring dependency")
+      .organization(JHipsterModuleOrganization.builder().addDependency(SPRING_BOOT).build())
+      .tags("server", "spring", "spring-boot", "langchain4j")
+      .factory(langChain4J::buildModule);
+  }
+}

--- a/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
+++ b/src/main/java/tech/jhipster/lite/shared/slug/domain/JHLiteModuleSlug.java
@@ -156,7 +156,8 @@ public enum JHLiteModuleSlug implements JHipsterModuleSlugFactory {
   VUE_OAUTH2_KEYCLOAK("vue-oauth2-keycloak"),
   VUE_PINIA("vue-pinia"),
   TS_PAGINATION_DOMAIN("ts-pagination-domain"),
-  TS_REST_PAGINATION("ts-rest-pagination");
+  TS_REST_PAGINATION("ts-rest-pagination"),
+  LANGCHAIN4J("langchain4j");
 
   private static final Map<String, JHLiteModuleSlug> moduleSlugMap = Stream.of(values()).collect(
     Collectors.toMap(JHLiteModuleSlug::get, Function.identity())

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -407,6 +407,11 @@
         <artifactId>openapi-backwards-compat-maven-plugin</artifactId>
         <version>${openapi-backwards-compat-maven-plugin.version}</version>
       </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-spring-boot-starter</artifactId>
+        <version>${langchain4j.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -71,6 +71,7 @@
     <asciidoctor-maven-plugin.version>3.0.0</asciidoctor-maven-plugin.version>
     <openapi-maven-plugin.version>0.0.21</openapi-maven-plugin.version>
     <openapi-backwards-compat-maven-plugin.version>1.0.3</openapi-backwards-compat-maven-plugin.version>
+    <langchain4j.version>0.35.0</langchain4j.version>
   </properties>
 
   <dependencyManagement>

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -412,6 +412,11 @@
         <artifactId>langchain4j-spring-boot-starter</artifactId>
         <version>${langchain4j.version}</version>
       </dependency>
+      <dependency>
+        <groupId>dev.langchain4j</groupId>
+        <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId>
+        <version>${langchain4j.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 </project>

--- a/src/main/resources/generator/server/springboot/langchain4j/langchain4j.md.mustache
+++ b/src/main/resources/generator/server/springboot/langchain4j/langchain4j.md.mustache
@@ -1,0 +1,5 @@
+# LangChain4J
+
+How to use it :
+
+[Official documentation](https://docs.langchain4j.dev/tutorials/spring-boot-integration/)

--- a/src/main/resources/generator/server/springboot/langchain4j/langchain4j.md.mustache
+++ b/src/main/resources/generator/server/springboot/langchain4j/langchain4j.md.mustache
@@ -1,5 +1,5 @@
-# LangChain4J
+# LangChain4j
 
-How to use it :
+How to use it:
 
 [Official documentation](https://docs.langchain4j.dev/tutorials/spring-boot-integration/)

--- a/src/test/features/server/springboot/langchain4j.feature
+++ b/src/test/features/server/springboot/langchain4j.feature
@@ -1,6 +1,6 @@
-Feature: LangChain4J module
+Feature: LangChain4j module
 
-  Scenario: Should add Spring Boot LangChain4J Starter
+  Scenario: Should add Spring Boot LangChain4j Starter
     When I apply modules to default project
       | maven-java  |
       | spring-boot |

--- a/src/test/features/server/springboot/langchain4j.feature
+++ b/src/test/features/server/springboot/langchain4j.feature
@@ -1,0 +1,10 @@
+Feature: LangChain4J module
+
+  Scenario: Should add Spring Boot LangChain4J Starter
+    When I apply modules to default project
+      | maven-java  |
+      | spring-boot |
+      | langchain4j |
+    Then I should have entries in "src/main/resources/config/application.yml"
+      | open-ai     |
+      | langchain4j |

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
@@ -1,0 +1,57 @@
+package tech.jhipster.lite.generator.server.springboot.langchain4j.domain;
+
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.pomFile;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.junit.jupiter.MockitoExtension;
+import tech.jhipster.lite.TestFileUtils;
+import tech.jhipster.lite.UnitTest;
+import tech.jhipster.lite.module.domain.JHipsterModule;
+import tech.jhipster.lite.module.domain.JHipsterModulesFixture;
+import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
+
+@UnitTest
+@ExtendWith(MockitoExtension.class)
+public class LangChain4JModuleFactoryTest {
+
+  @InjectMocks
+  private LangChain4JModuleFactory factory;
+
+  @Test
+  void shouldCreateModule() {
+    JHipsterModuleProperties properties = JHipsterModulesFixture.propertiesBuilder(TestFileUtils.tmpDirForTest())
+      .projectBaseName("myApp")
+      .build();
+
+    JHipsterModule module = factory.buildModule(properties);
+
+    assertThatModuleWithFiles(module, pomFile())
+      .hasFile("pom.xml")
+      .containing("<langchain4j.version>")
+      .containing(
+        """
+            <dependency>
+              <groupId>dev.langchain4j</groupId>
+              <artifactId>langchain4j-spring-boot-starter</artifactId>
+              <version>${langchain4j.version}</version>
+            </dependency>
+        """
+      )
+      .and()
+      .hasFile("src/main/resources/config/application.yml")
+      .containing(
+        """
+        langchain4j:
+          open-ai:
+            chat-model:
+              api-key: ${OPENAI_API_KEY}
+              log-requests: 'true'
+              log-responses: 'true'
+              model-name: gpt-4o-mini
+        """
+      );
+  }
+}

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
@@ -40,6 +40,15 @@ class LangChain4JModuleFactoryTest {
             </dependency>
         """
       )
+      .containing(
+        """
+            <dependency>
+              <groupId>dev.langchain4j</groupId>
+              <artifactId>langchain4j-open-ai-spring-boot-starter</artifactId>
+              <version>${langchain4j.version}</version>
+            </dependency>
+        """
+      )
       .and()
       .hasFile("src/main/resources/config/application.yml")
       .containing(

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
@@ -15,7 +15,7 @@ import tech.jhipster.lite.module.domain.properties.JHipsterModuleProperties;
 
 @UnitTest
 @ExtendWith(MockitoExtension.class)
-public class LangChain4JModuleFactoryTest {
+class LangChain4JModuleFactoryTest {
 
   @InjectMocks
   private LangChain4JModuleFactory factory;

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
@@ -56,7 +56,7 @@ class LangChain4JModuleFactoryTest {
         langchain4j:
           open-ai:
             chat-model:
-              # # You can temporarily use 'demo' key, which is provided for free for demonstration purposes
+              # You can temporarily use 'demo' key, which is provided for free for demonstration purposes
               api-key: ${OPENAI_API_KEY}
               log-requests: 'true'
               log-responses: 'true'

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/langchain4j/domain/LangChain4JModuleFactoryTest.java
@@ -56,6 +56,7 @@ class LangChain4JModuleFactoryTest {
         langchain4j:
           open-ai:
             chat-model:
+              # # You can temporarily use 'demo' key, which is provided for free for demonstration purposes
               api-key: ${OPENAI_API_KEY}
               log-requests: 'true'
               log-responses: 'true'


### PR DESCRIPTION
I add langchain4j support by using langchain4j-spring-starter dependency (version: 0.35.0)

It fixes https://github.com/jhipster/jhipster-lite/issues/9298