### PR TITLE
feat(spring-boot): avoid declaring twice the logging level for tests

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactory.java
@@ -100,7 +100,6 @@ public class SpringBootCoreModuleFactory {
         .and()
       .springTestProperties()
         .set(propertyKey("spring.main.banner-mode"), propertyValue("off"))
-        .set(propertyKey(basePackageLoggingLevel), propertyValue("OFF"))
         .set(propertyKey("logging.config"), propertyValue("classpath:logback.xml"))
         .and()
       .optionalReplacements()

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/core/domain/SpringBootCoreModuleFactoryTest.java
@@ -1,6 +1,11 @@
 package tech.jhipster.lite.generator.server.springboot.core.domain;
 
-import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.*;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.ModuleFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.assertThatModuleWithFiles;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.file;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.gradleBuildFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.gradleLibsVersionFile;
+import static tech.jhipster.lite.module.infrastructure.secondary.JHipsterModulesAssertions.pomFile;
 
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -175,10 +180,6 @@ class SpringBootCoreModuleFactoryTest {
           """
           logging:
             config: classpath:logback.xml
-            level:
-              tech:
-                jhipster:
-                  jhlitest: 'OFF'
           spring:
             main:
               banner-mode: 'off'


### PR DESCRIPTION
It was declared in both application-test.yml and logback.xml