### PR TITLE
ci: use java 23 version instead of 22 for at least one build

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -264,7 +264,7 @@ jobs:
           - app: mariadbapp
             spring-config-format: properties
           - app: consulapp
-            java-version: 22
+            java-version: 23
           - app: vuejwtapp
             node-version: 'latest'
           - app: fullapp


### PR DESCRIPTION
22 is now obsolete, let's use 23