### PR TITLE
Sonar 25: Drop the support of sonar.password property for the analysis

### DIFF
--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,8 +1,7 @@
 sonar.projectKey=jhlite
 sonar.projectName=JHipster Lite
 # used for local sonarqube Docker image
-sonar.login=admin
-sonar.password=admin
+sonar.token=COMPLETE_WITH_YOUR_TOKEN
 
 sonar.sources=src/main/
 sonar.tests=src/test/

--- a/src/main/docker/sonar.yml
+++ b/src/main/docker/sonar.yml
@@ -1,7 +1,7 @@
 # This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 services:
   sonar:
-    image: sonarqube:10.7.0-community
+    image: sonarqube:25.2.0.102705-community
     container_name: sonar
     # Authentication is turned off for out of the box experience while trying out SonarQube
     # For real use cases delete sonar.forceAuthentication variable or set sonar.forceAuthentication=true


### PR DESCRIPTION
@pascalgrimaud @murdos Sonar 25 drops the support of sonar.password property for the analysis

https://community.sonarsource.com/t/sonarqube-community-build-25-2-0-102705-released/134495

https://docs.sonarsource.com/sonarqube-community-build/server-upgrade-and-maintenance/release-notes-and-notices/release-notes/

https://sonarsource.atlassian.net/issues/?jql=fixVersion%20%3D%2016130%20AND%20issuetype%20%21%3D%20Task%20ORDER%20BY%20status%20DESC%2C%20created%20ASC%20

We need a token like that
<img width="1379" alt="image" src="https://github.com/user-attachments/assets/d35238a8-c20a-4e93-8a58-0a9988628eb6" />

