### PR TITLE
Fix: Update apache/kafka-native Docker tag to v3.9.0

### DIFF
--- a/src/main/resources/generator/dependencies/Dockerfile
+++ b/src/main/resources/generator/dependencies/Dockerfile
@@ -9,7 +9,7 @@ FROM mysql:9.1.0
 FROM cassandra:5.0.2
 FROM mcr.microsoft.com/mssql/server:2022-latest
 FROM postgres:17.0
-FROM apache/kafka-native:3.8.1
+FROM apache/kafka-native:3.9.0
 FROM tchiotludo/akhq:0.25.1
 FROM apachepulsar/pulsar:4.0.0
 FROM neo4j:5.25.1-community

--- a/src/main/resources/generator/server/springboot/broker/kafka/KafkaTestContainerExtension.java.mustache
+++ b/src/main/resources/generator/server/springboot/broker/kafka/KafkaTestContainerExtension.java.mustache
@@ -15,6 +15,8 @@ public class KafkaTestContainerExtension implements BeforeAllCallback {
   public void beforeAll(final ExtensionContext context) {
     if (!kafkaContainerStarted.get()) {
       kafkaContainer = new KafkaContainer(DockerImageName.parse("{{kafkaDockerImage}}")).withNetwork(null);
+      // Waiting this issue https://github.com/testcontainers/testcontainers-java/issues/9506 to remove this line
+      kafkaContainer.withEnv("KAFKA_LISTENERS", "PLAINTEXT://:9092,BROKER://:9093,CONTROLLER://:9094");
       kafkaContainer.start();
       kafkaContainerStarted.set(true);
       System.setProperty("kafka.bootstrap.servers", kafkaContainer.getBootstrapServers());


### PR DESCRIPTION
Fix #11313

@pascalgrimaud @murdos I opend an issue https://github.com/testcontainers/testcontainers-java/issues/9506 on tescontainers.
I use temporary fix proposed on the ticket.