### PR TITLE
Fix: update springdoc-openapi.version to v2.8.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <jacoco.version>0.8.12</jacoco.version>
     <jgit.version>7.1.0.202411261347-r</jgit.version>
     <archunit-junit5.version>1.3.0</archunit-junit5.version>
-    <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+    <springdoc-openapi.version>2.8.0</springdoc-openapi.version>
     <properties-maven-plugin.version>1.2.1</properties-maven-plugin.version>
     <sonar-maven-plugin.version>5.0.0.4389</sonar-maven-plugin.version>
     <apache-commons-io.version>2.18.0</apache-commons-io.version>

--- a/src/main/java/tech/jhipster/lite/module/infrastructure/primary/OpenApiModulesConfiguration.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/primary/OpenApiModulesConfiguration.java
@@ -35,6 +35,7 @@ class OpenApiModulesConfiguration {
 
   private static final String STRING_TYPE = "string";
   private static final String OBJECT_TYPE = "object";
+  private static final String DESCRIPTION = "Definitions for properties in this module";
   private static final String MODULE_PROPERTY_DEFINITION_SCHEMA_NAME = "JHipsterModulePropertiesDefinition";
   private static final String MODULE_PROPERTIES_DEFINITION_SCHEMA_NAME = "JHipsterModulePropertyDefinition";
 
@@ -61,11 +62,8 @@ class OpenApiModulesConfiguration {
   @SuppressWarnings("unchecked")
   private Schema<?> propertiesDefinitionSchema() {
     return new Schema<>()
-      .addProperty(
-        "definitions",
-        new Schema<>().type("array").description("Definitions for properties in this module").items(MODULE_PROPERTIES_DEFINITION_SCHEMA)
-      )
-      .description("Definitions for properties in this module")
+      .addProperty("definitions", new Schema<>().type("array").description(DESCRIPTION).items(MODULE_PROPERTIES_DEFINITION_SCHEMA))
+      .description(DESCRIPTION)
       .type(OBJECT_TYPE);
   }
 
@@ -97,6 +95,7 @@ class OpenApiModulesConfiguration {
       Schema<?> schema = new Schema<>()
         .name(schemaName(module.slug()))
         .type(OBJECT_TYPE)
+        .description(DESCRIPTION)
         .addProperty("projectFolder", new Schema<>().type(STRING_TYPE).description("Path to the project"))
         .addProperty(
           "commit",

--- a/src/main/resources/generator/dependencies/pom.xml
+++ b/src/main/resources/generator/dependencies/pom.xml
@@ -19,7 +19,7 @@
     <spring-boot.version>3.4.1</spring-boot.version>
     <spring-cloud.version>2024.0.0</spring-cloud.version>
     <spring-cloud-netflix-eureka-client.version>4.2.0</spring-cloud-netflix-eureka-client.version>
-    <springdoc-openapi.version>2.7.0</springdoc-openapi.version>
+    <springdoc-openapi.version>2.8.0</springdoc-openapi.version>
     <kafka-clients.version>3.9.0</kafka-clients.version>
     <mongock.version>5.5.0</mongock.version>
     <neo4j-migrations.version>2.15.1</neo4j-migrations.version>

--- a/src/test/java/tech/jhipster/lite/wire/springdoc/infrastructure/primary/SpringDocSteps.java
+++ b/src/test/java/tech/jhipster/lite/wire/springdoc/infrastructure/primary/SpringDocSteps.java
@@ -19,6 +19,9 @@ public class SpringDocSteps {
 
   @Then("I should have schema for {string}")
   public void shouldHaveSchema(String schema) {
-    assertThatLastResponse().hasOkStatus().hasElement("$.components.schemas." + schema + ".type").withValue("object");
+    assertThatLastResponse()
+      .hasOkStatus()
+      .hasElement("$.components.schemas." + schema + ".description")
+      .withValue("Definitions for properties in this module");
   }
 }


### PR DESCRIPTION
Fix #11681 

`type` property does not appear in the JSON `http://localhost:7471/v3/api-docs/all`

I still can't find out why, maybe with this update `Upgrade swagger-core to 2.2.27`

https://github.com/springdoc/springdoc-openapi/releases/tag/v2.8.0