### PR TITLE
build(generator): correctly handle mvn verify -DskipTests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,6 +529,7 @@
             </goals>
             <phase>test</phase>
             <configuration>
+              <skip>${skipTests}</skip>
               <arguments>run test:unit:coverage</arguments>
               <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
             </configuration>
@@ -540,6 +541,7 @@
             </goals>
             <phase>verify</phase>
             <configuration>
+              <skip>${skipTests}</skip>
               <arguments>run test:component:headless</arguments>
               <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
             </configuration>
@@ -551,6 +553,7 @@
             </goals>
             <phase>verify</phase>
             <configuration>
+              <skip>${skipTests}</skip>
               <arguments>run test:coverage:check</arguments>
               <npmInheritsProxyConfigFromMaven>false</npmInheritsProxyConfigFromMaven>
             </configuration>


### PR DESCRIPTION
Previously skipTests was only fulfilled by frontend-maven-plugin for the test phase, but not tasks ran on verify phase, which caused issues with fronted coverage calculation