### PR TITLE
use colors to identify each rank

### DIFF
--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -12,7 +12,6 @@ $jhlite-button-toggle-active-color-background: button-main.$jhlite-button-color-
 $jhlite-button-toggle-active-hover-color-background: button-main.$jhlite-button-hover-color-background;
 $jhlite-button-toggle-transition-duration: 0.5s;
 
-// Now define the main component
 .jhlite-button-toggle {
   @extend %jhlite-button-main;
 

--- a/src/main/style/organism/landscape-rank-module-filter/_landscape-rank-module-filter.scss
+++ b/src/main/style/organism/landscape-rank-module-filter/_landscape-rank-module-filter.scss
@@ -1,9 +1,55 @@
 @use '../../token/size';
+@use '../../token/colors';
 
 .jhlite-landscape-rank-module-filter {
   &--ranks {
     display: flex;
     gap: size.$jhlite-global-size-field-padding;
     align-items: center;
+
+    .jhlite-button-toggle::before {
+      position: absolute;
+      inset: 0;
+      transition: 0.5s ease-out;
+      border: 2px solid transparent;
+      border-radius: 8px;
+      content: '';
+    }
+
+    .jhlite-button-toggle {
+      position: relative;
+      overflow: unset;
+
+      &.-rank-color::before {
+        position: absolute;
+        inset: -5px;
+        transition: 0.5s ease-in;
+        content: '';
+      }
+
+      &.-rank-color.-reduced-attention::before {
+        border-style: dotted;
+      }
+
+      &.-rank-color.-s::before {
+        border-color: colors.$jhlite-rank-s-color;
+      }
+
+      &.-rank-color.-a::before {
+        border-color: colors.$jhlite-rank-a-color;
+      }
+
+      &.-rank-color.-b::before {
+        border-color: colors.$jhlite-rank-b-color;
+      }
+
+      &.-rank-color.-c::before {
+        border-color: colors.$jhlite-rank-c-color;
+      }
+
+      &.-rank-color.-d::before {
+        border-color: colors.$jhlite-rank-d-color;
+      }
+    }
   }
 }

--- a/src/main/style/organism/landscape/_landscape.scss
+++ b/src/main/style/organism/landscape/_landscape.scss
@@ -197,7 +197,7 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
 
   .-highlight-rank.-diff-rank-minimal-emphasis,
   .-diff-rank-minimal-emphasis {
-    border: 1px dotted $jhlite-landscape-line-color;
+    border: 2px dotted $jhlite-landscape-line-color;
   }
 
   .-highlight-rank {

--- a/src/main/style/organism/landscape/_landscape.scss
+++ b/src/main/style/organism/landscape/_landscape.scss
@@ -195,9 +195,33 @@ $jhlite-landscape-primary-alternative-color: colors.$jhlite-global-primary-alter
     box-shadow: 0 0 0 size.$jhlite-global-size-field-border-focus colors.$jhlite-attention-highlight-color;
   }
 
+  .-highlight-rank.-diff-rank-minimal-emphasis,
   .-diff-rank-minimal-emphasis {
-    opacity: 0.5;
     border: 1px dotted $jhlite-landscape-line-color;
+  }
+
+  .-highlight-rank {
+    border-width: 2px;
+
+    &.-s {
+      border-color: colors.$jhlite-rank-s-color;
+    }
+
+    &.-a {
+      border-color: colors.$jhlite-rank-a-color;
+    }
+
+    &.-b {
+      border-color: colors.$jhlite-rank-b-color;
+    }
+
+    &.-c {
+      border-color: colors.$jhlite-rank-c-color;
+    }
+
+    &.-d {
+      border-color: colors.$jhlite-rank-d-color;
+    }
   }
 }
 

--- a/src/main/style/token/_colors.scss
+++ b/src/main/style/token/_colors.scss
@@ -85,3 +85,8 @@ $jhlite-valid-highlight-end-color: $jhlite-global-color-success;
 $jhlite-invalid-highlight-start-color: #bf3e3e;
 $jhlite-invalid-highlight-end-color: $jhlite-global-color-error;
 $jhlite-attention-highlight-color: #ffd700;
+$jhlite-rank-s-color: #673ab7;
+$jhlite-rank-a-color: #4caf50;
+$jhlite-rank-b-color: #2196f3;
+$jhlite-rank-c-color: #ffc107;
+$jhlite-rank-d-color: #ff5722;

--- a/src/main/style/token/_colors.scss
+++ b/src/main/style/token/_colors.scss
@@ -89,4 +89,4 @@ $jhlite-rank-s-color: #673ab7;
 $jhlite-rank-a-color: #4caf50;
 $jhlite-rank-b-color: #2196f3;
 $jhlite-rank-c-color: #ffc107;
-$jhlite-rank-d-color: #ff5722;
+$jhlite-rank-d-color: #ff7043;

--- a/src/main/webapp/app/module/domain/landscape/Landscape.ts
+++ b/src/main/webapp/app/module/domain/landscape/Landscape.ts
@@ -431,6 +431,10 @@ export class Landscape {
     return this.properties;
   }
 
+  public getModuleRank(module: ModuleSlug): Optional<ModuleRank> {
+    return this.getModule(module).map(currentModule => currentModule.rank());
+  }
+
   public hasModuleDifferentRank(module: ModuleSlug, rank: ModuleRank): boolean {
     return this.getModule(module)
       .map(currentModule => currentModule.rank() !== rank)

--- a/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
+++ b/src/main/webapp/app/module/domain/landscape/ModuleRank.ts
@@ -1,2 +1,4 @@
 export const RANKS = ['RANK_D', 'RANK_C', 'RANK_B', 'RANK_A', 'RANK_S'] as const;
 export type ModuleRank = (typeof RANKS)[number];
+
+export const extractRankLetter = (rank: ModuleRank): string => rank.substring(5);

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -63,6 +63,23 @@ export default defineComponent({
 
     const isRankHovered = (rank: ModuleRank): boolean => rank === 'RANK_S' && hoverRankS.value;
 
+    const getRankColorClass = (rank: ModuleRank): string => {
+      const colorMap = {
+        RANK_D: '-rank-color -d',
+        RANK_C: '-rank-color -c',
+        RANK_B: '-rank-color -b',
+        RANK_A: '-rank-color -a',
+        RANK_S: '-rank-color -s',
+      };
+      return colorMap[rank];
+    };
+
+    const isAnyRankSelected = (): boolean => selectedRank.value !== undefined;
+
+    const isReduceAttention = (rank: ModuleRank): boolean => {
+      return selectedRank.value !== undefined && selectedRank.value !== rank;
+    };
+
     return {
       ranks,
       isRankSelected,
@@ -72,6 +89,9 @@ export default defineComponent({
       getRankDescription,
       isRankDisabled,
       isRankHovered,
+      getRankColorClass,
+      isAnyRankSelected,
+      isReduceAttention,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -1,5 +1,4 @@
-import type { ModuleRank } from '@/module/domain/landscape/ModuleRank';
-import { RANKS } from '@/module/domain/landscape/ModuleRank';
+import { ModuleRank, RANKS, extractRankLetter } from '@/module/domain/landscape/ModuleRank';
 import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
 import { Optional } from '@/shared/optional/domain/Optional';
@@ -63,16 +62,7 @@ export default defineComponent({
 
     const isRankHovered = (rank: ModuleRank): boolean => rank === 'RANK_S' && hoverRankS.value;
 
-    const getRankColorClass = (rank: ModuleRank): string => {
-      const colorMap = {
-        RANK_D: '-rank-color -d',
-        RANK_C: '-rank-color -c',
-        RANK_B: '-rank-color -b',
-        RANK_A: '-rank-color -a',
-        RANK_S: '-rank-color -s',
-      };
-      return colorMap[rank];
-    };
+    const getRankColorClass = (rank: ModuleRank): string => `-rank-color -${extractRankLetter(rank).toLowerCase()}`;
 
     const isAnyRankSelected = (): boolean => selectedRank.value.isPresent();
 

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -6,7 +6,9 @@
       class="jhlite-button-toggle"
       :class="{
          '-active': isRankSelected(rank),
-         '-hovered': isRankHovered(rank)
+         '-hovered': isRankHovered(rank),
+         [getRankColorClass(rank)]: isAnyRankSelected(),
+         '-reduced-attention': isReduceAttention(rank)
        }"
       @click="toggleRank(rank)"
       :data-testid="`rank-${rank}-filter`"

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -661,10 +661,10 @@ export default defineComponent({
       }
     };
 
-    const handleRankFilter = (rank: ModuleRank | undefined): void => {
+    const handleRankFilter = (rank: Optional<ModuleRank>): void => {
       clearPresetSelection();
 
-      selectedRank.value = Optional.ofNullable(rank);
+      selectedRank.value = rank;
       void reloadLandscape(landscapeValue().filterByRank(selectedRank.value));
     };
 

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -21,7 +21,7 @@ import { LandscapeFeatureSlug } from '@/module/domain/landscape/LandscapeFeature
 import { LandscapeLevel } from '@/module/domain/landscape/LandscapeLevel';
 import { LandscapeModule } from '@/module/domain/landscape/LandscapeModule';
 import { LandscapeSelectionElement } from '@/module/domain/landscape/LandscapeSelectionElement';
-import { ModuleRank } from '@/module/domain/landscape/ModuleRank';
+import { ModuleRank, extractRankLetter } from '@/module/domain/landscape/ModuleRank';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
 import { ALERT_BUS } from '@/shared/alert/application/AlertProvider';
 import { IconVue } from '@/shared/icon/infrastructure/primary';
@@ -425,7 +425,7 @@ export default defineComponent({
       if (selectedRank.value.isPresent()) {
         return landscapeValue()
           .getModuleRank(module)
-          .map(rank => ` -highlight-rank -${rank.toLowerCase().substring(5)}`)
+          .map(rank => ` -highlight-rank -${extractRankLetter(rank).toLowerCase()}`)
           .orElse('');
       }
 

--- a/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
+++ b/src/main/webapp/app/module/primary/landscape/Landscape.component.ts
@@ -325,6 +325,7 @@ export default defineComponent({
         + anchorPointClass(module)
         + searchHighlightClass(module)
         + diffRankMinimalEmphasisClass(module)
+        + rankHighlightClass(module)
       );
     };
 
@@ -414,6 +415,21 @@ export default defineComponent({
         .map(rank => landscapeValue().hasModuleDifferentRank(module, rank))
         .map(hasDifferentRank => (hasDifferentRank ? ' -diff-rank-minimal-emphasis' : ''))
         .orElse('');
+    };
+
+    const rankHighlightClass = (module: LandscapeElementId): string => {
+      if (module instanceof LandscapeFeatureSlug) {
+        return '';
+      }
+
+      if (selectedRank.value.isPresent()) {
+        return landscapeValue()
+          .getModuleRank(module)
+          .map(rank => ` -highlight-rank -${rank.toLowerCase().substring(5)}`)
+          .orElse('');
+      }
+
+      return '';
     };
 
     const modeClass = (): string => {

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.fixture.ts
@@ -48,7 +48,7 @@ export const defaultLandscape = (): Landscape =>
     {
       elements: [
         initialModule('java-base', 'Add base java classes', [], featureSlugs('java-build-tools'), 'RANK_S'),
-        initialModule('spring-boot', 'Add spring boot core', [], featureSlugs('java-build-tools')),
+        initialModule('spring-boot', 'Add spring boot core', [], featureSlugs('java-build-tools'), 'RANK_B'),
         new LandscapeFeature(featureSlug('ci'), [
           initialModule('gitlab-maven', 'Add simple gitlab ci for maven', [], moduleSlugs('maven'), 'RANK_S'),
           initialModule('gitlab-gradle', 'Add simple gitlab ci for gradle', [], moduleSlugs('gradle'), 'RANK_S'),
@@ -80,7 +80,7 @@ export const javaBuildToolFeature = (): LandscapeFeature =>
     initialModule('gradle', 'Add gradle', [], moduleSlugs('init')),
   ]);
 
-const initialModule = (
+export const initialModule = (
   slug: string,
   operation: string,
   properties: ModulePropertyDefinition[],

--- a/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
+++ b/src/test/webapp/unit/module/domain/landscape/Landscape.spec.ts
@@ -446,7 +446,7 @@ describe('Landscape', () => {
         expect.objectContaining({
           information: expect.objectContaining({
             slug: moduleSlug('spring-boot'),
-            rank: 'RANK_D',
+            rank: 'RANK_B',
           }),
         }),
       );

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeComponent.spec.ts
@@ -1450,6 +1450,36 @@ describe('Landscape', () => {
       });
     });
 
+    it('should highlight module with the same rank as the filtered rank', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_S');
+
+      const filteredModuleElement = wrapper.find(wrappedElement('init-module'));
+      expect(filteredModuleElement.exists()).toBe(true);
+      expect(filteredModuleElement.classes()).toContain('-highlight-rank');
+      expect(filteredModuleElement.classes()).toContain('-s');
+    });
+
+    it('should highlight modules according to their ranks when applying any filter by rank', async () => {
+      const { wrapper, rankComponent } = await setupRankTest();
+
+      await triggerRankFilter(wrapper, rankComponent, 'RANK_A');
+
+      const moduleRankExpectations = {
+        init: 's',
+        liquibase: 'a',
+        'spring-boot': 'b',
+        postgresql: 'c',
+        maven: 'd',
+      };
+      Object.entries(moduleRankExpectations).forEach(([module, rank]) => {
+        const moduleElement = wrapper.find(wrappedElement(`${module}-module`));
+        expect(moduleElement.classes()).toContain('-highlight-rank');
+        expect(moduleElement.classes()).toContain(`-${rank}`);
+      });
+    });
+
     const setupRankTest = async () => {
       const wrapper = await componentWithLandscape();
       const rankComponent = wrapper.findComponent(LandscapeRankModuleFilterVue);

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -51,6 +51,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
       expect(buttons[index].text()).toBe(rank.replace('RANK_', ''));
     });
   });
+
   it('should format rank full name correctly', () => {
     const wrapper = wrap();
 
@@ -123,6 +124,50 @@ describe('LandscapeRankModuleFilterComponent', () => {
     expect(rankBButton.attributes('disabled')).toBeUndefined();
     expect(rankCButton.attributes('disabled')).toBeDefined();
     expect(rankDButton.attributes('disabled')).toBeDefined();
+  });
+
+  it('should display the colors associated with each rank when select a rank', async () => {
+    const wrapper = wrap();
+
+    const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
+    await rankAButton.trigger('click');
+
+    const rankColorClasses = {
+      RANK_D: '-d',
+      RANK_C: '-c',
+      RANK_B: '-b',
+      RANK_A: '-a',
+      RANK_S: '-s',
+    };
+    for (const rank of RANKS) {
+      const rankButton = wrapper.find(wrappedElement(`rank-${rank}-filter`));
+
+      expect(rankButton.classes()).toContain('-rank-color');
+      expect(rankButton.classes()).toContain(rankColorClasses[rank]);
+    }
+  });
+
+  it('should reduce the attention to the ranks colors which do not match the selected rank', async () => {
+    const wrapper = wrap();
+
+    const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
+    await rankAButton.trigger('click');
+
+    expect(rankAButton.classes()).toContain('-active');
+    expect(rankAButton.classes()).toContain('-rank-color');
+    expect(rankAButton.classes()).toContain('-a');
+    expect(rankAButton.classes()).not.toContain('-reduced-attention');
+    for (const rank of RANKS.filter(r => r !== 'RANK_A')) {
+      const otherRankButton = wrapper.find(wrappedElement(`rank-${rank}-filter`));
+      expect(otherRankButton.classes()).toContain('-reduced-attention');
+      expect(otherRankButton.classes()).not.toContain('-active');
+    }
+
+    await rankAButton.trigger('click');
+    for (const rank of RANKS) {
+      const rankButton = wrapper.find(wrappedElement(`rank-${rank}-filter`));
+      expect(rankButton.classes()).not.toContain('-reduced-attention');
+    }
   });
 
   const rankEnabledLandscape = (): Landscape =>

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -1,10 +1,12 @@
+import { Landscape } from '@/module/domain/landscape/Landscape';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import { ModuleRankStatistics, toModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
 import { VueWrapper, mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { wrappedElement } from '../../../WrappedElement';
-import { defaultLandscape } from '../../domain/landscape/Landscape.fixture';
+import { initialModule } from '../../domain/landscape/Landscape.fixture';
+import { applicationBaseNamePropertyDefinition } from '../../domain/Modules.fixture';
 
 const wrap = (props?: { moduleRankStatistics: ModuleRankStatistics }): VueWrapper => {
   return mount(LandscapeRankModuleFilterVue, {
@@ -107,7 +109,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
   });
 
   it('should disable rank button without module rank associated', () => {
-    const moduleRankStatistics = toModuleRankStatistics(defaultLandscape());
+    const moduleRankStatistics = toModuleRankStatistics(rankEnabledLandscape());
     const wrapper = wrap({ moduleRankStatistics });
 
     const rankSButton = wrapper.find(wrappedElement('rank-RANK_S-filter'));
@@ -117,9 +119,20 @@ describe('LandscapeRankModuleFilterComponent', () => {
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
 
     expect(rankSButton.attributes('disabled')).toBeUndefined();
-    expect(rankDButton.attributes('disabled')).toBeUndefined();
-    expect(rankCButton.attributes('disabled')).toBeUndefined();
     expect(rankAButton.attributes('disabled')).toBeUndefined();
-    expect(rankBButton.attributes('disabled')).toBeDefined();
+    expect(rankBButton.attributes('disabled')).toBeUndefined();
+    expect(rankCButton.attributes('disabled')).toBeDefined();
+    expect(rankDButton.attributes('disabled')).toBeDefined();
   });
+
+  const rankEnabledLandscape = (): Landscape =>
+    Landscape.initialState([
+      {
+        elements: [
+          initialModule('rank-s', 'Add infinitest filters', [applicationBaseNamePropertyDefinition()], [], 'RANK_S'),
+          initialModule('rank-a', 'Add some initial tools', [applicationBaseNamePropertyDefinition()], [], 'RANK_A'),
+          initialModule('rank-b', 'Add some initial tools', [applicationBaseNamePropertyDefinition()], [], 'RANK_B'),
+        ],
+      },
+    ]);
 });

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -2,6 +2,7 @@ import { Landscape } from '@/module/domain/landscape/Landscape';
 import { RANKS } from '@/module/domain/landscape/ModuleRank';
 import { ModuleRankStatistics, toModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import { LandscapeRankModuleFilterVue } from '@/module/primary/landscape-rank-module-filter';
+import { Optional } from '@/shared/optional/domain/Optional';
 import { VueWrapper, mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 import { wrappedElement } from '../../../WrappedElement';
@@ -30,7 +31,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     const rankDButton = wrapper.find(wrappedElement('rank-RANK_D-filter'));
     await rankDButton.trigger('click');
 
-    expect(wrapper.emitted('selected')).toEqual([[RANKS[0]]]);
+    expect(wrapper.emitted('selected')).toEqual([[Optional.of(RANKS[0])]]);
   });
 
   it('should deselect rank when clicking on selected filter button', async () => {
@@ -40,7 +41,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     await rankDButton.trigger('click');
     await rankDButton.trigger('click');
 
-    expect(wrapper.emitted('selected')).toEqual([[RANKS[0]], [undefined]]);
+    expect(wrapper.emitted('selected')).toEqual([[Optional.of(RANKS[0])], [Optional.empty()]]);
   });
 
   it('should format rank short name correctly', () => {
@@ -77,7 +78,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     await rankAButton.trigger('click');
     await wrapper.vm.$nextTick();
 
-    expect(wrapper.emitted('selected')).toEqual([[RANKS[3]]]);
+    expect(wrapper.emitted('selected')).toEqual([[Optional.of(RANKS[3])]]);
   });
 
   it('should emit undefined when deselecting a rank', async () => {
@@ -87,7 +88,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     await rankSButton.trigger('click');
     await rankSButton.trigger('click');
 
-    expect(wrapper.emitted('selected')).toEqual([[RANKS[4]], [undefined]]);
+    expect(wrapper.emitted('selected')).toEqual([[Optional.of(RANKS[4])], [Optional.empty()]]);
   });
 
   it('should only emit one rank at a time', async () => {
@@ -98,7 +99,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     await rankBButton.trigger('click');
     await rankCButton.trigger('click');
 
-    expect(wrapper.emitted('selected')).toEqual([[RANKS[2]], [RANKS[1]]]);
+    expect(wrapper.emitted('selected')).toEqual([[Optional.of(RANKS[2])], [Optional.of(RANKS[1])]]);
   });
 
   it('should display correct description for rank button', () => {

--- a/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
+++ b/src/test/webapp/unit/module/secondary/RestModulesRepository.spec.ts
@@ -198,7 +198,7 @@ const restLandscape = (): RestLandscape => ({
     {
       elements: [
         landscapeModule('java-base', 'Add base java classes', emptyProperties(), [featureDependency('java-build-tools')], 'RANK_S'),
-        landscapeModule('spring-boot', 'Add spring boot core', emptyProperties(), [featureDependency('java-build-tools')]),
+        landscapeModule('spring-boot', 'Add spring boot core', emptyProperties(), [featureDependency('java-build-tools')], 'RANK_B'),
         landscapeFeature('ci', [
           landscapeModule('gitlab-maven', 'Add simple gitlab ci for maven', emptyProperties(), [moduleDependency('maven')], 'RANK_S'),
           landscapeModule('gitlab-gradle', 'Add simple gitlab ci for gradle', emptyProperties(), [moduleDependency('gradle')], 'RANK_S'),


### PR DESCRIPTION
- following https://github.com/jhipster/jhipster-lite/pull/11910
- related to https://github.com/jhipster/jhipster-lite/issues/10934



https://github.com/user-attachments/assets/c7b22a58-16e8-46c7-8aa0-17360e88c919


After filtering the modules by rank, it was difficult to distinguish between the modules that were filtered by rank and the dependency modules, which could belong to different ranks.
- Do not display any rank-related colors until the user clicks on one of the rank buttons to maintain the current user experience.  
- After filtering by rank, the filtering buttons will feature an external border color representing each rank. A solid border color indicates the filtered rank, while a dotted border indicates the dependency modules from the filtered rank. Each module will have border colors that match their ranks.
- When the rank filter button is deselected, all colors disappear, including the legend border color from the rank filter button.
