### PR TITLE
fix the rank button alignment to be centered

### DIFF
--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -56,15 +56,18 @@ $jhlite-button-toggle-transition-duration: 0.5s;
 
 .jhlite-button-toggle-short-name {
   display: inline-block;
-  transition: all $jhlite-button-toggle-transition-duration ease-out;
+  transition:
+    max-width $jhlite-button-toggle-transition-duration 500ms ease-in,
+    opacity $jhlite-button-toggle-transition-duration 1ms ease-in;
   opacity: 1;
+  max-width: 300px;
   white-space: nowrap;
 }
 
 .jhlite-button-toggle-full-name {
   display: inline-block;
   transition:
-    opacity $jhlite-button-toggle-transition-duration 1ms ease-out,
+    opacity 1ms 1ms ease-out,
     max-width $jhlite-button-toggle-transition-duration 1ms ease-out;
   opacity: 0;
   max-width: 0;
@@ -75,7 +78,9 @@ $jhlite-button-toggle-transition-duration: 0.5s;
 .jhlite-button-toggle:hover,
 .jhlite-button-toggle.-active {
   .jhlite-button-toggle-short-name {
+    transition: max-width 500ms 1ms ease-out;
     opacity: 0;
+    max-width: 0;
   }
 
   .jhlite-button-toggle-full-name {

--- a/src/main/style/atom/button/button-toggle/_button-toggle.scss
+++ b/src/main/style/atom/button/button-toggle/_button-toggle.scss
@@ -56,13 +56,16 @@ $jhlite-button-toggle-transition-duration: 0.5s;
 
 .jhlite-button-toggle-short-name {
   display: inline-block;
+  transition: all $jhlite-button-toggle-transition-duration ease-out;
   opacity: 1;
   white-space: nowrap;
 }
 
 .jhlite-button-toggle-full-name {
   display: inline-block;
-  transition: all $jhlite-button-toggle-transition-duration 1ms ease-out;
+  transition:
+    opacity $jhlite-button-toggle-transition-duration 1ms ease-out,
+    max-width $jhlite-button-toggle-transition-duration 1ms ease-out;
   opacity: 0;
   max-width: 0;
   overflow: hidden;
@@ -76,7 +79,9 @@ $jhlite-button-toggle-transition-duration: 0.5s;
   }
 
   .jhlite-button-toggle-full-name {
-    transition: max-width 2 * $jhlite-button-toggle-transition-duration 50ms ease-in;
+    transition:
+      opacity $jhlite-button-toggle-transition-duration 1ms ease-in,
+      max-width 2 * $jhlite-button-toggle-transition-duration 1ms ease-in;
     opacity: 1;
     max-width: 300px;
   }

--- a/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
+++ b/src/main/style/atom/button/button-toggle/button-toggle.mixin.pug
@@ -4,7 +4,7 @@ mixin jhlite-button-toggle(opts)
   button.jhlite-button-toggle(class=activeClass, disabled=disabled)
     if shortName && fullName
       span.jhlite-button-toggle-content
-        span.jhlite-button-toggle-short-name= shortName
         span.jhlite-button-toggle-full-name= fullName
+        span.jhlite-button-toggle-short-name= shortName
     else
       block

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -2,10 +2,12 @@ import { ModuleRank, RANKS, extractRankLetter } from '@/module/domain/landscape/
 import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
 import { Optional } from '@/shared/optional/domain/Optional';
+import { ToggleButtonExpandableVue } from '@/shared/toggle-button-expandable/infrastructure/primary';
 import { PropType, defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
+  components: { ToggleButtonExpandableVue },
   props: {
     moduleRankStatistics: {
       type: Array as PropType<ModuleRankStatistics>,
@@ -16,7 +18,6 @@ export default defineComponent({
   setup(props, { emit }) {
     const ranks = RANKS;
     const selectedRank = ref<Optional<ModuleRank>>(Optional.empty());
-
     const rankDescriptions: RankDescription = {
       RANK_D: 'Experimental or advanced module requiring specific expertise',
       RANK_C: 'Module without known production usage',
@@ -43,11 +44,20 @@ export default defineComponent({
 
     const isRankDisabled = (rank: ModuleRank): boolean => props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
 
-    const getRankColorClass = (rank: ModuleRank): string => `-rank-color -${extractRankLetter(rank).toLowerCase()}`;
+    const getRankClasses = (rank: ModuleRank): string[] => {
+      const classes: string[] = [];
 
-    const isAnyRankSelected = (): boolean => selectedRank.value.isPresent();
+      if (selectedRank.value.isPresent()) {
+        classes.push('-rank-color');
+        classes.push(`-${extractRankLetter(rank).toLowerCase()}`);
 
-    const isReduceAttention = (rank: ModuleRank): boolean => selectedRank.value.filter(r => r !== rank).isPresent();
+        if (selectedRank.value.filter(r => r !== rank).isPresent()) {
+          classes.push('-reduced-attention');
+        }
+      }
+
+      return classes;
+    };
 
     return {
       ranks,
@@ -57,9 +67,7 @@ export default defineComponent({
       formatRankFullName,
       getRankDescription,
       isRankDisabled,
-      getRankColorClass,
-      isAnyRankSelected,
-      isReduceAttention,
+      getRankClasses,
     };
   },
 });

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -16,7 +16,6 @@ export default defineComponent({
   setup(props, { emit }) {
     const ranks = RANKS;
     const selectedRank = ref<Optional<ModuleRank>>(Optional.empty());
-    const hoverRankS = ref<boolean>(false);
 
     const rankDescriptions: RankDescription = {
       RANK_D: 'Experimental or advanced module requiring specific expertise',
@@ -44,8 +43,6 @@ export default defineComponent({
 
     const isRankDisabled = (rank: ModuleRank): boolean => props.moduleRankStatistics.find(ru => ru.rank === rank)?.quantity === 0;
 
-    const isRankHovered = (rank: ModuleRank): boolean => rank === 'RANK_S' && hoverRankS.value;
-
     const getRankColorClass = (rank: ModuleRank): string => `-rank-color -${extractRankLetter(rank).toLowerCase()}`;
 
     const isAnyRankSelected = (): boolean => selectedRank.value.isPresent();
@@ -60,7 +57,6 @@ export default defineComponent({
       formatRankFullName,
       getRankDescription,
       isRankDisabled,
-      isRankHovered,
       getRankColorClass,
       isAnyRankSelected,
       isReduceAttention,

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -1,23 +1,16 @@
 <div class="landscape-rank-module-filter">
   <div class="jhlite-landscape-rank-module-filter--ranks">
-    <button
+    <ToggleButtonExpandableVue
       v-for="rank in ranks"
       :key="rank"
-      class="jhlite-button-toggle"
-      :class="{
-         '-active': isRankSelected(rank),
-         [getRankColorClass(rank)]: isAnyRankSelected(),
-         '-reduced-attention': isReduceAttention(rank)
-       }"
-      @click="toggleRank(rank)"
-      :data-testid="`rank-${rank}-filter`"
+      :shortName="formatRankShortName(rank)"
+      :fullName="formatRankFullName(rank)"
+      :isActive="isRankSelected(rank)"
+      :customClasses="getRankClasses(rank)"
+      :dataTestId="`rank-${rank}-filter`"
       :title="getRankDescription(rank)"
       :disabled="isRankDisabled(rank)"
-    >
-      <span class="jhlite-button-toggle-content">
-        <span class="jhlite-button-toggle-short-name" :data-testid="`short-name-${rank}`">{{ formatRankShortName(rank) }}</span>
-        <span class="jhlite-button-toggle-full-name" :data-testid="`full-name-${rank}`">{{ formatRankFullName(rank) }}</span>
-      </span>
-    </button>
+      @click="toggleRank(rank)"
+    />
   </div>
 </div>

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -6,7 +6,6 @@
       class="jhlite-button-toggle"
       :class="{
          '-active': isRankSelected(rank),
-         '-hovered': isRankHovered(rank),
          [getRankColorClass(rank)]: isAnyRankSelected(),
          '-reduced-attention': isReduceAttention(rank)
        }"

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
@@ -1,0 +1,75 @@
+import { defineComponent, ref } from 'vue';
+
+export default defineComponent({
+  name: 'ToggleButtonExpandableVue',
+  props: {
+    shortName: {
+      type: String,
+      required: true,
+    },
+    fullName: {
+      type: String,
+      required: true,
+    },
+    isActive: {
+      type: Boolean,
+      default: false,
+    },
+    customClasses: {
+      type: Array as () => string[],
+      default: () => [],
+    },
+    dataTestId: {
+      type: String,
+      default: '',
+    },
+    title: {
+      type: String,
+      default: '',
+    },
+    disabled: {
+      type: Boolean,
+      default: false,
+    },
+  },
+  emits: ['click', 'mouseenter', 'mouseleave'],
+  setup(props, { emit }) {
+    const isHovered = ref(false);
+    const fullNameVisible = ref(props.isActive);
+
+    const buttonClasses = (): string => {
+      return [...props.customClasses, props.isActive ? '-active' : ''].filter(Boolean).join(' ');
+    };
+
+    const isShortNameVisible = (): boolean => {
+      return !fullNameVisible.value;
+    };
+
+    const handleClick = (): void => emit('click');
+
+    const handleMouseEnter = (): void => {
+      isHovered.value = true;
+      emit('mouseenter');
+    };
+
+    const handleMouseLeave = (): void => {
+      isHovered.value = false;
+      emit('mouseleave');
+    };
+
+    const handleFullNameTransitionEnd = (event: TransitionEvent): void => {
+      if (event.propertyName === 'opacity') {
+        fullNameVisible.value = isHovered.value || props.isActive;
+      }
+    };
+
+    return {
+      buttonClasses,
+      isShortNameVisible,
+      handleClick,
+      handleMouseEnter,
+      handleMouseLeave,
+      handleFullNameTransitionEnd,
+    };
+  },
+});

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
@@ -1,4 +1,4 @@
-import { defineComponent, ref } from 'vue';
+import { defineComponent } from 'vue';
 
 export default defineComponent({
   name: 'ToggleButtonExpandableVue',
@@ -34,42 +34,15 @@ export default defineComponent({
   },
   emits: ['click', 'mouseenter', 'mouseleave'],
   setup(props, { emit }) {
-    const isHovered = ref(false);
-    const fullNameVisible = ref(props.isActive);
-
     const buttonClasses = (): string => {
       return [...props.customClasses, props.isActive ? '-active' : ''].filter(Boolean).join(' ');
     };
 
-    const isShortNameVisible = (): boolean => {
-      return !fullNameVisible.value;
-    };
-
     const handleClick = (): void => emit('click');
-
-    const handleMouseEnter = (): void => {
-      isHovered.value = true;
-      emit('mouseenter');
-    };
-
-    const handleMouseLeave = (): void => {
-      isHovered.value = false;
-      emit('mouseleave');
-    };
-
-    const handleFullNameTransitionEnd = (event: TransitionEvent): void => {
-      if (event.propertyName === 'opacity') {
-        fullNameVisible.value = isHovered.value || props.isActive;
-      }
-    };
 
     return {
       buttonClasses,
-      isShortNameVisible,
       handleClick,
-      handleMouseEnter,
-      handleMouseLeave,
-      handleFullNameTransitionEnd,
     };
   },
 });

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.html
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.html
@@ -2,22 +2,12 @@
   class="jhlite-button-toggle"
   :class="buttonClasses()"
   @click="handleClick()"
-  @mouseenter="handleMouseEnter()"
-  @mouseleave="handleMouseLeave()"
   :data-testid="dataTestId"
   :title="title"
   :disabled="disabled"
 >
   <span class="jhlite-button-toggle-content">
-    <span class="jhlite-button-toggle-short-name" v-if="isShortNameVisible()" :data-testid="`short-name-${shortName}`">
-      {{ shortName }}
-    </span>
-    <span
-      class="jhlite-button-toggle-full-name"
-      :data-testid="`full-name-${shortName}`"
-      @transitionend="handleFullNameTransitionEnd($event)"
-    >
-      {{ fullName }}
-    </span>
+    <span class="jhlite-button-toggle-full-name" :data-testid="`full-name-${shortName}`"> {{ fullName }} </span>
+    <span class="jhlite-button-toggle-short-name" :data-testid="`short-name-${shortName}`"> {{ shortName }} </span>
   </span>
 </button>

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.html
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.html
@@ -1,0 +1,23 @@
+<button
+  class="jhlite-button-toggle"
+  :class="buttonClasses()"
+  @click="handleClick()"
+  @mouseenter="handleMouseEnter()"
+  @mouseleave="handleMouseLeave()"
+  :data-testid="dataTestId"
+  :title="title"
+  :disabled="disabled"
+>
+  <span class="jhlite-button-toggle-content">
+    <span class="jhlite-button-toggle-short-name" v-if="isShortNameVisible()" :data-testid="`short-name-${shortName}`">
+      {{ shortName }}
+    </span>
+    <span
+      class="jhlite-button-toggle-full-name"
+      :data-testid="`full-name-${shortName}`"
+      @transitionend="handleFullNameTransitionEnd($event)"
+    >
+      {{ fullName }}
+    </span>
+  </span>
+</button>

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.vue
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.vue
@@ -1,0 +1,3 @@
+<template src="./ToggleButtonExpandable.html"></template>
+
+<script lang="ts" src="./ToggleButtonExpandable.component.ts"></script>

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/index.ts
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/index.ts
@@ -1,0 +1,3 @@
+import ToggleButtonExpandableVue from './ToggleButtonExpandable.vue';
+
+export { ToggleButtonExpandableVue };

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -12,7 +12,7 @@ import { applicationBaseNamePropertyDefinition } from '../../domain/Modules.fixt
 const wrap = (props?: { moduleRankStatistics: ModuleRankStatistics }): VueWrapper => {
   return mount(LandscapeRankModuleFilterVue, {
     props: props || {
-      moduleRankStatistics: RANKS.map(rank => ({ rank, quantity: 1 })), // Force enable all ranks
+      moduleRankStatistics: RANKS.map(rank => ({ rank, quantity: 1 })),
     },
   });
 };
@@ -145,6 +145,46 @@ describe('LandscapeRankModuleFilterComponent', () => {
 
       expect(rankButton.classes()).toContain('-rank-color');
       expect(rankButton.classes()).toContain(rankColorClasses[rank]);
+    }
+  });
+
+  it('should display buttons without colors by default', async () => {
+    const wrapper = wrap();
+
+    const rankColorClasses = {
+      RANK_D: '-d',
+      RANK_C: '-c',
+      RANK_B: '-b',
+      RANK_A: '-a',
+      RANK_S: '-s',
+    };
+    for (const rank of RANKS) {
+      const rankButton = wrapper.find(wrappedElement(`rank-${rank}-filter`));
+
+      expect(rankButton.classes()).not.toContain('-rank-color');
+      expect(rankButton.classes()).not.toContain(rankColorClasses[rank]);
+    }
+  });
+
+  it('should display buttons without colors when a selected rank is deselected', async () => {
+    const wrapper = wrap();
+
+    const rankAButton = wrapper.find(wrappedElement('rank-RANK_A-filter'));
+    await rankAButton.trigger('click');
+    await rankAButton.trigger('click');
+
+    const rankColorClasses = {
+      RANK_D: '-d',
+      RANK_C: '-c',
+      RANK_B: '-b',
+      RANK_A: '-a',
+      RANK_S: '-s',
+    };
+    for (const rank of RANKS) {
+      const rankButton = wrapper.find(wrappedElement(`rank-${rank}-filter`));
+
+      expect(rankButton.classes()).not.toContain('-rank-color');
+      expect(rankButton.classes()).not.toContain(rankColorClasses[rank]);
     }
   });
 

--- a/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
+++ b/src/test/webapp/unit/module/primary/landscape/LandscapeRankModuleFilterComponent.spec.ts
@@ -148,7 +148,7 @@ describe('LandscapeRankModuleFilterComponent', () => {
     }
   });
 
-  it('should display buttons without colors by default', async () => {
+  it('should display buttons without colors by default', () => {
     const wrapper = wrap();
 
     const rankColorClasses = {

--- a/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
+++ b/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
@@ -18,7 +18,7 @@ describe('ToggleButtonExpandable', () => {
       expect(shortName.text()).toBe('S');
     });
 
-    it('should display full name when initialized as active', async () => {
+    it('should display full name when initialized as active', () => {
       const wrapper = mount(ToggleButtonExpandableVue, {
         props: {
           shortName: 'S',

--- a/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
+++ b/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
@@ -1,0 +1,187 @@
+import { ToggleButtonExpandableVue } from '@/shared/toggle-button-expandable/infrastructure/primary';
+import { mount } from '@vue/test-utils';
+import { describe, expect, it } from 'vitest';
+
+describe('ToggleButtonExpandable', () => {
+  describe('when initially rendered', () => {
+    it('should display short name by default', () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+        },
+      });
+
+      const shortName = wrapper.find('[data-testid="short-name-S"]');
+
+      expect(shortName.exists()).toBe(true);
+      expect(shortName.text()).toBe('S');
+    });
+
+    it('should display full name when initialized as active', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+          isActive: true,
+        },
+      });
+
+      const shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(false);
+      const fullName = wrapper.find('[data-testid="full-name-S"]');
+      expect(fullName.exists()).toBe(true);
+    });
+  });
+
+  describe('when customizing appearance', () => {
+    it('should highlight when active', () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+          isActive: true,
+        },
+      });
+
+      expect(wrapper.classes()).toContain('-active');
+    });
+
+    it('should apply additional styling when provided', () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+          customClasses: ['-rank-color -s'],
+        },
+      });
+
+      expect(wrapper.classes()).toContain('-rank-color');
+      expect(wrapper.classes()).toContain('-s');
+    });
+  });
+
+  describe('when interacting with the button', () => {
+    it('should notify when clicked', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+        },
+      });
+
+      await wrapper.trigger('click');
+
+      expect(wrapper.emitted('click')).toBeTruthy();
+      expect(wrapper.emitted('click')?.length).toBe(1);
+    });
+
+    it('should prevent interaction when disabled', () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+          disabled: true,
+        },
+      });
+
+      expect(wrapper.attributes('disabled')).toBe('');
+    });
+  });
+
+  describe('when hovering over the button', () => {
+    it('should expand to show full name', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+        },
+      });
+      const shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+      expect(shortName.isVisible()).toBe(true);
+
+      await wrapper.trigger('mouseenter');
+      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
+      await fullNameElement.trigger('transitionend', {
+        propertyName: 'opacity',
+      });
+
+      const fullName = wrapper.find('[data-testid="full-name-S"]');
+      expect(fullName.exists()).toBe(true);
+      const shortNameExpected = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortNameExpected.exists()).toBe(false);
+    });
+
+    it('should collapse back to short name after mouse leaves', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+        },
+      });
+      let shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+      await wrapper.trigger('mouseenter');
+      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
+      await fullNameElement.trigger('transitionend', {
+        propertyName: 'opacity',
+      });
+      shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(false);
+
+      await wrapper.trigger('mouseleave');
+      await fullNameElement.trigger('transitionend', {
+        propertyName: 'opacity',
+      });
+
+      shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+    });
+
+    it('should only respond to completed opacity transitions when expanding', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+        },
+      });
+      let shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+
+      await wrapper.trigger('mouseenter');
+      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
+      await fullNameElement.trigger('transitionend', {
+        propertyName: 'max-width',
+      });
+
+      shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+    });
+  });
+
+  describe('when changing state programmatically', () => {
+    it('should expand when becoming active', async () => {
+      const wrapper = mount(ToggleButtonExpandableVue, {
+        props: {
+          shortName: 'S',
+          fullName: 'RANK S',
+          isActive: false,
+        },
+      });
+      let shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(true);
+
+      await wrapper.setProps({ isActive: true });
+      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
+      await fullNameElement.trigger('transitionend', {
+        propertyName: 'opacity',
+      });
+
+      shortName = wrapper.find('[data-testid="short-name-S"]');
+      expect(shortName.exists()).toBe(false);
+      const fullName = wrapper.find('[data-testid="full-name-S"]');
+      expect(fullName.exists()).toBe(true);
+    });
+  });
+});

--- a/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
+++ b/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
@@ -12,10 +12,7 @@ describe('ToggleButtonExpandable', () => {
         },
       });
 
-      const shortName = wrapper.find('[data-testid="short-name-S"]');
-
-      expect(shortName.exists()).toBe(true);
-      expect(shortName.text()).toBe('S');
+      expect(wrapper.classes()).not.toContain('-active');
     });
 
     it('should display full name when initialized as active', () => {
@@ -27,10 +24,7 @@ describe('ToggleButtonExpandable', () => {
         },
       });
 
-      const shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(false);
-      const fullName = wrapper.find('[data-testid="full-name-S"]');
-      expect(fullName.exists()).toBe(true);
+      expect(wrapper.classes()).toContain('-active');
     });
   });
 
@@ -86,102 +80,6 @@ describe('ToggleButtonExpandable', () => {
       });
 
       expect(wrapper.attributes('disabled')).toBe('');
-    });
-  });
-
-  describe('when hovering over the button', () => {
-    it('should expand to show full name', async () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
-        props: {
-          shortName: 'S',
-          fullName: 'RANK S',
-        },
-      });
-      const shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-      expect(shortName.isVisible()).toBe(true);
-
-      await wrapper.trigger('mouseenter');
-      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
-      await fullNameElement.trigger('transitionend', {
-        propertyName: 'opacity',
-      });
-
-      const fullName = wrapper.find('[data-testid="full-name-S"]');
-      expect(fullName.exists()).toBe(true);
-      const shortNameExpected = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortNameExpected.exists()).toBe(false);
-    });
-
-    it('should collapse back to short name after mouse leaves', async () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
-        props: {
-          shortName: 'S',
-          fullName: 'RANK S',
-        },
-      });
-      let shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-      await wrapper.trigger('mouseenter');
-      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
-      await fullNameElement.trigger('transitionend', {
-        propertyName: 'opacity',
-      });
-      shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(false);
-
-      await wrapper.trigger('mouseleave');
-      await fullNameElement.trigger('transitionend', {
-        propertyName: 'opacity',
-      });
-
-      shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-    });
-
-    it('should only respond to completed opacity transitions when expanding', async () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
-        props: {
-          shortName: 'S',
-          fullName: 'RANK S',
-        },
-      });
-      let shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-
-      await wrapper.trigger('mouseenter');
-      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
-      await fullNameElement.trigger('transitionend', {
-        propertyName: 'max-width',
-      });
-
-      shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-    });
-  });
-
-  describe('when changing state programmatically', () => {
-    it('should expand when becoming active', async () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
-        props: {
-          shortName: 'S',
-          fullName: 'RANK S',
-          isActive: false,
-        },
-      });
-      let shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(true);
-
-      await wrapper.setProps({ isActive: true });
-      const fullNameElement = wrapper.find('[data-testid="full-name-S"]');
-      await fullNameElement.trigger('transitionend', {
-        propertyName: 'opacity',
-      });
-
-      shortName = wrapper.find('[data-testid="short-name-S"]');
-      expect(shortName.exists()).toBe(false);
-      const fullName = wrapper.find('[data-testid="full-name-S"]');
-      expect(fullName.exists()).toBe(true);
     });
   });
 });


### PR DESCRIPTION
Here is a demo video showing the alignment was fixed:


https://github.com/user-attachments/assets/e4a9a3ff-1322-4853-9ca3-c11cba838b3b

I needed to hide the short name (e.g., 'S') only after the full name (e.g., 'RANK S') was completely shown. That's why I had to create a component `ToggleButtonExpandableVue` to encapsulate the logic to hide the short name using v-if only after the opacity transition from the full name finished.

I tried to fix the problem using only CSS, and I encountered the following strange behavior (a glitch). I can call it a "visual bug"; it is unpleasant and annoying :). Here is a demo video showing the glitch:


https://github.com/user-attachments/assets/f6277c5d-26b5-40eb-992b-fc934854b8d8

