### PR TITLE
Revert "Sonar: reactivate circular dependencies rules"

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -33,7 +33,7 @@ sonar.test.exclusions=\
 
 sonar.typescript.tsconfigPath=tsconfig.json
 
-sonar.issue.ignore.multicriteria=S1640,S3437,S4502,S4684,S4032,S5778,S1133,S119,UndocumentedApi,S5976,S2068,S117,S2083,S6206,S6564,S4649
+sonar.issue.ignore.multicriteria=S1640,S3437,S4502,S4684,S4032,S5778,S1133,S119,UndocumentedApi,S5976,S2068,S117,S2083,S6206,S6564,S4649,S7027,S7091
 
 # Rule: Replace map by enum map
 sonar.issue.ignore.multicriteria.S1640.resourceKey=src/main/java/**/*
@@ -99,3 +99,11 @@ sonar.issue.ignore.multicriteria.S6564.ruleKey=typescript:S6564
 # Rule: Unexpected missing generic font family for icons font
 sonar.issue.ignore.multicriteria.S4649.resourceKey=src/main/webapp/**/*
 sonar.issue.ignore.multicriteria.S4649.ruleKey=css:S4649
+
+# Rule: Circular dependencies between classes in the same package should be resolved
+sonar.issue.ignore.multicriteria.S7027.resourceKey=src/**/java/**/*
+sonar.issue.ignore.multicriteria.S7027.ruleKey=javaarchitecture:S7027
+
+# Rule: Circular dependencies between classes across packages should be resolved
+sonar.issue.ignore.multicriteria.S7091.resourceKey=src/**/java/**/*
+sonar.issue.ignore.multicriteria.S7091.ruleKey=javaarchitecture:S7091


### PR DESCRIPTION
Reverts jhipster/jhipster-lite#11270

![image](https://github.com/user-attachments/assets/2b783b06-ef05-48c4-a5f8-4575424043b5)
not detected 