### PR TITLE
React/ESLint: add @typescript-eslint/consistent-type-imports rule

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactory.java
@@ -146,6 +146,7 @@ public class ReactCoreModulesFactory {
               \t\t\t'@typescript-eslint/no-explicit-any': 'off',
               \t\t\t'@typescript-eslint/no-unsafe-argument': 'off',
               \t\t\t'@typescript-eslint/await-thenable': 'off',
+              \t\t\t'@typescript-eslint/consistent-type-imports': 'error',
               \t\t\t'@typescript-eslint/no-misused-promises': [
               \t\t\t\t'error',
               \t\t\t\t{

--- a/src/test/resources/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactoryTest.shouldBuildModuleWithStyle.eslint.config.js.approved.txt
+++ b/src/test/resources/tech/jhipster/lite/generator/client/react/core/domain/ReactCoreModulesFactoryTest.shouldBuildModuleWithStyle.eslint.config.js.approved.txt
@@ -34,6 +34,7 @@ export default typescript.config(
       '@typescript-eslint/no-explicit-any': 'off',
       '@typescript-eslint/no-unsafe-argument': 'off',
       '@typescript-eslint/await-thenable': 'off',
+      '@typescript-eslint/consistent-type-imports': 'error',
       '@typescript-eslint/no-misused-promises': [
         'error',
         {


### PR DESCRIPTION
Related to #11296 