### PR TITLE
Sonar: Use already-defined constant 'PROPERTIES_FIELD' instead of duplicating its value here

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendJavaBuildToolModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/javatool/frontendmaven/domain/FrontendJavaBuildToolModuleFactory.java
@@ -210,7 +210,7 @@ public class FrontendJavaBuildToolModuleFactory {
   }
 
   public JHipsterModule buildMergeCypressCoverageModule(JHipsterModuleProperties properties) {
-    Assert.notNull("properties", properties);
+    Assert.notNull(PROPERTIES_FIELD, properties);
     //@formatter:off
     return commonModuleFiles(properties)
       .javaBuildProperties()


### PR DESCRIPTION
Fix https://sonarcloud.io/project/issues?sinceLeakPeriod=true&issueStatuses=OPEN%2CCONFIRMED&id=jhipster_jhipster-lite&open=AZbztM01fo5Gw4DGS5Ez