### PR TITLE
display filter rank options in frontend

### DIFF
--- a/src/main/style/atom/button/_button.scss
+++ b/src/main/style/atom/button/_button.scss
@@ -1,2 +1,3 @@
 @use 'button-main/button-main';
 @use 'button-switch/button-switch';
+@use 'button-toggle/button-toggle';

--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -10,18 +10,26 @@ $jhlite-button-toggle-hover-color-background: rgba(button-main.$jhlite-button-co
 $jhlite-button-toggle-disabled-color-background: button-main.$jhlite-button-disabled-color-background;
 $jhlite-button-toggle-active-color-background: button-main.$jhlite-button-color-background;
 $jhlite-button-toggle-active-hover-color-background: button-main.$jhlite-button-hover-color-background;
+$jhlite-button-toggle-transition-duration: 0.5s;
 
+// Now define the main component
 .jhlite-button-toggle {
   @extend %jhlite-button-main;
 
+  display: inline-flex;
+  position: relative;
+  align-items: center;
+  transition: background-color $jhlite-button-toggle-transition-duration ease;
   border: $jhlite-button-toggle-border;
   background-color: transparent;
   padding: $jhlite-button-toggle-padding;
+  overflow: hidden;
   text-transform: none;
   color: var(--jhlite-global-color-text);
   font-size: $jhlite-button-toggle-font-size;
 
-  &:hover {
+  &:hover,
+  &.-hovered {
     background-color: $jhlite-button-toggle-hover-color-background;
   }
 
@@ -38,5 +46,41 @@ $jhlite-button-toggle-active-hover-color-background: button-main.$jhlite-button-
     &:hover {
       background-color: $jhlite-button-toggle-active-hover-color-background;
     }
+  }
+}
+
+.jhlite-button-toggle-content {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+}
+
+.jhlite-button-toggle-short-name {
+  display: inline-block;
+  opacity: 1;
+  white-space: nowrap;
+}
+
+.jhlite-button-toggle-full-name {
+  display: inline-block;
+  transition: all $jhlite-button-toggle-transition-duration 1ms ease-out;
+  opacity: 0;
+  max-width: 0;
+  overflow: hidden;
+  white-space: nowrap;
+}
+
+.jhlite-button-toggle:hover,
+.jhlite-button-toggle.-active,
+.jhlite-button-toggle.-hovered {
+  .jhlite-button-toggle-short-name {
+    opacity: 0;
+  }
+
+  .jhlite-button-toggle-full-name {
+    transition: max-width 2 * $jhlite-button-toggle-transition-duration 50ms ease-in;
+    opacity: 1;
+    max-width: 300px;
   }
 }

--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -1,0 +1,44 @@
+@use 'sass:math';
+@use '../../../token/colors' as colors;
+@use '../../../token/color/brand' as brand;
+@use '../button-main/button-main' as button-main;
+
+$jhlite-button-toggle-padding: math.div(5, 16) * 1rem math.div(15, 16) * 1rem;
+$jhlite-button-toggle-border: 1px solid brand.$jhlite-color-brand-600;
+$jhlite-button-toggle-font-size: math.div(13, 16) * 1rem;
+$jhlite-button-toggle-hover-color-background: rgba(brand.$jhlite-color-brand-600, 0.1);
+$jhlite-button-toggle-disabled-color-background: rgba(brand.$jhlite-color-brand-600, 0.5);
+$jhlite-button-toggle-active-color-background: brand.$jhlite-color-brand-600;
+$jhlite-button-toggle-active-hover-color-background: brand.$jhlite-color-brand-700;
+
+.jhlite-button-toggle {
+  @extend %jhlite-button-main;
+
+  border: $jhlite-button-toggle-border;
+  background-color: transparent;
+  padding: $jhlite-button-toggle-padding;
+  text-transform: none;
+  color: var(--jhlite-global-color-text);
+  font-size: $jhlite-button-toggle-font-size;
+
+  &:hover {
+    background-color: $jhlite-button-toggle-hover-color-background;
+  }
+
+  &:disabled {
+    border-color: $jhlite-button-toggle-disabled-color-background;
+
+    &:hover {
+      background-color: $jhlite-button-toggle-disabled-color-background;
+    }
+  }
+
+  &.-active {
+    background-color: $jhlite-button-toggle-active-color-background;
+    color: colors.$jhlite-global-color-text-light;
+
+    &:hover {
+      background-color: $jhlite-button-toggle-active-hover-color-background;
+    }
+  }
+}

--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -6,10 +6,10 @@
 $jhlite-button-toggle-padding: math.div(5, 16) * 1rem math.div(15, 16) * 1rem;
 $jhlite-button-toggle-border: 1px solid brand.$jhlite-color-brand-600;
 $jhlite-button-toggle-font-size: math.div(13, 16) * 1rem;
-$jhlite-button-toggle-hover-color-background: rgba(brand.$jhlite-color-brand-600, 0.1);
-$jhlite-button-toggle-disabled-color-background: rgba(brand.$jhlite-color-brand-600, 0.5);
-$jhlite-button-toggle-active-color-background: brand.$jhlite-color-brand-600;
-$jhlite-button-toggle-active-hover-color-background: brand.$jhlite-color-brand-700;
+$jhlite-button-toggle-hover-color-background: rgba(button-main.$jhlite-button-color-background, 0.1);
+$jhlite-button-toggle-disabled-color-background: button-main.$jhlite-button-disabled-color-background;
+$jhlite-button-toggle-active-color-background: button-main.$jhlite-button-color-background;
+$jhlite-button-toggle-active-hover-color-background: button-main.$jhlite-button-hover-color-background;
 
 .jhlite-button-toggle {
   @extend %jhlite-button-main;
@@ -26,8 +26,6 @@ $jhlite-button-toggle-active-hover-color-background: brand.$jhlite-color-brand-7
   }
 
   &:disabled {
-    border-color: $jhlite-button-toggle-disabled-color-background;
-
     &:hover {
       background-color: $jhlite-button-toggle-disabled-color-background;
     }

--- a/src/main/style/atom/button/button-toggle/button-toggle.code.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.code.pug
@@ -3,3 +3,6 @@ include button-toggle.mixin.pug
 +jhlite-button-toggle Toggle
 +jhlite-button-toggle({active: true}) Toggle active
 +jhlite-button-toggle({disabled: true}) Toggle disabled
++jhlite-button-toggle({shortName: 'JS', fullName: 'JavaScript'})
++jhlite-button-toggle({shortName: 'TS', fullName: 'TypeScript', active: true})
++jhlite-button-toggle({shortName: 'CSS', fullName: 'Cascading Style Sheets', disabled: true})

--- a/src/main/style/atom/button/button-toggle/button-toggle.code.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.code.pug
@@ -1,0 +1,5 @@
+include button-toggle.mixin.pug
+
++jhlite-button-toggle Toggle
++jhlite-button-toggle({active: true}) Toggle active
++jhlite-button-toggle({disabled: true}) Toggle disabled

--- a/src/main/style/atom/button/button-toggle/button-toggle.md
+++ b/src/main/style/atom/button/button-toggle/button-toggle.md
@@ -1,1 +1,9 @@
 ### Button toggle
+
+Button toggle can display a short name by default and expand to show a full name on hover or when active.
+
+Use the `shortName` and `fullName` properties to enable this feature:
+
+```pug
++jhlite-button-toggle({shortName: 'JS', fullName: 'JavaScript'})
+```

--- a/src/main/style/atom/button/button-toggle/button-toggle.md
+++ b/src/main/style/atom/button/button-toggle/button-toggle.md
@@ -1,0 +1,1 @@
+### Button toggle

--- a/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
@@ -1,5 +1,10 @@
 mixin jhlite-button-toggle(opts)
-  - const { active, disabled } = opts || {};
+  - const { active, disabled, shortName, fullName } = opts || {};
   - const activeClass = active ? '-active' : null;
   button.jhlite-button-toggle(class=activeClass, disabled=disabled)
-    block
+    if shortName && fullName
+      span.jhlite-button-toggle-content
+        span.jhlite-button-toggle-short-name= shortName
+        span.jhlite-button-toggle-full-name= fullName
+    else
+      block

--- a/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
@@ -1,0 +1,5 @@
+mixin jhlite-button-toggle(opts)
+  - const { active, disabled } = opts || {};
+  - const activeClass = active ? '-active' : null;
+  button.jhlite-button-toggle(class=activeClass, disabled=disabled)
+    block

--- a/src/main/style/atom/button/button-toggle/button-toggle.render.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.render.pug
@@ -1,0 +1,4 @@
+extends /layout
+
+block body
+  include button-toggle.code.pug

--- a/src/main/style/atom/button/button.pug
+++ b/src/main/style/atom/button/button.pug
@@ -5,3 +5,5 @@
     include:componentDoc(height=150) button-main/button-main.md
   .tikui-vertical-spacing--line
     include:componentDoc(height=150) button-switch/button-switch.md
+  .tikui-vertical-spacing--line
+    include:componentDoc(height=150) button-toggle/button-toggle.md

--- a/src/main/style/organism/_organism.scss
+++ b/src/main/style/organism/_organism.scss
@@ -9,3 +9,4 @@
 @use 'landscape-loader/landscape-loader';
 @use 'landscape-minimap/landscape-minimap';
 @use 'landscape-preset-configuration/landscape-preset-configuration';
+@use 'landscape-rank-module-filter/landscape-rank-module-filter';

--- a/src/main/style/organism/landscape-rank-module-filter/_landscape-rank-module-filter.scss
+++ b/src/main/style/organism/landscape-rank-module-filter/_landscape-rank-module-filter.scss
@@ -1,0 +1,9 @@
+@use '../../token/size';
+
+.jhlite-landscape-rank-module-filter {
+  &--ranks {
+    display: flex;
+    gap: size.$jhlite-global-size-field-padding;
+    align-items: center;
+  }
+}

--- a/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.code.pug
+++ b/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.code.pug
@@ -1,0 +1,3 @@
+include landscape-rank-module-filter.mixin.pug
+
++jhlite-landscape-rank-module-filter

--- a/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.md
+++ b/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.md
@@ -1,0 +1,1 @@
+## Landscape rank module filter

--- a/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.mixin.pug
+++ b/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.mixin.pug
@@ -1,0 +1,10 @@
+include /atom/button/button-toggle/button-toggle.mixin.pug
+
+mixin jhlite-landscape-rank-module-filter
+  .jhlite-landscape-rank-module-filter
+    .jhlite-landscape-rank-module-filter--ranks
+      +jhlite-button-toggle D
+      +jhlite-button-toggle({ disabled: true }) C
+      +jhlite-button-toggle({ disabled: true }) B
+      +jhlite-button-toggle({ disabled: true }) A
+      +jhlite-button-toggle({ active: true }) S

--- a/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.render.pug
+++ b/src/main/style/organism/landscape-rank-module-filter/landscape-rank-module-filter.render.pug
@@ -1,0 +1,4 @@
+extends /layout
+
+block body
+  include landscape-rank-module-filter.code.pug

--- a/src/main/style/organism/landscape/_landscape.scss
+++ b/src/main/style/organism/landscape/_landscape.scss
@@ -194,6 +194,11 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
     border-radius: size.$jhlite-global-size-field-radius;
     box-shadow: 0 0 0 size.$jhlite-global-size-field-border-focus colors.$jhlite-attention-highlight-color;
   }
+
+  .-diff-rank-minimal-emphasis {
+    opacity: 0.5;
+    border: 1px dotted $jhlite-landscape-line-color;
+  }
 }
 
 .jhipster-landscape {

--- a/src/main/style/organism/landscape/_landscape.scss
+++ b/src/main/style/organism/landscape/_landscape.scss
@@ -3,7 +3,10 @@
 @use '../../token/size';
 
 $jhlite-landscape-padding: 20px;
+$jhipster-landscape-modes-selection-top-position: $jhlite-landscape-padding;
 $jhipster-landscape-preset-selection-top-position: 85px;
+$jhipster-landscape-modes-selection-top-position-large-screen: 85px;
+$jhipster-landscape-preset-selection-top-position-large-screen: 150px;
 $jhipster-landscape-preset-selection-left-position: $jhlite-landscape-padding;
 $jhlite-landscape-line-color: colors.$jhlite-global-line-color;
 $jhlite-landscape-box-radius: colors.$jhlite-global-box-radius;
@@ -23,7 +26,7 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
 
   .jhipster-landscape-modes-selection {
     position: absolute;
-    top: $jhlite-landscape-padding;
+    top: $jhipster-landscape-modes-selection-top-position;
     left: $jhlite-landscape-padding;
     z-index: 3;
     border: 1px dotted $jhlite-landscape-line-color;
@@ -37,6 +40,13 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
     top: $jhipster-landscape-preset-selection-top-position;
     left: $jhipster-landscape-preset-selection-left-position;
     z-index: 3;
+    background: var(--jhlite-chip-bg-color);
+  }
+
+  .jhipster-landscape-rank-module-selection {
+    display: flex;
+    justify-content: center;
+    margin-left: $jhlite-landscape-padding;
     background: var(--jhlite-chip-bg-color);
   }
 
@@ -192,6 +202,14 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
 
 @media screen and (min-width: breakpoint.$jhlite-global-breakpoint-small-medium) {
   .jhipster-landscape {
+    .jhipster-landscape-modes-selection {
+      top: $jhipster-landscape-modes-selection-top-position-large-screen;
+    }
+
+    .jhipster-landscape-preset-selection {
+      top: $jhipster-landscape-preset-selection-top-position-large-screen;
+    }
+
     .jhipster-landscape-content {
       display: flex;
       flex-direction: column;

--- a/src/main/style/organism/organism.pug
+++ b/src/main/style/organism/organism.pug
@@ -23,6 +23,8 @@ block content
     .tikui-vertical-spacing--line
       include:componentDoc(height=160) landscape-preset-configuration/landscape-preset-configuration.md
     .tikui-vertical-spacing--line
+      include:componentDoc(height=160) landscape-rank-module-filter/landscape-rank-module-filter.md
+    .tikui-vertical-spacing--line
       include:componentDoc(height=230) module-parameters/module-parameters.md
     .tikui-vertical-spacing--line
       include:componentDoc(height=870) modules-patch/modules-patch.md

--- a/src/main/webapp/app/module/domain/ModuleRankCount.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankCount.ts
@@ -1,0 +1,8 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+
+type ModuleRankCountQuantity = number;
+
+export type ModuleRankCount = {
+  rank: ModuleRank;
+  quantity: ModuleRankCountQuantity;
+};

--- a/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
@@ -1,10 +1,10 @@
-import { RankUsed } from '@/module/domain/RankUsed';
+import { ModuleRankCount } from '@/module/domain/ModuleRankCount';
 import { Landscape } from '@/module/domain/landscape/Landscape';
 import { ModuleRank, RANKS } from '@/module/domain/landscape/ModuleRank';
 
-export type RanksUsed = RankUsed[];
+export type ModuleRankStatistics = ModuleRankCount[];
 
-export const toRanksUsed = (landscape: Landscape): RanksUsed => {
+export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatistics => {
   const rankCounts = new Map<ModuleRank, number>(RANKS.map(rank => [rank, 0]));
 
   landscape

--- a/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
@@ -5,17 +5,18 @@ import { ModuleRank, RANKS } from '@/module/domain/landscape/ModuleRank';
 export type ModuleRankStatistics = ModuleRankCount[];
 
 export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatistics => {
-  const rankCounts = new Map<ModuleRank, number>(RANKS.map(rank => [rank, 0]));
-
-  landscape
+  const rankCounts = landscape
     .standaloneLevels()
     .flatMap(level => level.elements)
     .flatMap(element => element.allModules())
-    .reduce((counts, module) => {
-      const currentCount = counts.get(module.rank()) || 0;
-      counts.set(module.rank(), currentCount + 1);
-      return counts;
-    }, rankCounts);
+    .reduce(
+      (counts, module) => {
+        const currentCount = counts.get(module.rank()) || 0;
+        counts.set(module.rank(), currentCount + 1);
+        return counts;
+      },
+      new Map<ModuleRank, number>(RANKS.map(rank => [rank, 0])),
+    );
 
   return RANKS.map(rank => ({
     rank,

--- a/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
@@ -11,7 +11,7 @@ export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatisti
     .flatMap(element => element.allModules())
     .reduce(
       (counts, module) => {
-        const currentCount = counts.get(module.rank()) || 0;
+        const currentCount = counts.get(module.rank())!;
         counts.set(module.rank(), currentCount + 1);
         return counts;
       },
@@ -20,6 +20,6 @@ export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatisti
 
   return RANKS.map(rank => ({
     rank,
-    quantity: rankCounts.get(rank) ?? 0,
+    quantity: rankCounts.get(rank)!,
   }));
 };

--- a/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
@@ -20,6 +20,6 @@ export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatisti
 
   return RANKS.map(rank => ({
     rank,
-    quantity: rankCounts.get(rank) || 0,
+    quantity: rankCounts.get(rank) ?? 0,
   }));
 };

--- a/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
+++ b/src/main/webapp/app/module/domain/ModuleRankStatistics.ts
@@ -11,10 +11,11 @@ export const toModuleRankStatistics = (landscape: Landscape): ModuleRankStatisti
     .standaloneLevels()
     .flatMap(level => level.elements)
     .flatMap(element => element.allModules())
-    .forEach(module => {
-      const currentCount = rankCounts.get(module.rank()) || 0;
-      rankCounts.set(module.rank(), currentCount + 1);
-    });
+    .reduce((counts, module) => {
+      const currentCount = counts.get(module.rank()) || 0;
+      counts.set(module.rank(), currentCount + 1);
+      return counts;
+    }, rankCounts);
 
   return RANKS.map(rank => ({
     rank,

--- a/src/main/webapp/app/module/domain/RankDescription.ts
+++ b/src/main/webapp/app/module/domain/RankDescription.ts
@@ -1,0 +1,3 @@
+export type RankDescription = {
+  [key: string]: string;
+};

--- a/src/main/webapp/app/module/domain/RankUsed.ts
+++ b/src/main/webapp/app/module/domain/RankUsed.ts
@@ -1,0 +1,8 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+
+type RankUsedQuantity = number;
+
+export type RankUsed = {
+  rank: ModuleRank;
+  quantity: RankUsedQuantity;
+};

--- a/src/main/webapp/app/module/domain/RankUsed.ts
+++ b/src/main/webapp/app/module/domain/RankUsed.ts
@@ -1,8 +1,0 @@
-import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
-
-type RankUsedQuantity = number;
-
-export type RankUsed = {
-  rank: ModuleRank;
-  quantity: RankUsedQuantity;
-};

--- a/src/main/webapp/app/module/domain/RanksUsed.ts
+++ b/src/main/webapp/app/module/domain/RanksUsed.ts
@@ -1,0 +1,23 @@
+import { RankUsed } from '@/module/domain/RankUsed';
+import { Landscape } from '@/module/domain/landscape/Landscape';
+import { ModuleRank, RANKS } from '@/module/domain/landscape/ModuleRank';
+
+export type RanksUsed = RankUsed[];
+
+export const toRanksUsed = (landscape: Landscape): RanksUsed => {
+  const rankCounts = new Map<ModuleRank, number>(RANKS.map(rank => [rank, 0]));
+
+  landscape
+    .standaloneLevels()
+    .flatMap(level => level.elements)
+    .flatMap(element => element.allModules())
+    .forEach(module => {
+      const currentCount = rankCounts.get(module.rank()) || 0;
+      rankCounts.set(module.rank(), currentCount + 1);
+    });
+
+  return RANKS.map(rank => ({
+    rank,
+    quantity: rankCounts.get(rank) || 0,
+  }));
+};

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -477,16 +477,15 @@ export class Landscape {
   }
 
   private updateModulesVisibility(rank: ModuleRank): (modules: LandscapeModule[]) => LandscapeModule[] {
-    return modules => modules.map(module => module.withVisibility(this.moduleMatchingRank(module, rank)));
+    return modules => modules.map(module => module.withAllVisibility(this.moduleMatchingRank(module, rank)) as LandscapeModule);
   }
 
   private hasVisibleModules(modules: LandscapeModule[]): boolean {
     return modules.some(module => module.isVisible());
   }
 
-  private setModuleVisibility(element: LandscapeModule, rank: ModuleRank): LandscapeElement {
-    const module = element.asModule();
-    return module.withVisibility(this.moduleMatchingRank(module, rank));
+  private setModuleVisibility(module: LandscapeModule, rank: ModuleRank): LandscapeElement {
+    return module.withAllVisibility(this.moduleMatchingRank(module, rank));
   }
 
   private dependencyFeatureOfRankedModule(featureSlug: LandscapeFeatureSlug, rank: ModuleRank): boolean {

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -413,10 +413,8 @@ export class Landscape {
       .orElse(false);
   }
 
-  public filterByRank(rank: ModuleRank | undefined): Landscape {
-    return Optional.ofNullable(rank)
-      .map(currentRank => this.createFilteredLandscape(currentRank))
-      .orElse(this);
+  public filterByRank(rank: Optional<ModuleRank>): Landscape {
+    return rank.map(currentRank => this.createFilteredLandscape(currentRank)).orElse(this);
   }
 
   private createFilteredLandscape(rank: ModuleRank): Landscape {

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -407,6 +407,12 @@ export class Landscape {
     return this.properties;
   }
 
+  public hasModuleDifferentRank(module: ModuleSlug, rank: ModuleRank): boolean {
+    return Optional.ofNullable(this.modules.get(module.get()))
+      .map(currentModule => currentModule.rank() !== rank)
+      .orElse(false);
+  }
+
   public filterByRank(rank: ModuleRank | undefined): Landscape {
     return Optional.ofNullable(rank)
       .map(currentRank => this.createFilteredLandscape(currentRank))

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -1,3 +1,5 @@
+import { LandscapeElement } from '@/module/domain/landscape/LandscapeElement';
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { Memoizer } from '@/shared/memoizer/domain/Memoizer';
 import { Optional } from '@/shared/optional/domain/Optional';
 import { ModulePropertyDefinition } from '../ModulePropertyDefinition';
@@ -403,6 +405,62 @@ export class Landscape {
 
   selectedModulesProperties(): ModulePropertyDefinition[] {
     return this.properties;
+  }
+
+  public filterByRank(rank: ModuleRank | undefined): Landscape {
+    return Optional.ofNullable(rank)
+      .map(currentRank => this.createFilteredLandscape(currentRank))
+      .orElse(this);
+  }
+
+  private createFilteredLandscape(rank: ModuleRank): Landscape {
+    const filteredLevels = this.projections.levels.map(level => this.filterLevel(level, rank)).filter(level => level.elements.length > 0);
+
+    return new Landscape(this.state, new LevelsProjections(filteredLevels));
+  }
+
+  private filterLevel(level: LandscapeLevel, rank: ModuleRank): { elements: LandscapeElement[] } {
+    return {
+      elements: level.elements.map(element => this.filterElementByRank(element, rank)).flatMap(optional => optional.toArray()),
+    };
+  }
+
+  private filterElementByRank(element: LandscapeElement, rank: ModuleRank): Optional<LandscapeElement> {
+    return element instanceof LandscapeFeature ? this.filterFeature(element, rank) : this.filterModule(element, rank);
+  }
+
+  private filterFeature(feature: LandscapeFeature, rank: ModuleRank): Optional<LandscapeElement> {
+    if (this.dependencyFeatureOfRankedModule(feature.slug(), rank)) {
+      return Optional.of(feature);
+    }
+
+    return Optional.of(feature.modules)
+      .filter(modules => modules.some(module => this.moduleMatchingRank(module, rank)))
+      .map(modules => modules.filter(module => this.moduleMatchingRank(module, rank)))
+      .map(filteredModules => new LandscapeFeature(feature.slug(), filteredModules));
+  }
+
+  private dependencyFeatureOfRankedModule(featureSlug: LandscapeFeatureSlug, rank: ModuleRank): boolean {
+    return Array.from(this.modules.values())
+      .filter(module => module.rank() === rank)
+      .some(rankedModule => rankedModule.dependencies().some(dep => dep.get() === featureSlug.get()));
+  }
+
+  private moduleMatchingRank(module: LandscapeModule, rank: ModuleRank): boolean {
+    return module.rank() === rank || this.dependencyOfRankedModule(module, rank);
+  }
+
+  private dependencyOfRankedModule(module: LandscapeModule, rank: ModuleRank): boolean {
+    return Optional.of(Array.from(this.modules.values()))
+      .map(modules => modules.filter(m => m.rank() === rank))
+      .map(rankedModules => rankedModules.some(rankedModule => rankedModule.dependencies().some(dep => dep.get() === module.slug().get())))
+      .orElse(false);
+  }
+
+  private filterModule(element: LandscapeElement, rank: ModuleRank): Optional<LandscapeElement> {
+    return Optional.of(element.allModules()[0])
+      .filter(module => this.moduleMatchingRank(module, rank))
+      .map(() => element);
   }
 }
 

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -408,7 +408,7 @@ export class Landscape {
   }
 
   public hasModuleDifferentRank(module: ModuleSlug, rank: ModuleRank): boolean {
-    return Optional.ofNullable(this.modules.get(module.get()))
+    return this.getModule(module)
       .map(currentModule => currentModule.rank() !== rank)
       .orElse(false);
   }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeElement.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeElement.ts
@@ -5,4 +5,5 @@ export interface LandscapeElement {
   slug(): LandscapeElementId;
   slugString(): string;
   allModules(): LandscapeModule[];
+  isVisible(): boolean;
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeElement.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeElement.ts
@@ -6,4 +6,5 @@ export interface LandscapeElement {
   slugString(): string;
   allModules(): LandscapeModule[];
   isVisible(): boolean;
+  withAllVisibility(visible: boolean): LandscapeElement;
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
@@ -28,4 +28,9 @@ export class LandscapeFeature implements LandscapeElement {
   isVisible(): boolean {
     return this.visible;
   }
+
+  withAllVisibility(visible: boolean): LandscapeElement {
+    const restoredModules = this.allModules().map(module => module.withVisibility(visible));
+    return new LandscapeFeature(this.slug(), restoredModules, visible);
+  }
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
@@ -30,7 +30,7 @@ export class LandscapeFeature implements LandscapeElement {
   }
 
   withAllVisibility(visible: boolean): LandscapeElement {
-    const restoredModules = this.allModules().map(module => module.withVisibility(visible));
+    const restoredModules = this.allModules().map(module => module.withAllVisibility(visible) as LandscapeModule);
     return new LandscapeFeature(this.slug(), restoredModules, visible);
   }
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeFeature.ts
@@ -3,10 +3,15 @@ import { LandscapeFeatureSlug } from './LandscapeFeatureSlug';
 import { LandscapeModule } from './LandscapeModule';
 
 export class LandscapeFeature implements LandscapeElement {
+  private readonly visible: boolean;
+
   constructor(
     private readonly featureSlug: LandscapeFeatureSlug,
     readonly modules: LandscapeModule[],
-  ) {}
+    visible: boolean = true,
+  ) {
+    this.visible = visible;
+  }
 
   slugString(): string {
     return this.slug().get();
@@ -18,5 +23,9 @@ export class LandscapeFeature implements LandscapeElement {
 
   allModules(): LandscapeModule[] {
     return this.modules;
+  }
+
+  isVisible(): boolean {
+    return this.visible;
   }
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -20,6 +20,7 @@ export interface LandscapeModuleContext {
   applied: boolean;
   selectionTree: LandscapeSelectionTree;
   unselectionTree: LandscapeUnselectionTree;
+  visible: boolean;
 }
 
 const INITIAL_CONTEXT: LandscapeModuleContext = {
@@ -27,6 +28,7 @@ const INITIAL_CONTEXT: LandscapeModuleContext = {
   applied: false,
   selectionTree: LandscapeSelectionTree.EMPTY,
   unselectionTree: LandscapeUnselectionTree.EMPTY,
+  visible: true,
 };
 
 export class LandscapeModule implements LandscapeElement {
@@ -85,5 +87,12 @@ export class LandscapeModule implements LandscapeElement {
 
   unselectionTree(): LandscapeUnselectionTree {
     return this.context.unselectionTree;
+  }
+  isVisible(): boolean {
+    return this.context.visible;
+  }
+
+  withVisibility(visible: boolean): LandscapeModule {
+    return new LandscapeModule(this.information, { ...this.context, visible });
   }
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -69,10 +69,6 @@ export class LandscapeModule implements LandscapeElement {
     return [this];
   }
 
-  asModule(): this {
-    return this;
-  }
-
   inContext(context: LandscapeModuleContext): LandscapeModule {
     return new LandscapeModule(this.information, context);
   }
@@ -98,10 +94,6 @@ export class LandscapeModule implements LandscapeElement {
   }
 
   withAllVisibility(visible: boolean): LandscapeElement {
-    return this.withVisibility(visible);
-  }
-
-  withVisibility(visible: boolean): LandscapeModule {
     return new LandscapeModule(this.information, { ...this.context, visible });
   }
 }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -1,3 +1,4 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { ModulePropertyDefinition } from '../ModulePropertyDefinition';
 import { ModuleSlug } from '../ModuleSlug';
 import { LandscapeElement } from './LandscapeElement';
@@ -11,6 +12,7 @@ export interface LandscapeModuleInformation {
   operation: ModuleOperation;
   properties: ModulePropertyDefinition[];
   dependencies: LandscapeElementId[];
+  rank: ModuleRank;
 }
 
 export interface LandscapeModuleContext {

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -51,6 +51,10 @@ export class LandscapeModule implements LandscapeElement {
     return this.information.dependencies;
   }
 
+  rank(): ModuleRank {
+    return this.information.rank;
+  }
+
   operation(): string {
     return this.information.operation;
   }

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -69,6 +69,10 @@ export class LandscapeModule implements LandscapeElement {
     return [this];
   }
 
+  asModule(): LandscapeModule {
+    return this;
+  }
+
   inContext(context: LandscapeModuleContext): LandscapeModule {
     return new LandscapeModule(this.information, context);
   }
@@ -88,8 +92,13 @@ export class LandscapeModule implements LandscapeElement {
   unselectionTree(): LandscapeUnselectionTree {
     return this.context.unselectionTree;
   }
+
   isVisible(): boolean {
     return this.context.visible;
+  }
+
+  withAllVisibility(visible: boolean): LandscapeElement {
+    return this.withVisibility(visible);
   }
 
   withVisibility(visible: boolean): LandscapeModule {

--- a/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
+++ b/src/main/webapp/app/module/domain/landscape/LandscapeModule.ts
@@ -69,7 +69,7 @@ export class LandscapeModule implements LandscapeElement {
     return [this];
   }
 
-  asModule(): LandscapeModule {
+  asModule(): this {
     return this;
   }
 

--- a/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
+++ b/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
@@ -1,6 +1,2 @@
 export const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'] as const;
 export type ModuleRank = (typeof RANKS)[number];
-
-export interface RankDescription {
-  [key: string]: string;
-}

--- a/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
+++ b/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
@@ -1,0 +1,1 @@
+export type ModuleRank = 'RANK_D' | 'RANK_C' | 'RANK_B' | 'RANK_A' | 'RANK_S';

--- a/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
+++ b/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
@@ -1,2 +1,6 @@
 export const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'] as const;
 export type ModuleRank = (typeof RANKS)[number];
+
+export interface RankDescription {
+  [key: string]: string;
+}

--- a/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
+++ b/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
@@ -1,1 +1,2 @@
-export type ModuleRank = 'RANK_D' | 'RANK_C' | 'RANK_B' | 'RANK_A' | 'RANK_S';
+export const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'] as const;
+export type ModuleRank = (typeof RANKS)[number];

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -25,9 +25,7 @@ export default defineComponent({
       RANK_S: 'Production-proven module providing unique features, validated by community feedback (10+ endorsements)',
     };
 
-    const isRankSelected = (rank: ModuleRank): boolean => {
-      return selectedRank.value === rank;
-    };
+    const isRankSelected = (rank: ModuleRank): boolean => selectedRank.value === rank;
 
     const toggleRank = (rank: ModuleRank): void => {
       if (selectedRank.value === rank) {
@@ -38,17 +36,11 @@ export default defineComponent({
       emit('selected', selectedRank.value);
     };
 
-    const formatRank = (rank: ModuleRank): string => {
-      return rank.replace('RANK_', '');
-    };
+    const formatRank = (rank: ModuleRank): string => rank.replace('RANK_', '');
 
-    const getRankDescription = (rank: ModuleRank): string => {
-      return rankDescriptions[rank];
-    };
+    const getRankDescription = (rank: ModuleRank): string => rankDescriptions[rank];
 
-    const isRankDisabled = (rank: ModuleRank): boolean => {
-      return props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
-    };
+    const isRankDisabled = (rank: ModuleRank): boolean => props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
 
     return {
       ranks,

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,0 +1,35 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  name: 'LandscapeRankModuleFilterVue',
+  emits: ['selected'],
+  setup(_, { emit }) {
+    const ranks: ModuleRank[] = ['RANK_S', 'RANK_A', 'RANK_B', 'RANK_C', 'RANK_D'];
+    const selectedRank = ref<ModuleRank | undefined>(undefined);
+
+    const isRankSelected = (rank: ModuleRank): boolean => {
+      return selectedRank.value === rank;
+    };
+
+    const toggleRank = (rank: ModuleRank): void => {
+      if (selectedRank.value === rank) {
+        selectedRank.value = undefined;
+      } else {
+        selectedRank.value = rank;
+      }
+      emit('selected', selectedRank.value);
+    };
+
+    const formatRank = (rank: ModuleRank): string => {
+      return rank.replace('RANK_', '');
+    };
+
+    return {
+      ranks,
+      isRankSelected,
+      toggleRank,
+      formatRank,
+    };
+  },
+});

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -2,7 +2,7 @@ import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
-import { defineComponent, PropType, ref } from 'vue';
+import { PropType, defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -2,7 +2,7 @@ import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
-import { PropType, defineComponent, ref } from 'vue';
+import { PropType, defineComponent, onMounted, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
@@ -16,6 +16,7 @@ export default defineComponent({
   setup(props, { emit }) {
     const ranks = RANKS;
     const selectedRank = ref<ModuleRank | undefined>(undefined);
+    const hoverRankS = ref<boolean>(false);
 
     const rankDescriptions: RankDescription = {
       RANK_D: 'Experimental or advanced module requiring specific expertise',
@@ -23,6 +24,22 @@ export default defineComponent({
       RANK_B: 'Module with at least one confirmed production usage',
       RANK_A: 'Module with multiple production usages across different projects and documented through talks, books or blog posts',
       RANK_S: 'Production-proven module providing unique features, validated by community feedback (10+ endorsements)',
+    };
+
+    onMounted(() => {
+      animateRankSHover();
+    });
+
+    const animateRankSHover = (): void => {
+      const delayBeforeHover = 1000;
+      const hoverDuration = 1000;
+
+      setTimeout(() => {
+        hoverRankS.value = true;
+        setTimeout(() => {
+          hoverRankS.value = false;
+        }, hoverDuration);
+      }, delayBeforeHover);
     };
 
     const isRankSelected = (rank: ModuleRank): boolean => selectedRank.value === rank;
@@ -36,19 +53,25 @@ export default defineComponent({
       emit('selected', selectedRank.value);
     };
 
-    const formatRank = (rank: ModuleRank): string => rank.replace('RANK_', 'RANK ');
+    const formatRankShortName = (rank: ModuleRank): string => rank.replace('RANK_', '');
+
+    const formatRankFullName = (rank: ModuleRank): string => rank.replace('RANK_', 'RANK ');
 
     const getRankDescription = (rank: ModuleRank): string => rankDescriptions[rank];
 
     const isRankDisabled = (rank: ModuleRank): boolean => props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
 
+    const isRankHovered = (rank: ModuleRank): boolean => rank === 'RANK_S' && hoverRankS.value;
+
     return {
       ranks,
       isRankSelected,
       toggleRank,
-      formatRank,
+      formatRankShortName,
+      formatRankFullName,
       getRankDescription,
       isRankDisabled,
+      isRankHovered,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,11 +1,11 @@
-import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+import { ModuleRank, RANKS } from '@/module/domain/landscape/ModuleRank';
 import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
   emits: ['selected'],
   setup(_, { emit }) {
-    const ranks: ModuleRank[] = ['RANK_S', 'RANK_A', 'RANK_B', 'RANK_C', 'RANK_D'];
+    const ranks = RANKS;
     const selectedRank = ref<ModuleRank | undefined>(undefined);
 
     const isRankSelected = (rank: ModuleRank): boolean => {

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,14 +1,14 @@
 import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
+import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
-import type { RanksUsed } from '@/module/domain/RanksUsed';
 import { defineComponent, PropType, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
   props: {
-    ranksUsed: {
-      type: Array as PropType<RanksUsed>,
+    moduleRankStatistics: {
+      type: Array as PropType<ModuleRankStatistics>,
       required: true,
     },
   },
@@ -47,8 +47,8 @@ export default defineComponent({
     };
 
     const isRankDisabled = (rank: ModuleRank): boolean => {
-      const rankUsed = props.ranksUsed.find(ru => ru.rank === rank);
-      return rankUsed?.quantity === 0;
+      const moduleRankStatistics = props.moduleRankStatistics.find(ru => ru.rank === rank);
+      return moduleRankStatistics?.quantity === 0;
     };
 
     return {

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,4 +1,4 @@
-import { ModuleRank, RANKS } from '@/module/domain/landscape/ModuleRank';
+import { ModuleRank, RankDescription, RANKS } from '@/module/domain/landscape/ModuleRank';
 import { defineComponent, ref } from 'vue';
 
 export default defineComponent({
@@ -7,6 +7,14 @@ export default defineComponent({
   setup(_, { emit }) {
     const ranks = RANKS;
     const selectedRank = ref<ModuleRank | undefined>(undefined);
+
+    const rankDescriptions: RankDescription = {
+      RANK_D: 'Experimental or advanced module requiring specific expertise',
+      RANK_C: 'Module without known production usage',
+      RANK_B: 'Module with at least one confirmed production usage',
+      RANK_A: 'Module with multiple production usages across different projects and documented through talks, books or blog posts',
+      RANK_S: 'Production-proven module providing unique features, validated by community feedback (10+ endorsements)',
+    };
 
     const isRankSelected = (rank: ModuleRank): boolean => {
       return selectedRank.value === rank;
@@ -25,11 +33,16 @@ export default defineComponent({
       return rank.replace('RANK_', '');
     };
 
+    const getRankDescription = (rank: ModuleRank): string => {
+      return rankDescriptions[rank];
+    };
+
     return {
       ranks,
       isRankSelected,
       toggleRank,
       formatRank,
+      getRankDescription,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -36,7 +36,7 @@ export default defineComponent({
       emit('selected', selectedRank.value);
     };
 
-    const formatRank = (rank: ModuleRank): string => rank.replace('RANK_', '');
+    const formatRank = (rank: ModuleRank): string => rank.replace('RANK_', 'RANK ');
 
     const getRankDescription = (rank: ModuleRank): string => rankDescriptions[rank];
 

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -47,8 +47,7 @@ export default defineComponent({
     };
 
     const isRankDisabled = (rank: ModuleRank): boolean => {
-      const moduleRankStatistics = props.moduleRankStatistics.find(ru => ru.rank === rank);
-      return moduleRankStatistics?.quantity === 0;
+      return props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
     };
 
     return {

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,12 +1,19 @@
 import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import type { RankDescription } from '@/module/domain/RankDescription';
-import { defineComponent, ref } from 'vue';
+import type { RanksUsed } from '@/module/domain/RanksUsed';
+import { defineComponent, PropType, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
+  props: {
+    ranksUsed: {
+      type: Array as PropType<RanksUsed>,
+      required: true,
+    },
+  },
   emits: ['selected'],
-  setup(_, { emit }) {
+  setup(props, { emit }) {
     const ranks = RANKS;
     const selectedRank = ref<ModuleRank | undefined>(undefined);
 
@@ -39,12 +46,18 @@ export default defineComponent({
       return rankDescriptions[rank];
     };
 
+    const isRankDisabled = (rank: ModuleRank): boolean => {
+      const rankUsed = props.ranksUsed.find(ru => ru.rank === rank);
+      return rankUsed?.quantity === 0;
+    };
+
     return {
       ranks,
       isRankSelected,
       toggleRank,
       formatRank,
       getRankDescription,
+      isRankDisabled,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,4 +1,6 @@
-import { ModuleRank, RankDescription, RANKS } from '@/module/domain/landscape/ModuleRank';
+import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+import { RANKS } from '@/module/domain/landscape/ModuleRank';
+import type { RankDescription } from '@/module/domain/RankDescription';
 import { defineComponent, ref } from 'vue';
 
 export default defineComponent({

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -3,8 +3,8 @@
     <button
       v-for="rank in ranks"
       :key="rank"
-      class="jhlite-button-switch"
-      :class="{ '-selected': isRankSelected(rank) }"
+      class="jhlite-button-toggle"
+      :class="{ '-active': isRankSelected(rank) }"
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"
     >

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -8,6 +8,7 @@
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"
       :title="getRankDescription(rank)"
+      :disabled="isRankDisabled(rank)"
     >
       {{ formatRank(rank) }}
     </button>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -4,13 +4,19 @@
       v-for="rank in ranks"
       :key="rank"
       class="jhlite-button-toggle"
-      :class="{ '-active': isRankSelected(rank) }"
+      :class="{
+         '-active': isRankSelected(rank),
+         '-hovered': isRankHovered(rank)
+       }"
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"
       :title="getRankDescription(rank)"
       :disabled="isRankDisabled(rank)"
     >
-      {{ formatRank(rank) }}
+      <span class="jhlite-button-toggle-content">
+        <span class="jhlite-button-toggle-short-name" :data-testid="`short-name-${rank}`">{{ formatRankShortName(rank) }}</span>
+        <span class="jhlite-button-toggle-full-name" :data-testid="`full-name-${rank}`">{{ formatRankFullName(rank) }}</span>
+      </span>
     </button>
   </div>
 </div>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -1,9 +1,9 @@
 <div class="landscape-rank-module-filter">
-  <div class="landscape-rank-module-filter--ranks">
+  <div class="jhlite-landscape-rank-module-filter--ranks">
     <button
       v-for="rank in ranks"
       :key="rank"
-      class="landscape-rank-module-filter--rank"
+      class="jhlite-button-switch"
       :class="{ '-selected': isRankSelected(rank) }"
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -1,0 +1,14 @@
+<div class="landscape-rank-module-filter">
+  <div class="landscape-rank-module-filter--ranks">
+    <button
+      v-for="rank in ranks"
+      :key="rank"
+      class="landscape-rank-module-filter--rank"
+      :class="{ '-selected': isRankSelected(rank) }"
+      @click="toggleRank(rank)"
+      :data-testid="`rank-${rank}-filter`"
+    >
+      {{ formatRank(rank) }}
+    </button>
+  </div>
+</div>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -7,6 +7,7 @@
       :class="{ '-active': isRankSelected(rank) }"
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"
+      :title="getRankDescription(rank)"
     >
       {{ formatRank(rank) }}
     </button>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.vue
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.vue
@@ -1,0 +1,3 @@
+<template src="./LandscapeRankModuleFilter.html"></template>
+
+<script lang="ts" src="./LandscapeRankModuleFilter.component.ts"></script>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/index.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/index.ts
@@ -1,0 +1,3 @@
+import LandscapeRankModuleFilterVue from './LandscapeRankModuleFilter.vue';
+
+export { LandscapeRankModuleFilterVue };

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -8,11 +8,11 @@ import {
 import { AnchorPointState } from '@/module/domain/AnchorPointState';
 import { ModuleParameter } from '@/module/domain/ModuleParameter';
 import { ModulePropertyDefinition } from '@/module/domain/ModulePropertyDefinition';
+import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
+import { toModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import { ModuleSlug } from '@/module/domain/ModuleSlug';
 import { Preset } from '@/module/domain/Preset';
 import { ProjectHistory } from '@/module/domain/ProjectHistory';
-import type { RanksUsed } from '@/module/domain/RanksUsed';
-import { toRanksUsed } from '@/module/domain/RanksUsed';
 import { Landscape } from '@/module/domain/landscape/Landscape';
 import { LandscapeElement } from '@/module/domain/landscape/LandscapeElement';
 import { LandscapeElementId } from '@/module/domain/landscape/LandscapeElementId';
@@ -97,7 +97,7 @@ export default defineComponent({
     const highlightedModule = ref<Optional<ModuleSlug>>(Optional.empty());
 
     const selectedRank = ref<Optional<ModuleRank>>(Optional.empty());
-    const ranksUsed = ref<RanksUsed>([]);
+    const moduleRankStatistics = ref<ModuleRankStatistics>([]);
 
     onMounted(() => {
       modules
@@ -191,7 +191,7 @@ export default defineComponent({
     };
 
     const loadLandscapeRankModuleFilterProperty = (): void => {
-      ranksUsed.value = toRanksUsed(landscapeValue());
+      moduleRankStatistics.value = toModuleRankStatistics(landscapeValue());
     };
 
     type Navigation = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown' | 'Space';
@@ -707,7 +707,7 @@ export default defineComponent({
       selectedPresetName,
       performSearch,
       handleRankFilter,
-      ranksUsed,
+      moduleRankStatistics,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -654,14 +654,20 @@ export default defineComponent({
     };
 
     const reloadLandscape = async (response: Landscape): Promise<void> => {
-      landscapeElements.value = new Map<string, HTMLElement>();
       landscape.value.loaded(response);
       levels.value.loaded(response.standaloneLevels());
 
-      await nextTick();
-      updateConnectors();
+      await rebuildLandscapeElements();
+
+      await nextTick().then(updateConnectors);
       landscapeNavigation.value.loaded(new LandscapeNavigation(landscapeElements.value, levels.value.value()));
       loadAnchorPointModulesMap();
+    };
+
+    const rebuildLandscapeElements = async (): Promise<void> => {
+      // Wait for DOM update before clearing and rebuilding refs
+      await nextTick();
+      landscapeElements.value = new Map<string, HTMLElement>();
     };
 
     return {

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -652,7 +652,7 @@ export default defineComponent({
       clearPresetSelection();
 
       selectedRank.value = Optional.ofNullable(rank);
-      reloadLandscape(originalLandscape.value.value().filterByRank(selectedRank.value)).then(() => {});
+      void reloadLandscape(originalLandscape.value.value().filterByRank(selectedRank.value));
     };
 
     const reloadLandscape = async (response: Landscape): Promise<void> => {

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -642,30 +642,17 @@ export default defineComponent({
 
     const handleRankFilter = (rank: ModuleRank | undefined): void => {
       selectedRank.value = Optional.ofNullable(rank);
-      resetToOriginalLandscape().then(() => loadRankFilteredLandscape(landscapeValue().filterByRank(selectedRank.value)));
+      reloadLandscape(originalLandscape.value.value().filterByRank(selectedRank.value)).then(() => {});
     };
 
-    const resetToOriginalLandscape = (): Promise<void> => {
-      return loadOriginalLandscape(originalLandscape.value.value());
-    };
-
-    const loadOriginalLandscape = async (response: Landscape): Promise<void> => {
-      landscape.value.loaded(response);
-      levels.value.loaded(response.standaloneLevels());
-    };
-
-    const loadRankFilteredLandscape = async (response: Landscape): Promise<void> => {
+    const reloadLandscape = async (response: Landscape): Promise<void> => {
       landscapeElements.value = new Map<string, HTMLElement>();
-
       landscape.value.loaded(response);
       levels.value.loaded(response.standaloneLevels());
 
       await nextTick();
-
       updateConnectors();
-
       landscapeNavigation.value.loaded(new LandscapeNavigation(landscapeElements.value, levels.value.value()));
-
       loadAnchorPointModulesMap();
     };
 

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -11,6 +11,8 @@ import { ModulePropertyDefinition } from '@/module/domain/ModulePropertyDefiniti
 import { ModuleSlug } from '@/module/domain/ModuleSlug';
 import { Preset } from '@/module/domain/Preset';
 import { ProjectHistory } from '@/module/domain/ProjectHistory';
+import type { RanksUsed } from '@/module/domain/RanksUsed';
+import { toRanksUsed } from '@/module/domain/RanksUsed';
 import { Landscape } from '@/module/domain/landscape/Landscape';
 import { LandscapeElement } from '@/module/domain/landscape/LandscapeElement';
 import { LandscapeElementId } from '@/module/domain/landscape/LandscapeElementId';
@@ -95,6 +97,7 @@ export default defineComponent({
     const highlightedModule = ref<Optional<ModuleSlug>>(Optional.empty());
 
     const selectedRank = ref<Optional<ModuleRank>>(Optional.empty());
+    const ranksUsed = ref<RanksUsed>([]);
 
     onMounted(() => {
       modules
@@ -160,6 +163,7 @@ export default defineComponent({
 
       canLoadMiniMap.value = true;
       loadAnchorPointModulesMap();
+      loadLandscapeRankModuleFilterProperty();
     };
 
     const loadAnchorPointModulesMap = (): void => {
@@ -184,6 +188,10 @@ export default defineComponent({
           anchorPointModulesMap.value.set(endingElementSlug, { atStart: endingElementSlugExists.atStart, atEnd: true });
         }
       });
+    };
+
+    const loadLandscapeRankModuleFilterProperty = (): void => {
+      ranksUsed.value = toRanksUsed(landscapeValue());
     };
 
     type Navigation = 'ArrowLeft' | 'ArrowRight' | 'ArrowUp' | 'ArrowDown' | 'Space';
@@ -699,6 +707,7 @@ export default defineComponent({
       selectedPresetName,
       performSearch,
       handleRankFilter,
+      ranksUsed,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -414,7 +414,7 @@ export default defineComponent({
       }
 
       return selectedRank.value
-        .map(rank => landscapeValue().hasModuleDifferentRank(module as ModuleSlug, rank))
+        .map(rank => landscapeValue().hasModuleDifferentRank(module, rank))
         .map(hasDifferentRank => (hasDifferentRank ? ' -diff-rank-minimal-emphasis' : ''))
         .orElse('');
     };

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -649,6 +649,8 @@ export default defineComponent({
     };
 
     const handleRankFilter = (rank: ModuleRank | undefined): void => {
+      clearPresetSelection();
+
       selectedRank.value = Optional.ofNullable(rank);
       reloadLandscape(originalLandscape.value.value().filterByRank(selectedRank.value)).then(() => {});
     };

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -19,6 +19,7 @@ import { LandscapeFeatureSlug } from '@/module/domain/landscape/LandscapeFeature
 import { LandscapeLevel } from '@/module/domain/landscape/LandscapeLevel';
 import { LandscapeModule } from '@/module/domain/landscape/LandscapeModule';
 import { LandscapeSelectionElement } from '@/module/domain/landscape/LandscapeSelectionElement';
+import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
 import { ALERT_BUS } from '@/shared/alert/application/AlertProvider';
 import { IconVue } from '@/shared/icon/infrastructure/primary';
 import { Loader } from '@/shared/loader/infrastructure/primary/Loader';
@@ -46,6 +47,7 @@ export default defineComponent({
     LandscapeLoaderVue,
     LandscapeMiniMapVue,
     LandscapePresetConfigurationVue,
+    LandscapeRankModuleFilterVue,
   },
   setup() {
     const applicationListener = inject(APPLICATION_LISTENER);

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -63,7 +63,6 @@ export default defineComponent({
     const selectedMode = ref<DisplayMode>('COMPACTED');
 
     const landscape = ref(Loader.loading<Landscape>());
-    const originalLandscape = ref(Loader.loading<Landscape>());
     const levels = ref(Loader.loading<LandscapeLevel[]>());
 
     const canLoadMiniMap = ref(false);
@@ -151,8 +150,6 @@ export default defineComponent({
     };
 
     const loadLandscape = async (response: Landscape): Promise<void> => {
-      originalLandscape.value.loaded(response);
-
       landscape.value.loaded(response);
       levels.value.loaded(response.standaloneLevels());
 
@@ -652,7 +649,7 @@ export default defineComponent({
       clearPresetSelection();
 
       selectedRank.value = Optional.ofNullable(rank);
-      void reloadLandscape(originalLandscape.value.value().filterByRank(selectedRank.value));
+      void reloadLandscape(landscapeValue().filterByRank(selectedRank.value));
     };
 
     const reloadLandscape = async (response: Landscape): Promise<void> => {

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -29,7 +29,7 @@
     <div class="jhipster-landscape-content">
       <div class="jhipster-landscape-content--header">
         <div class="jhipster-landscape-rank-module-selection">
-          <LandscapeRankModuleFilterVue :ranksUsed="ranksUsed" @selected="handleRankFilter" />
+          <LandscapeRankModuleFilterVue :moduleRankStatistics="moduleRankStatistics" @selected="handleRankFilter" />
         </div>
         <div class="jhipster-landscape-search-container">
           <div class="jhipster-landscape-search">

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -22,6 +22,9 @@
       </div>
     </div>
   </div>
+  <div class="jhipster-landscape-rank-module-selection">
+    <LandscapeRankModuleFilterVue />
+  </div>
   <div class="jhipster-landscape-preset-selection">
     <LandscapePresetConfigurationVue :selectedPresetName="selectedPresetName" @selected="selectModulesFromPreset" />
   </div>

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -22,15 +22,15 @@
       </div>
     </div>
   </div>
-  <div class="jhipster-landscape-rank-module-selection">
-    <LandscapeRankModuleFilterVue @selected="handleRankFilter" />
-  </div>
   <div class="jhipster-landscape-preset-selection">
     <LandscapePresetConfigurationVue :selectedPresetName="selectedPresetName" @selected="selectModulesFromPreset" />
   </div>
   <div class="jhlite-menu-content-template--content">
     <div class="jhipster-landscape-content">
       <div class="jhipster-landscape-content--header">
+        <div class="jhipster-landscape-rank-module-selection">
+          <LandscapeRankModuleFilterVue @selected="handleRankFilter" />
+        </div>
         <div class="jhipster-landscape-search-container">
           <div class="jhipster-landscape-search">
             <div class="jhlite-field--field">

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -29,7 +29,7 @@
     <div class="jhipster-landscape-content">
       <div class="jhipster-landscape-content--header">
         <div class="jhipster-landscape-rank-module-selection">
-          <LandscapeRankModuleFilterVue @selected="handleRankFilter" />
+          <LandscapeRankModuleFilterVue :ranksUsed="ranksUsed" @selected="handleRankFilter" />
         </div>
         <div class="jhipster-landscape-search-container">
           <div class="jhipster-landscape-search">

--- a/src/main/webapp/app/module/primary/landscape/Landscape.html
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.html
@@ -23,7 +23,7 @@
     </div>
   </div>
   <div class="jhipster-landscape-rank-module-selection">
-    <LandscapeRankModuleFilterVue />
+    <LandscapeRankModuleFilterVue @selected="handleRankFilter" />
   </div>
   <div class="jhipster-landscape-preset-selection">
     <LandscapePresetConfigurationVue :selectedPresetName="selectedPresetName" @selected="selectModulesFromPreset" />

--- a/src/main/webapp/app/module/secondary/RestLandscapeModule.ts
+++ b/src/main/webapp/app/module/secondary/RestLandscapeModule.ts
@@ -26,6 +26,7 @@ export const toLandscapeModule = (module: RestLandscapeModule): LandscapeModule 
     operation: module.operation,
     properties: toPropertiesDefinitions(module.properties),
     dependencies: toModuleDependencies(module.dependencies),
+    rank: module.rank,
   });
 
 const toModuleDependencies = (dependencies: RestLandscapeDependency[] | undefined): LandscapeElementId[] => {

--- a/src/main/webapp/app/module/secondary/RestLandscapeModule.ts
+++ b/src/main/webapp/app/module/secondary/RestLandscapeModule.ts
@@ -1,3 +1,4 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { LandscapeElementId } from '../domain/landscape/LandscapeElementId';
 import { LandscapeElementType } from '../domain/landscape/LandscapeElementType';
 import { LandscapeFeatureSlug } from '../domain/landscape/LandscapeFeatureSlug';
@@ -11,6 +12,7 @@ export interface RestLandscapeModule {
   operation: string;
   properties: RestModulePropertiesDefinitions;
   dependencies?: RestLandscapeDependency[];
+  rank: ModuleRank;
 }
 
 export interface RestLandscapeDependency {

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -47,7 +47,7 @@ export const defaultLandscape = (): Landscape =>
     },
     {
       elements: [
-        initialModule('java-base', 'Add base java classes', [], featureSlugs('java-build-tools')),
+        initialModule('java-base', 'Add base java classes', [], featureSlugs('java-build-tools'), 'RANK_S'),
         initialModule('spring-boot', 'Add spring boot core', [], featureSlugs('java-build-tools')),
         new LandscapeFeature(featureSlug('ci'), [
           initialModule('gitlab-maven', 'Add simple gitlab ci for maven', [], moduleSlugs('maven'), 'RANK_S'),

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -19,8 +19,8 @@ export const defaultLandscape = (): Landscape =>
   Landscape.initialState([
     {
       elements: [
-        initialModule('infinitest', 'Add infinitest filters', [applicationBaseNamePropertyDefinition()], []),
-        initialModule('init', 'Add some initial tools', [applicationBaseNamePropertyDefinition()], []),
+        initialModule('infinitest', 'Add infinitest filters', [applicationBaseNamePropertyDefinition()], [], 'RANK_S'),
+        initialModule('init', 'Add some initial tools', [applicationBaseNamePropertyDefinition()], [], 'RANK_S'),
         initialModule(
           'init-props',
           'Add some initial tools with extra properties',

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -3,6 +3,7 @@ import { LandscapeElementId } from '@/module/domain/landscape/LandscapeElementId
 import { LandscapeFeature } from '@/module/domain/landscape/LandscapeFeature';
 import { LandscapeFeatureSlug } from '@/module/domain/landscape/LandscapeFeatureSlug';
 import { LandscapeModule } from '@/module/domain/landscape/LandscapeModule';
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { ModulePropertyDefinition } from '@/module/domain/ModulePropertyDefinition';
 import { ModuleSlug } from '@/module/domain/ModuleSlug';
 import {
@@ -84,12 +85,14 @@ const initialModule = (
   operation: string,
   properties: ModulePropertyDefinition[],
   dependencies: LandscapeElementId[],
+  rank: ModuleRank = 'RANK_D',
 ): LandscapeModule =>
   LandscapeModule.initialState({
     slug: moduleSlug(slug),
     operation,
     properties,
     dependencies,
+    rank,
   });
 
 const featureSlugs = (...slugs: string[]): LandscapeFeatureSlug[] => slugs.map(featureSlug);

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -69,7 +69,7 @@ export const defaultLandscape = (): Landscape =>
     {
       elements: [
         initialModule('sample-feature', 'Add sample feature', [], [featureSlug('spring-mvc'), moduleSlug('bean-validation-test')]),
-        initialModule('liquibase', 'Add liquibase', [], featureSlugs('jpa')),
+        initialModule('liquibase', 'Add liquibase', [], featureSlugs('jpa'), 'RANK_A'),
       ],
     },
   ]);

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -57,7 +57,7 @@ export const defaultLandscape = (): Landscape =>
     },
     {
       elements: [
-        new LandscapeFeature(featureSlug('jpa'), [initialModule('postgresql', 'Add PostGreSQL', [], moduleSlugs('spring-boot'))]),
+        new LandscapeFeature(featureSlug('jpa'), [initialModule('postgresql', 'Add PostGreSQL', [], moduleSlugs('spring-boot'), 'RANK_C')]),
         new LandscapeFeature(featureSlug('spring-mvc'), [
           initialModule('spring-boot-tomcat', 'Add Tomcat', [], moduleSlugs('spring-boot')),
           initialModule('spring-boot-undertow', 'Add Undertow', [], moduleSlugs('spring-boot')),

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -38,7 +38,7 @@ export const defaultLandscape = (): Landscape =>
     {
       elements: [
         new LandscapeFeature(featureSlug('client'), [
-          initialModule('vue', 'Add vue', [], moduleSlugs('init')),
+          initialModule('vue', 'Add vue', [], moduleSlugs('init'), 'RANK_S'),
           initialModule('react', 'Add react', [], moduleSlugs('init')),
           initialModule('angular', 'Add angular', [], moduleSlugs('init')),
         ]),
@@ -50,8 +50,8 @@ export const defaultLandscape = (): Landscape =>
         initialModule('java-base', 'Add base java classes', [], featureSlugs('java-build-tools')),
         initialModule('spring-boot', 'Add spring boot core', [], featureSlugs('java-build-tools')),
         new LandscapeFeature(featureSlug('ci'), [
-          initialModule('gitlab-maven', 'Add simple gitlab ci for maven', [], moduleSlugs('maven')),
-          initialModule('gitlab-gradle', 'Add simple gitlab ci for gradle', [], moduleSlugs('gradle')),
+          initialModule('gitlab-maven', 'Add simple gitlab ci for maven', [], moduleSlugs('maven'), 'RANK_S'),
+          initialModule('gitlab-gradle', 'Add simple gitlab ci for gradle', [], moduleSlugs('gradle'), 'RANK_S'),
         ]),
       ],
     },

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -290,19 +290,19 @@ describe('Landscape', () => {
   });
 
   describe('Has module different rank', () => {
-    it('should return false for unknown module', () => {
+    it('should not detect different ranks when checking an unknown module', () => {
       const landscape = defaultLandscape();
 
       expect(landscape.hasModuleDifferentRank(moduleSlug('unknown'), 'RANK_S')).toBe(false);
     });
 
-    it('should return false when module has same rank', () => {
+    it('should not detect different ranks when module has same rank as checked', () => {
       const landscape = defaultLandscape();
 
       expect(landscape.hasModuleDifferentRank(moduleSlug('init'), 'RANK_S')).toBe(false);
     });
 
-    it('should return true when module has different rank', () => {
+    it('should detect different ranks when module has different rank from checked', () => {
       const landscape = defaultLandscape();
 
       expect(landscape.hasModuleDifferentRank(moduleSlug('react'), 'RANK_S')).toBe(true);

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -1,4 +1,5 @@
 import { LandscapeFeature } from '@/module/domain/landscape/LandscapeFeature';
+import { LandscapeModule } from '@/module/domain/landscape/LandscapeModule';
 import { LandscapeSelectionElement } from '@/module/domain/landscape/LandscapeSelectionElement';
 import { LandscapeSelectionTree } from '@/module/domain/landscape/LandscapeSelectionTree';
 import { Optional } from '@/shared/optional/domain/Optional';
@@ -411,6 +412,54 @@ describe('Landscape', () => {
       expect(ciFeature).toEqual(
         expect.objectContaining({
           featureSlug: featureSlug('ci'),
+        }),
+      );
+    });
+
+    it('should keep nested feature and modules dependencies with different ranks than the rank filter applied', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_C'));
+
+      const levels = filteredLandscape.standaloneLevels();
+      const initModule = levels[0].elements.find(element => element instanceof LandscapeModule && element.slugString() === 'init');
+      expect(initModule).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('init'),
+            rank: 'RANK_S',
+          }),
+        }),
+      );
+      const javaBuildToolFeature = filteredLandscape
+        .standaloneLevels()[1]
+        .elements.find(element => element instanceof LandscapeFeature && element.slugString() === 'java-build-tools');
+      expect(javaBuildToolFeature).toEqual(
+        expect.objectContaining({
+          featureSlug: featureSlug('java-build-tools'),
+        }),
+      );
+      const springBootModule = levels[2].elements.find(
+        element => element instanceof LandscapeModule && element.slugString() === 'spring-boot',
+      );
+      expect(springBootModule).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('spring-boot'),
+            rank: 'RANK_D',
+          }),
+        }),
+      );
+      const postgresqlModule = levels[3].elements
+        .find(element => element instanceof LandscapeFeature)
+        ?.allModules()
+        .find(module => module.slugString() == 'postgresql');
+      expect(postgresqlModule).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('postgresql'),
+            rank: 'RANK_C',
+          }),
         }),
       );
     });

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -1,6 +1,7 @@
 import { LandscapeFeature } from '@/module/domain/landscape/LandscapeFeature';
 import { LandscapeSelectionElement } from '@/module/domain/landscape/LandscapeSelectionElement';
 import { LandscapeSelectionTree } from '@/module/domain/landscape/LandscapeSelectionTree';
+import { Optional } from '@/shared/optional/domain/Optional';
 import { describe, expect, it } from 'vitest';
 import { applicationBaseNamePropertyDefinition, moduleSlug, optionalBooleanPropertyDefinition } from '../Modules.fixture';
 import { defaultLandscape, featureSlug } from './Landscape.fixture';
@@ -312,7 +313,7 @@ describe('Landscape', () => {
     it('should return same landscape when no rank filter is applied', () => {
       const landscape = defaultLandscape();
 
-      const filteredLandscape = landscape.filterByRank(undefined);
+      const filteredLandscape = landscape.filterByRank(Optional.empty());
 
       expect(filteredLandscape).toEqual(landscape);
     });
@@ -320,7 +321,7 @@ describe('Landscape', () => {
     it('should filter modules by rank', () => {
       const landscape = defaultLandscape();
 
-      const filteredLandscape = landscape.filterByRank('RANK_S');
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_S'));
 
       const levels = filteredLandscape.standaloneLevels();
       expect(levels).toHaveLength(3);
@@ -357,7 +358,7 @@ describe('Landscape', () => {
     it('should filter modules in feature keeping only modules with specified rank', () => {
       const landscape = defaultLandscape();
 
-      const filteredLandscape = landscape.filterByRank('RANK_S');
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_S'));
 
       const clientFeature = filteredLandscape
         .standaloneLevels()[1]
@@ -376,7 +377,7 @@ describe('Landscape', () => {
     it('should keep dependency modules with different ranks than the rank filter applied', () => {
       const landscape = defaultLandscape();
 
-      const filteredLandscape = landscape.filterByRank('RANK_D');
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_D'));
 
       const levels = filteredLandscape.standaloneLevels();
       const initModule = levels[0].elements[0].allModules()[0];
@@ -402,7 +403,7 @@ describe('Landscape', () => {
     it('should keep features with different ranks modules than the rank filter applied', () => {
       const landscape = defaultLandscape();
 
-      const filteredLandscape = landscape.filterByRank('RANK_D');
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_D'));
 
       const levels = filteredLandscape.standaloneLevels();
       const ciFeature = levels[2].elements[2];

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -463,6 +463,23 @@ describe('Landscape', () => {
         }),
       );
     });
+
+    it('should restore all module visibilities when removing rank filter', () => {
+      const landscape = defaultLandscape();
+      const filteredLandscape = landscape.filterByRank(Optional.of('RANK_C'));
+
+      const unfilterLandscape = filteredLandscape.filterByRank(Optional.empty());
+
+      const levels = unfilterLandscape.standaloneLevels();
+      const initModule = levels[0].elements.find(element => element.slugString() === 'init');
+      const reactModule = levels[1].elements[0].allModules().find(module => module.slugString() === 'react');
+      const postgresqlModule = levels[3].elements[0].allModules().find(module => module.slugString() === 'postgresql');
+      const liquibaseModule = levels[4].elements.find(element => element.slugString() === 'liquibase');
+      expect(initModule?.isVisible()).toBe(true);
+      expect(reactModule?.isVisible()).toBe(true);
+      expect(postgresqlModule?.isVisible()).toBe(true);
+      expect(liquibaseModule?.isVisible()).toBe(true);
+    });
   });
 });
 

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -1,3 +1,4 @@
+import { LandscapeFeature } from '@/module/domain/landscape/LandscapeFeature';
 import { LandscapeSelectionElement } from '@/module/domain/landscape/LandscapeSelectionElement';
 import { LandscapeSelectionTree } from '@/module/domain/landscape/LandscapeSelectionTree';
 import { describe, expect, it } from 'vitest';
@@ -284,6 +285,112 @@ describe('Landscape', () => {
         .selectedModulesProperties();
 
       expect(properties).toEqual([applicationBaseNamePropertyDefinition(), optionalBooleanPropertyDefinition()]);
+    });
+  });
+
+  describe('Filter by rank', () => {
+    it('should return same landscape when no rank filter is applied', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank(undefined);
+
+      expect(filteredLandscape).toEqual(landscape);
+    });
+
+    it('should filter modules by rank', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank('RANK_S');
+
+      const levels = filteredLandscape.standaloneLevels();
+      expect(levels).toHaveLength(3);
+      const rootModules = levels[0].elements.flatMap(element => element.allModules());
+      expect(rootModules).toHaveLength(2);
+      expect(rootModules).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            information: expect.objectContaining({
+              slug: moduleSlug('infinitest'),
+              rank: 'RANK_S',
+            }),
+          }),
+          expect.objectContaining({
+            information: expect.objectContaining({
+              slug: moduleSlug('init'),
+              rank: 'RANK_S',
+            }),
+          }),
+        ]),
+      );
+      const clientFeatureModules = levels[1].elements[0].allModules();
+      expect(clientFeatureModules).toHaveLength(1);
+      expect(clientFeatureModules[0]).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('vue'),
+            rank: 'RANK_S',
+          }),
+        }),
+      );
+    });
+
+    it('should filter modules in feature keeping only modules with specified rank', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank('RANK_S');
+
+      const clientFeature = filteredLandscape
+        .standaloneLevels()[1]
+        .elements.find(element => element instanceof LandscapeFeature && element.slugString() === 'client');
+      expect(clientFeature).toBeDefined();
+      expect(clientFeature?.allModules()).toEqual([
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('vue'),
+            rank: 'RANK_S',
+          }),
+        }),
+      ]);
+    });
+
+    it('should keep dependency modules with different ranks than the rank filter applied', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank('RANK_D');
+
+      const levels = filteredLandscape.standaloneLevels();
+      const initModule = levels[0].elements[0].allModules()[0];
+      expect(initModule).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('init'),
+            rank: 'RANK_S',
+          }),
+        }),
+      );
+      const reactModule = levels[1].elements[0].allModules()[0];
+      expect(reactModule).toEqual(
+        expect.objectContaining({
+          information: expect.objectContaining({
+            slug: moduleSlug('react'),
+            rank: 'RANK_D',
+          }),
+        }),
+      );
+    });
+
+    it('should keep features with different ranks modules than the rank filter applied', () => {
+      const landscape = defaultLandscape();
+
+      const filteredLandscape = landscape.filterByRank('RANK_D');
+
+      const levels = filteredLandscape.standaloneLevels();
+      const ciFeature = levels[2].elements[2];
+      expect(ciFeature).toEqual(
+        expect.objectContaining({
+          featureSlug: featureSlug('ci'),
+        }),
+      );
     });
   });
 });

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -405,8 +405,9 @@ describe('Landscape', () => {
 
       const filteredLandscape = landscape.filterByRank(Optional.of('RANK_D'));
 
-      const levels = filteredLandscape.standaloneLevels();
-      const ciFeature = levels[2].elements[2];
+      const ciFeature = filteredLandscape
+        .standaloneLevels()[2]
+        .elements.find(element => element instanceof LandscapeFeature && element.slugString() === 'ci');
       expect(ciFeature).toEqual(
         expect.objectContaining({
           featureSlug: featureSlug('ci'),

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -288,6 +288,26 @@ describe('Landscape', () => {
     });
   });
 
+  describe('Has module different rank', () => {
+    it('should return false for unknown module', () => {
+      const landscape = defaultLandscape();
+
+      expect(landscape.hasModuleDifferentRank(moduleSlug('unknown'), 'RANK_S')).toBe(false);
+    });
+
+    it('should return false when module has same rank', () => {
+      const landscape = defaultLandscape();
+
+      expect(landscape.hasModuleDifferentRank(moduleSlug('init'), 'RANK_S')).toBe(false);
+    });
+
+    it('should return true when module has different rank', () => {
+      const landscape = defaultLandscape();
+
+      expect(landscape.hasModuleDifferentRank(moduleSlug('react'), 'RANK_S')).toBe(true);
+    });
+  });
+
   describe('Filter by rank', () => {
     it('should return same landscape when no rank filter is applied', () => {
       const landscape = defaultLandscape();

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1393,7 +1393,8 @@ describe('Landscape', () => {
       expect(wrapper.find(wrappedElement('infinitest-module')).exists()).toBe(true);
       expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
       expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('java-base')).exists()).toBe(false);
+      expect(wrapper.find(wrappedElement('java-base-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(false);
     });
 
     it('should show all modules when deselect rank', async () => {
@@ -1411,6 +1412,7 @@ describe('Landscape', () => {
       expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
       expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
       expect(wrapper.find(wrappedElement('java-base-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(true);
     });
 
     it('should present distinctly with minimal emphasis on dependency modules of different ranks than the selected one', async () => {

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1405,8 +1405,8 @@ describe('Landscape', () => {
         init: true,
         vue: true,
         'java-base': true,
-        'spring-boot': false,
       });
+      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(false);
     });
 
     it('should show all modules when deselect rank', async () => {
@@ -1420,8 +1420,8 @@ describe('Landscape', () => {
         init: true,
         vue: true,
         'java-base': true,
-        'spring-boot': true,
       });
+      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(true);
     });
 
     it('should present distinctly with minimal emphasis on dependency modules of different ranks than the selected one', async () => {

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1180,6 +1180,19 @@ describe('Landscape', () => {
       expect(presetDropdown.element.value).toBe('');
     });
 
+    it('should deselect preset option when a rank button is clicked', async () => {
+      const { wrapper, presetComponent } = await setupAndSelectPreset('init-maven');
+      const rankComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);
+
+      const rankButton = rankComponent.find(wrappedElement('rank-RANK_S-filter'));
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      const presetDropdown = presetComponent.find('select');
+      expect(presetDropdown.element.value).toBe('');
+    });
+
     const setupAndSelectPreset = async (presetValue: string) => {
       const { wrapper, presetComponent } = await setupPresetTest();
 

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1377,16 +1377,59 @@ describe('Landscape', () => {
 
   describe('Rank module filter', () => {
     it('should render the rank module filter', async () => {
-      const { presetComponent } = await setupRankTest();
+      const { rankComponent } = await setupRankTest();
 
-      expect(presetComponent.exists()).toBe(true);
+      expect(rankComponent.exists()).toBe(true);
+    });
+
+    it('should filter modules from selected rank', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+
+      const rankButton = rankComponent.find(wrappedElement('rank-RANK_S-filter'));
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(wrappedElement('infinitest-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('java-base')).exists()).toBe(false);
+    });
+
+    it('should show all modules when deselect rank', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+      const rankButton = rankComponent.find(wrappedElement('rank-RANK_S-filter'));
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(wrappedElement('infinitest-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('java-base-module')).exists()).toBe(true);
+    });
+
+    it('should present distinctly with minimal emphasis on dependency modules of different ranks than the selected one', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+
+      const rankButton = rankComponent.find(wrappedElement('rank-RANK_D-filter'));
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
+      expect(wrapper.find(wrappedElement('init-module')).classes()).toContain('-diff-rank-minimal-emphasis');
     });
 
     const setupRankTest = async () => {
       const wrapper = await componentWithLandscape();
-      const presetComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);
+      const rankComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);
 
-      return { wrapper, presetComponent };
+      return { wrapper, rankComponent: rankComponent };
     };
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1398,43 +1398,36 @@ describe('Landscape', () => {
     it('should filter modules from selected rank', async () => {
       const { wrapper, rankComponent } = await setupRankTest();
 
-      const rankButton = rankComponent.find(wrappedElement('rank-RANK_S-filter'));
-      await rankButton.trigger('click');
-      await flushPromises();
-      await wrapper.vm.$nextTick();
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_S');
 
-      expect(wrapper.find(wrappedElement('infinitest-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('java-base-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(false);
+      await expectModulesVisibility(wrapper, {
+        infinitest: true,
+        init: true,
+        vue: true,
+        'java-base': true,
+        'spring-boot': false,
+      });
     });
 
     it('should show all modules when deselect rank', async () => {
       const { wrapper, rankComponent } = await setupRankTest();
-      const rankButton = rankComponent.find(wrappedElement('rank-RANK_S-filter'));
-      await rankButton.trigger('click');
-      await flushPromises();
-      await wrapper.vm.$nextTick();
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_S');
 
-      await rankButton.trigger('click');
-      await flushPromises();
-      await wrapper.vm.$nextTick();
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_S');
 
-      expect(wrapper.find(wrappedElement('infinitest-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('vue-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('java-base-module')).exists()).toBe(true);
-      expect(wrapper.find(wrappedElement('spring-boot-module')).exists()).toBe(true);
+      await expectModulesVisibility(wrapper, {
+        infinitest: true,
+        init: true,
+        vue: true,
+        'java-base': true,
+        'spring-boot': true,
+      });
     });
 
     it('should present distinctly with minimal emphasis on dependency modules of different ranks than the selected one', async () => {
       const { wrapper, rankComponent } = await setupRankTest();
 
-      const rankButton = rankComponent.find(wrappedElement('rank-RANK_D-filter'));
-      await rankButton.trigger('click');
-      await flushPromises();
-      await wrapper.vm.$nextTick();
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_D');
 
       expect(wrapper.find(wrappedElement('init-module')).exists()).toBe(true);
       expect(wrapper.find(wrappedElement('init-module')).classes()).toContain('-diff-rank-minimal-emphasis');
@@ -1444,7 +1437,23 @@ describe('Landscape', () => {
       const wrapper = await componentWithLandscape();
       const rankComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);
 
-      return { wrapper, rankComponent: rankComponent };
+      return { wrapper, rankComponent };
+    };
+
+    const triggerRankFilter = async (wrapper: VueWrapper, rankComponent: VueWrapper, rank: string): Promise<void> => {
+      const rankButton = rankComponent.find(wrappedElement(`rank-${rank}-filter`));
+      await rankButton.trigger('click');
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+    };
+
+    const expectModulesVisibility = async (wrapper: VueWrapper, expectations: Record<string, boolean>) => {
+      await flushPromises();
+      await wrapper.vm.$nextTick();
+
+      Object.entries(expectations).forEach(([module, shouldExist]) => {
+        expect(wrapper.find(wrappedElement(`${module}-module`)).exists()).toBe(shouldExist);
+      });
     };
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -11,6 +11,7 @@ import { ModulesRepository } from '@/module/domain/ModulesRepository';
 import { ModulesToApply } from '@/module/domain/ModulesToApply';
 import { LandscapeVue } from '@/module/primary/landscape';
 import { LandscapePresetConfigurationVue } from '@/module/primary/landscape-preset-configuration';
+import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
 import { BodyCursorUpdater } from '@/module/primary/landscape/BodyCursorUpdater';
 import { LandscapeScroller } from '@/module/primary/landscape/LandscapeScroller';
 import { ALERT_BUS } from '@/shared/alert/application/AlertProvider';
@@ -1371,6 +1372,21 @@ describe('Landscape', () => {
       landscapeContainer.getBoundingClientRect = mockContainerRect;
 
       return { mockModuleRect, mockContainerRect, landscapeContainer };
+    };
+  });
+
+  describe('Rank module filter', () => {
+    it('should render the rank module filter', async () => {
+      const { presetComponent } = await setupRankTest();
+
+      expect(presetComponent.exists()).toBe(true);
+    });
+
+    const setupRankTest = async () => {
+      const wrapper = await componentWithLandscape();
+      const presetComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);
+
+      return { wrapper, presetComponent };
     };
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1433,6 +1433,23 @@ describe('Landscape', () => {
       expect(wrapper.find(wrappedElement('init-module')).classes()).toContain('-diff-rank-minimal-emphasis');
     });
 
+    it('should retain module selection state when filtered by rank', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+
+      const initialModuleElement = wrapper.find(wrappedElement('init-module'));
+      await initialModuleElement.trigger('click');
+      await flushPromises();
+
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_D');
+
+      const filteredModuleElement = wrapper.find(wrappedElement('init-module'));
+      expect(filteredModuleElement.exists()).toBe(true);
+      const classes = filteredModuleElement.classes();
+      ['-selected', '-compacted'].forEach(expectedClass => {
+        expect(classes).toContain(expectedClass);
+      });
+    });
+
     const setupRankTest = async () => {
       const wrapper = await componentWithLandscape();
       const rankComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -111,7 +111,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     expect(rankSButton.attributes('disabled')).toBeUndefined();
     expect(rankDButton.attributes('disabled')).toBeUndefined();
     expect(rankCButton.attributes('disabled')).toBeUndefined();
-    expect(rankAButton.attributes('disabled')).toBeDefined();
+    expect(rankAButton.attributes('disabled')).toBeUndefined();
     expect(rankBButton.attributes('disabled')).toBeDefined();
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -1,23 +1,15 @@
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
-import { RanksUsed, toRanksUsed } from '@/module/domain/RanksUsed';
+import { ModuleRankStatistics, toModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
 import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { wrappedElement } from '../../../WrappedElement';
 import { defaultLandscape } from '../../domain/landscape/Landscape.fixture';
 
-// const wrap = (): VueWrapper => {
-//   return mount(LandscapeRankModuleFilterVue, {
-//     props: {
-//       ranksUsed: toRanksUsed(defaultLandscape()),
-//     },
-//   });
-// };
-
-const wrap = (props?: { ranksUsed: RanksUsed }): VueWrapper => {
+const wrap = (props?: { moduleRankStatistics: ModuleRankStatistics }): VueWrapper => {
   return mount(LandscapeRankModuleFilterVue, {
     props: props || {
-      ranksUsed: RANKS.map(rank => ({ rank, quantity: 1 })), // Force enable all ranks
+      moduleRankStatistics: RANKS.map(rank => ({ rank, quantity: 1 })), // Force enable all ranks
     },
   });
 };
@@ -107,7 +99,8 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should disable rank button without module rank associated', () => {
-    const wrapper = wrap({ ranksUsed: toRanksUsed(defaultLandscape()) });
+    const moduleRankStatistics = toModuleRankStatistics(defaultLandscape());
+    const wrapper = wrap({ moduleRankStatistics });
 
     const rankSButton = wrapper.find(wrappedElement('rank-RANK_S-filter'));
     const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -110,8 +110,8 @@ describe('LandscapeRankModuleFilterComponent', () => {
 
     expect(rankSButton.attributes('disabled')).toBeUndefined();
     expect(rankDButton.attributes('disabled')).toBeUndefined();
+    expect(rankCButton.attributes('disabled')).toBeUndefined();
     expect(rankAButton.attributes('disabled')).toBeDefined();
     expect(rankBButton.attributes('disabled')).toBeDefined();
-    expect(rankCButton.attributes('disabled')).toBeDefined();
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -41,10 +41,18 @@ describe('LandscapeRankModuleFilterComponent', () => {
     expect(wrapper.emitted('selected')).toEqual([[RANKS[0]], [undefined]]);
   });
 
-  it('should format rank labels correctly', () => {
+  it('should format rank short name correctly', () => {
     const wrapper = wrap();
 
-    const buttons = wrapper.findAll('[data-testid^="rank-"]');
+    const buttons = wrapper.findAll('[data-testid^="short-name-"]');
+    RANKS.forEach((rank, index) => {
+      expect(buttons[index].text()).toBe(rank.replace('RANK_', ''));
+    });
+  });
+  it('should format rank full name correctly', () => {
+    const wrapper = wrap();
+
+    const buttons = wrapper.findAll('[data-testid^="full-name-"]');
     RANKS.forEach((rank, index) => {
       expect(buttons[index].text()).toBe(rank.replace('RANK_', 'RANK '));
     });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -74,7 +74,6 @@ describe('LandscapeRankModuleFilterComponent', () => {
 
     const rankBButton = wrapper.find(wrappedElement('rank-RANK_B-filter'));
     const rankCButton = wrapper.find(wrappedElement('rank-RANK_C-filter'));
-
     await rankBButton.trigger('click');
     await rankCButton.trigger('click');
 
@@ -85,6 +84,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     const wrapper = mount(LandscapeRankModuleFilterVue);
 
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+
     expect(rankDButton.attributes('title')).toBe('Experimental or advanced module requiring specific expertise');
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -46,7 +46,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
 
     const buttons = wrapper.findAll('[data-testid^="rank-"]');
     RANKS.forEach((rank, index) => {
-      expect(buttons[index].text()).toBe(rank.replace('RANK_', ''));
+      expect(buttons[index].text()).toBe(rank.replace('RANK_', 'RANK '));
     });
   });
 

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -80,4 +80,11 @@ describe('LandscapeRankModuleFilterComponent', () => {
 
     expect(wrapper.emitted('selected')).toEqual([[RANKS[2]], [RANKS[1]]]);
   });
+
+  it('should display correct description for rank button', () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+    expect(rankDButton.attributes('title')).toBe('Experimental or advanced module requiring specific expertise');
+  });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -1,7 +1,7 @@
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import { ModuleRankStatistics, toModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
-import { mount, VueWrapper } from '@vue/test-utils';
+import { VueWrapper, mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { wrappedElement } from '../../../WrappedElement';
 import { defaultLandscape } from '../../domain/landscape/Landscape.fixture';

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -1,0 +1,83 @@
+import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+import { wrappedElement } from '../../../WrappedElement';
+
+const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'];
+
+describe('LandscapeRankModuleFilterComponent', () => {
+  it('should display all rank filters', () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const buttons = wrapper.findAll('[data-testid^="rank-"]');
+    expect(buttons).toHaveLength(RANKS.length);
+  });
+
+  it('should select rank when clicking on filter button', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+    await rankDButton.trigger('click');
+
+    expect(wrapper.emitted('selected')).toEqual([[RANKS[0]]]);
+  });
+
+  it('should deselect rank when clicking on selected filter button', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+    await rankDButton.trigger('click');
+    await rankDButton.trigger('click');
+
+    expect(wrapper.emitted('selected')).toEqual([[RANKS[0]], [undefined]]);
+  });
+
+  it('should format rank labels correctly', () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const buttons = wrapper.findAll('[data-testid^="rank-"]');
+    RANKS.forEach((rank, index) => {
+      expect(buttons[index].text()).toBe(rank.replace('RANK_', ''));
+    });
+  });
+
+  it('should apply selected style to active filter', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+    await rankDButton.trigger('click');
+
+    expect(rankDButton.classes()).toContain('-selected');
+  });
+
+  it('should emit selected rank when clicking a filter button', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
+    await rankAButton.trigger('click');
+
+    expect(wrapper.emitted('selected')).toEqual([[RANKS[3]]]);
+  });
+
+  it('should emit undefined when deselecting a rank', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankSButton = wrapper.find(wrappedElement('rank-RANK_S-filter'));
+    await rankSButton.trigger('click');
+    await rankSButton.trigger('click');
+
+    expect(wrapper.emitted('selected')).toEqual([[RANKS[4]], [undefined]]);
+  });
+
+  it('should only emit one rank at a time', async () => {
+    const wrapper = mount(LandscapeRankModuleFilterVue);
+
+    const rankBButton = wrapper.find(wrappedElement('rank-RANK_B-filter'));
+    const rankCButton = wrapper.find(wrappedElement('rank-RANK_C-filter'));
+
+    await rankBButton.trigger('click');
+    await rankCButton.trigger('click');
+
+    expect(wrapper.emitted('selected')).toEqual([[RANKS[2]], [RANKS[1]]]);
+  });
+});

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -1,20 +1,37 @@
+import { RANKS } from '@/module/domain/landscape/ModuleRank';
+import { RanksUsed, toRanksUsed } from '@/module/domain/RanksUsed';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
-import { mount } from '@vue/test-utils';
+import { mount, VueWrapper } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { wrappedElement } from '../../../WrappedElement';
+import { defaultLandscape } from '../../domain/landscape/Landscape.fixture';
 
-const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'];
+// const wrap = (): VueWrapper => {
+//   return mount(LandscapeRankModuleFilterVue, {
+//     props: {
+//       ranksUsed: toRanksUsed(defaultLandscape()),
+//     },
+//   });
+// };
+
+const wrap = (props?: { ranksUsed: RanksUsed }): VueWrapper => {
+  return mount(LandscapeRankModuleFilterVue, {
+    props: props || {
+      ranksUsed: RANKS.map(rank => ({ rank, quantity: 1 })), // Force enable all ranks
+    },
+  });
+};
 
 describe('LandscapeRankModuleFilterComponent', () => {
   it('should display all rank filters', () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const buttons = wrapper.findAll('[data-testid^="rank-"]');
     expect(buttons).toHaveLength(RANKS.length);
   });
 
   it('should select rank when clicking on filter button', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
     await rankDButton.trigger('click');
@@ -23,7 +40,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should deselect rank when clicking on selected filter button', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
     await rankDButton.trigger('click');
@@ -33,7 +50,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should format rank labels correctly', () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const buttons = wrapper.findAll('[data-testid^="rank-"]');
     RANKS.forEach((rank, index) => {
@@ -42,7 +59,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should apply selected style to active filter', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
     await rankDButton.trigger('click');
@@ -51,16 +68,17 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should emit selected rank when clicking a filter button', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
     await rankAButton.trigger('click');
+    await wrapper.vm.$nextTick();
 
     expect(wrapper.emitted('selected')).toEqual([[RANKS[3]]]);
   });
 
   it('should emit undefined when deselecting a rank', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankSButton = wrapper.find(wrappedElement('rank-RANK_S-filter'));
     await rankSButton.trigger('click');
@@ -70,7 +88,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should only emit one rank at a time', async () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankBButton = wrapper.find(wrappedElement('rank-RANK_B-filter'));
     const rankCButton = wrapper.find(wrappedElement('rank-RANK_C-filter'));
@@ -81,10 +99,26 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should display correct description for rank button', () => {
-    const wrapper = mount(LandscapeRankModuleFilterVue);
+    const wrapper = wrap();
 
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
 
     expect(rankDButton.attributes('title')).toBe('Experimental or advanced module requiring specific expertise');
+  });
+
+  it('should disable rank button without module rank associated', () => {
+    const wrapper = wrap({ ranksUsed: toRanksUsed(defaultLandscape()) });
+
+    const rankSButton = wrapper.find(wrappedElement('rank-RANK_S-filter'));
+    const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
+    const rankBButton = wrapper.find(wrappedElement('rank-RANK_B-filter'));
+    const rankCButton = wrapper.find(wrappedElement('rank-RANK_C-filter'));
+    const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
+
+    expect(rankSButton.attributes('disabled')).toBeUndefined();
+    expect(rankDButton.attributes('disabled')).toBeUndefined();
+    expect(rankAButton.attributes('disabled')).toBeDefined();
+    expect(rankBButton.attributes('disabled')).toBeDefined();
+    expect(rankCButton.attributes('disabled')).toBeDefined();
   });
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -47,7 +47,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
     await rankDButton.trigger('click');
 
-    expect(rankDButton.classes()).toContain('-selected');
+    expect(rankDButton.classes()).toContain('-active');
   });
 
   it('should emit selected rank when clicking a filter button', async () => {

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -207,7 +207,9 @@ const restLandscape = (): RestLandscape => ({
     },
     {
       elements: [
-        landscapeFeature('jpa', [landscapeModule('postgresql', 'Add PostGreSQL', emptyProperties(), [moduleDependency('spring-boot')])]),
+        landscapeFeature('jpa', [
+          landscapeModule('postgresql', 'Add PostGreSQL', emptyProperties(), [moduleDependency('spring-boot')], 'RANK_C'),
+        ]),
         landscapeFeature('spring-mvc', [
           landscapeModule('spring-boot-tomcat', 'Add Tomcat', emptyProperties(), [moduleDependency('spring-boot')]),
           landscapeModule('spring-boot-undertow', 'Add Undertow', emptyProperties(), [moduleDependency('spring-boot')]),

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -177,7 +177,7 @@ const restLandscape = (): RestLandscape => ({
     {
       elements: [
         landscapeModule('infinitest', 'Add infinitest filters', applicationBaseNameProperties(), [], 'RANK_S'),
-        landscapeModule('init', 'Add some initial tools', applicationBaseNameProperties()),
+        landscapeModule('init', 'Add some initial tools', applicationBaseNameProperties(), [], 'RANK_S'),
         landscapeModule('init-props', 'Add some initial tools with extra properties', initPropsProperties()),
         landscapeModule('prettier', 'Add prettier', applicationBaseNameProperties()),
       ],
@@ -185,7 +185,7 @@ const restLandscape = (): RestLandscape => ({
     {
       elements: [
         landscapeFeature('client', [
-          landscapeModule('vue', 'Add vue', emptyProperties(), [moduleDependency('init')]),
+          landscapeModule('vue', 'Add vue', emptyProperties(), [moduleDependency('init')], 'RANK_S'),
           landscapeModule('react', 'Add react', emptyProperties(), [moduleDependency('init')]),
           landscapeModule('angular', 'Add angular', emptyProperties(), [moduleDependency('init')]),
         ]),

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -197,7 +197,7 @@ const restLandscape = (): RestLandscape => ({
     },
     {
       elements: [
-        landscapeModule('java-base', 'Add base java classes', emptyProperties(), [featureDependency('java-build-tools')]),
+        landscapeModule('java-base', 'Add base java classes', emptyProperties(), [featureDependency('java-build-tools')], 'RANK_S'),
         landscapeModule('spring-boot', 'Add spring boot core', emptyProperties(), [featureDependency('java-build-tools')]),
         landscapeFeature('ci', [
           landscapeModule('gitlab-maven', 'Add simple gitlab ci for maven', emptyProperties(), [moduleDependency('maven')], 'RANK_S'),

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -176,7 +176,7 @@ const restLandscape = (): RestLandscape => ({
   levels: [
     {
       elements: [
-        landscapeModule('infinitest', 'Add infinitest filters', applicationBaseNameProperties()),
+        landscapeModule('infinitest', 'Add infinitest filters', applicationBaseNameProperties(), [], 'RANK_S'),
         landscapeModule('init', 'Add some initial tools', applicationBaseNameProperties()),
         landscapeModule('init-props', 'Add some initial tools with extra properties', initPropsProperties()),
         landscapeModule('prettier', 'Add prettier', applicationBaseNameProperties()),

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -1,3 +1,4 @@
+import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
 import { ModuleSlug } from '@/module/domain/ModuleSlug';
 import { Presets } from '@/module/domain/Presets';
 import { RestLandscape } from '@/module/secondary/RestLandscape';
@@ -234,12 +235,14 @@ const landscapeModule = (
   operation: string,
   properties: RestModulePropertiesDefinitions,
   dependencies?: RestLandscapeDependency[],
+  rank: ModuleRank = 'RANK_D',
 ): RestLandscapeModule => ({
   type: 'MODULE',
   slug,
   operation,
   properties,
   dependencies,
+  rank,
 });
 
 const landscapeFeature = (slug: string, modules: RestLandscapeModule[]): RestLandscapeFeature => ({

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -200,8 +200,8 @@ const restLandscape = (): RestLandscape => ({
         landscapeModule('java-base', 'Add base java classes', emptyProperties(), [featureDependency('java-build-tools')]),
         landscapeModule('spring-boot', 'Add spring boot core', emptyProperties(), [featureDependency('java-build-tools')]),
         landscapeFeature('ci', [
-          landscapeModule('gitlab-maven', 'Add simple gitlab ci for maven', emptyProperties(), [moduleDependency('maven')]),
-          landscapeModule('gitlab-gradle', 'Add simple gitlab ci for gradle', emptyProperties(), [moduleDependency('gradle')]),
+          landscapeModule('gitlab-maven', 'Add simple gitlab ci for maven', emptyProperties(), [moduleDependency('maven')], 'RANK_S'),
+          landscapeModule('gitlab-gradle', 'Add simple gitlab ci for gradle', emptyProperties(), [moduleDependency('gradle')], 'RANK_S'),
         ]),
       ],
     },

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -224,7 +224,7 @@ const restLandscape = (): RestLandscape => ({
           featureDependency('spring-mvc'),
           moduleDependency('bean-validation-test'),
         ]),
-        landscapeModule('liquibase', 'Add liquibase', emptyProperties(), [featureDependency('jpa')]),
+        landscapeModule('liquibase', 'Add liquibase', emptyProperties(), [featureDependency('jpa')], 'RANK_A'),
       ],
     },
   ],


### PR DESCRIPTION
- Fix #10934 

### A demo video of the implemented feature:

https://github.com/user-attachments/assets/de86f924-1abf-4e85-8cd2-bc40a4552a29

There were many things going on in the above demo video so I will list the completed tasks below.

## Rank Module Filter Implementation Tasks

### UI Components
- [x] Create LandscapeRankModuleFilterVue component with:
  - [x] Rank filter buttons for all RANKS
  - [x] Active state styling for selected rank
  - [x] Title attributes with rank descriptions
  - [x] Disabled state for ranks without modules
  - [x] Click handlers for selection/deselection

### Rank Filtering Logic
- [x] Implement rank filtering in the Landscape class:
  - [x] filterByRank() method
  - [x] Module visibility based on selected rank
  - [x] Dependency handling for modules with different ranks
  - [x] Feature preservation when containing filtered modules

### Module Emphasis
- [x] Add minimal emphasis styling for:
  - [x] Dependency modules with different ranks than filter
  - [x] Features containing modules with different ranks

### Integration
- [x] Connect rank filter to Landscape component:
  - [x] Do not show rank filter on small screens
  - [x] Emit selected rank event
  - [x] Update Landscape display with filtered modules
  - [x] Handle preset interactions when the rank filter changes

### Design
- [x] Create tikui toggle-button atom
- [x] Create tikui landscap-rank-module-filter organism 

### The dark mode Landscape screen with rank module filter
![2025-02-14 10 53 26 localhost 05a23467da33](https://github.com/user-attachments/assets/daa5235e-6b38-44a7-9207-81556dbe719f)


TO-DO (**created at 2025-03-10**)
 - [x] Error when drawing the module connections
 - [x] Setup the modules configuration with the module rank classification (https://github.com/jhipster/jhipster-lite/pull/12058)
 - [x] Should preserve the selected modules when filtering by rank