### PR TITLE
Fix AsyncElementAsserter to properly work in async mode

### DIFF
--- a/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncElementAsserter.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/rest/AsyncElementAsserter.java
@@ -4,64 +4,65 @@ import java.time.Duration;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Supplier;
 
 class AsyncElementAsserter implements ElementAsserter<AsyncResponseAsserter> {
 
   private final Duration maxTime;
   private final AsyncResponseAsserter responseAsserter;
-  private final ElementAssertions assertions;
+  private final Supplier<ElementAssertions> assertions;
 
   AsyncElementAsserter(AsyncResponseAsserter responseAsserter, String jsonPath, Duration maxTime) {
     this.responseAsserter = responseAsserter;
     this.maxTime = maxTime;
-    assertions = new ElementAssertions(jsonPath);
+    this.assertions = () -> new ElementAssertions(jsonPath);
   }
 
   @Override
   public AsyncElementAsserter withValues(Collection<String> values) {
-    Awaiter.await(maxTime, () -> assertions.withValues(values));
+    Awaiter.await(maxTime, () -> assertions.get().withValues(values));
 
     return this;
   }
 
   @Override
   public AsyncElementAsserter withElementsCount(int count) {
-    Awaiter.await(maxTime, () -> assertions.withElementsCount(count));
+    Awaiter.await(maxTime, () -> assertions.get().withElementsCount(count));
 
     return this;
   }
 
   @Override
   public AsyncElementAsserter withMoreThanElementsCount(int count) {
-    Awaiter.await(maxTime, () -> assertions.withMoreThanElementsCount(count));
+    Awaiter.await(maxTime, () -> assertions.get().withMoreThanElementsCount(count));
 
     return this;
   }
 
   @Override
   public AsyncElementAsserter withValue(Object value) {
-    Awaiter.await(maxTime, () -> assertions.withValue(value));
+    Awaiter.await(maxTime, () -> assertions.get().withValue(value));
 
     return this;
   }
 
   @Override
   public <Data> AsyncElementAsserter containingExactly(List<Map<String, Data>> responses) {
-    Awaiter.await(maxTime, () -> assertions.containingExactly(responses));
+    Awaiter.await(maxTime, () -> assertions.get().containingExactly(responses));
 
     return this;
   }
 
   @Override
   public <Data> AsyncElementAsserter containing(Map<String, Data> response) {
-    Awaiter.await(maxTime, () -> assertions.containing(response));
+    Awaiter.await(maxTime, () -> assertions.get().containing(response));
 
     return this;
   }
 
   @Override
   public <Data> AsyncElementAsserter containing(List<Map<String, Data>> responses) {
-    Awaiter.await(maxTime, () -> assertions.containing(responses));
+    Awaiter.await(maxTime, () -> assertions.get().containing(responses));
 
     return this;
   }


### PR DESCRIPTION
## Description

The `AsyncElementAsserter` class was not functioning properly in asynchronous mode. In the current implementation, the `ElementAssertions` object is created in the constructor, and this object's constructor immediately checks if the JSON element exists. This made it impossible to verify elements that are added asynchronously.

## Changes

I fixed this issue by using the Supplier pattern to delay the creation of the `ElementAssertions` object:

1. Instead of directly creating the `ElementAssertions` object in the constructor, I used a Supplier to create it when needed.
2. Ensured that `assertions.get()` is called inside the `Awaiter.await()` lambda, allowing proper waiting for elements to appear.

Fix #11989