### PR TITLE
ci: use node 22.11.0 rather that latest lts

### DIFF
--- a/.github/workflows/github-actions.yml
+++ b/.github/workflows/github-actions.yml
@@ -260,7 +260,7 @@ jobs:
           - java-build-tool: maven
           - spring-config-format: yaml
           - java-version: 21
-          - node-version: 'lts/*'
+          - node-version: '22.11.0'
           - app: mariadbapp
             spring-config-format: properties
           - app: consulapp


### PR DESCRIPTION
In order to avoid version 22.12.0 that contains some regression. Fixes #11522