### PR TITLE
fix tikui styles broken by inter.css

### DIFF
--- a/src/main/style/atom/theme-button/_theme-button.scss
+++ b/src/main/style/atom/theme-button/_theme-button.scss
@@ -1,3 +1,5 @@
+@use '../../token/fonts';
+
 .jhlite-theme-button {
   display: flex;
 
@@ -21,6 +23,7 @@
     padding: calc(var(--jhlite-element-size) * 0.1);
     width: var(--jhlite-element-size);
     height: calc(var(--jhlite-element-size) * 0.35);
+    font-family: fonts.$jhlite-global-font-emoji-family;
     font-size: calc(var(--jhlite-element-size) * 0.3);
   }
 

--- a/src/main/style/token/_fonts.scss
+++ b/src/main/style/token/_fonts.scss
@@ -2,6 +2,7 @@
 
 $jhlite-font-weight-semi-bold: 600;
 $jhlite-global-font-primary-family: 'Inter', sans-serif;
+$jhlite-global-font-emoji-family: sans-serif;
 $jhlite-global-font-text-size: 2.5vw;
 $jhlite-global-font-text-desktop-size: 16px;
 $jhlite-global-font-glyph-family: jhlite-icons;


### PR DESCRIPTION
- Fix #11382 

After some research, I found the reason why the `inter` font-family changed the sun (☀️) emoji color to grey only on Chrome and not on Firefox. 

Firefox:
![image](https://github.com/user-attachments/assets/8a745200-abf2-4957-977d-abc0689fed39)


Chrome:
![image](https://github.com/user-attachments/assets/3798270b-93cc-45d3-bccd-b243e202f489)

According to the documentation, the Inter font has a specific behavior with certain emojis due to a specific glyph (U+20E3) that interferes with the rendering of special characters in Chrome[1]. This issue occurs because Chrome has difficulty resolving characters when the Inter font is present, causing some specific emojis not to render correctly[1].

The problem doesn't affect all emojis, only specific characters, as it depends on how Chrome discovers and resolves these special characters when it finds the Inter font in its font stack[1]. When Inter is present, Chrome cannot properly fall back to the system's emoji font in some specific cases[1].

Unfortunately, I can't explain why the moon emoji (🌙) didn't turn grey and only the sun emoji (☀️). However, the technical behavior described explains why some emojis are affected while others continue to work normally.

Citations:
[1] https://github.com/tailwindlabs/tailwindcss/issues/2499
[2] https://rsms.me/inter/
[3] https://github.com/rsms/inter/issues/371
[4] https://forum.obsidian.md/t/the-sun-emoji-is-displayed-as-a-monochrome-glyph/47751 

Use the sun and moon [here](https://rsms.me/inter/lab/?antialias=default&sample=%E2%98%80%EF%B8%8F%F0%9F%8C%99):

![image](https://github.com/user-attachments/assets/f6f95076-dd7e-4dc1-8c2f-03218a041234)
