### PR TITLE
Fix script test:coverage

### DIFF
--- a/src/main/webapp/app/shared/icon/infrastructure/primary/Icon.html
+++ b/src/main/webapp/app/shared/icon/infrastructure/primary/Icon.html
@@ -1,0 +1,7 @@
+<em
+  class="jhlite-icon"
+  :class="`jhlite-icon-${name}`"
+  :aria-hidden="ariaHidden"
+  :aria-label="!ariaHidden ? ariaLabel : undefined"
+  :title="title"
+></em>

--- a/src/main/webapp/app/shared/icon/infrastructure/primary/Icon.vue
+++ b/src/main/webapp/app/shared/icon/infrastructure/primary/Icon.vue
@@ -1,11 +1,3 @@
-<template>
-  <em
-    class="jhlite-icon"
-    :class="`jhlite-icon-${name}`"
-    :aria-hidden="ariaHidden"
-    :aria-label="!ariaHidden ? ariaLabel : undefined"
-    :title="title"
-  ></em>
-</template>
+<template src="./Icon.html"></template>
 
 <script lang="ts" src="./Icon.component.ts"></script>


### PR DESCRIPTION
Command `npm run test:coverage` doesn't cover `Icon.vue`

Before
<img width="805" alt="image" src="https://github.com/user-attachments/assets/eef5cb07-bb7e-4437-b1fc-cfda70817935" />

After
![image](https://github.com/user-attachments/assets/0ffa4482-fdc8-4876-a7c6-0ff27a800030)

No better solution...