### PR TITLE
Sonar: Control structures should use curly braces

### DIFF
--- a/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContext.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/rest/CucumberRestTestContext.java.mustache
@@ -187,7 +187,9 @@ public final class CucumberRestTestContext {
      */
     @SuppressWarnings("java:S1144")
     private boolean forUri(String uri) {
-      if (!uri.matches("[\\w-]+")) Assertions.fail("URI should be the name of a REST resource");
+      if (!uri.matches("[\\w-]+")) {
+        Assertions.fail("URI should be the name of a REST resource");
+      }
 
       return this.uri.matches(String.format(URI_MATCHER, uri));
     }


### PR DESCRIPTION
Same as https://github.com/jhipster/jhipster-lite/blob/f8a943761b6baf8c2f5efb0c169dc359471732a5/src/test/java/tech/jhipster/lite/cucumber/rest/CucumberRestTestContext.java#L195