### PR TITLE
feat(cucumber): replace test selection using cucumber.features by @SelectDirectories

### DIFF
--- a/src/main/resources/generator/server/springboot/cucumber/CucumberTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/cucumber/CucumberTest.java.mustache
@@ -1,12 +1,12 @@
 package {{packageName}}.cucumber;
 
-import static io.cucumber.junit.platform.engine.Constants.FEATURES_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.FILTER_TAGS_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.GLUE_PROPERTY_NAME;
 import static io.cucumber.junit.platform.engine.Constants.PLUGIN_PROPERTY_NAME;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectDirectories;
 import org.junit.platform.suite.api.Suite;
 import {{packageName}}.ComponentTest;
 
@@ -14,11 +14,11 @@ import {{packageName}}.ComponentTest;
 @ComponentTest
 @IncludeEngines("cucumber")
 @SuppressWarnings("java:S2187")
+@SelectDirectories("src/test/features")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "{{packageName}}")
 @ConfigurationParameter(
   key = PLUGIN_PROPERTY_NAME,
   value = "pretty, json:{{projectBuildDirectory}}/cucumber/cucumber.json, html:{{projectBuildDirectory}}/cucumber/cucumber.htm, junit:{{projectBuildDirectory}}/cucumber/TEST-cucumber.xml"
 )
-@ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/features")
 @ConfigurationParameter(key = FILTER_TAGS_PROPERTY_NAME, value = "not @disabled")
 public class CucumberTest {}

--- a/src/main/resources/generator/server/springboot/custom-jhlite/test/CucumberTest.java.mustache
+++ b/src/main/resources/generator/server/springboot/custom-jhlite/test/CucumberTest.java.mustache
@@ -4,6 +4,7 @@ import static io.cucumber.junit.platform.engine.Constants.*;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectDirectories;
 import org.junit.platform.suite.api.Suite;
 import {{packageName}}.ComponentTest;
 
@@ -11,10 +12,10 @@ import {{packageName}}.ComponentTest;
 @ComponentTest
 @IncludeEngines("cucumber")
 @SuppressWarnings("java:S2187")
+@SelectDirectories("src/test/features")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "{{packageName}}, tech.jhipster.lite.module.infrastructure.primary, tech.jhipster.lite.project.infrastructure.primary")
 @ConfigurationParameter(
   key = PLUGIN_PROPERTY_NAME,
   value = "pretty, json:{{projectBuildDirectory}}/cucumber/cucumber.json, html:{{projectBuildDirectory}}/cucumber/cucumber.htm, junit:{{projectBuildDirectory}}/cucumber/TEST-cucumber.xml"
 )
-@ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/features")
 public class CucumberTest {}

--- a/src/test/java/tech/jhipster/lite/cucumber/CucumberTest.java
+++ b/src/test/java/tech/jhipster/lite/cucumber/CucumberTest.java
@@ -4,6 +4,7 @@ import static io.cucumber.junit.platform.engine.Constants.*;
 
 import org.junit.platform.suite.api.ConfigurationParameter;
 import org.junit.platform.suite.api.IncludeEngines;
+import org.junit.platform.suite.api.SelectDirectories;
 import org.junit.platform.suite.api.Suite;
 import tech.jhipster.lite.ComponentTest;
 
@@ -11,10 +12,10 @@ import tech.jhipster.lite.ComponentTest;
 @ComponentTest
 @IncludeEngines("cucumber")
 @SuppressWarnings("java:S2187")
+@SelectDirectories("src/test/features")
 @ConfigurationParameter(key = GLUE_PROPERTY_NAME, value = "tech.jhipster.lite")
 @ConfigurationParameter(
   key = PLUGIN_PROPERTY_NAME,
   value = "pretty, json:target/cucumber/cucumber.json, html:target/cucumber/cucumber.htm, junit:target/cucumber/TEST-cucumber.xml"
 )
-@ConfigurationParameter(key = FEATURES_PROPERTY_NAME, value = "src/test/features")
 public class CucumberTest {}


### PR DESCRIPTION
This fixes the warning during execution:
> WARNING: Discovering tests using the cucumber.features property. [...] If you are using the JUnit 5 Suite Engine, Platform Launcher API or Console Launcher you should not use this property.