### PR TITLE
CSS: Properties may be safely replaced with a shorthand

### DIFF
--- a/src/main/style/atom/button/button-main/_button-main.scss
+++ b/src/main/style/atom/button/button-main/_button-main.scss
@@ -52,9 +52,7 @@ $jhlite-button-font-weight: fonts.$jhlite-font-weight-semi-bold;
   }
 
   &.-rounded-top {
-    border-radius: 0;
-    border-top-left-radius: $jhlite-button-radius;
-    border-top-right-radius: $jhlite-button-radius;
+    border-radius: $jhlite-button-radius $jhlite-button-radius 0 0;
   }
 }
 


### PR DESCRIPTION
<img width="466" alt="image" src="https://github.com/user-attachments/assets/00daf27c-934c-42c0-b53c-e4844cd68f46">
