### PR TITLE
Spring-boot actuators: switch configuration access to be opt-in rather than opt-out

### DIFF
--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactory.java
@@ -32,6 +32,10 @@ public class SpringBootActuatorModuleFactory {
         .set(propertyKey("management.endpoint.health.probes.enabled"), propertyValue(true))
         .set(propertyKey("management.endpoint.health.show-details"), propertyValue("always"))
         .and()
+      .springLocalProperties()
+        .set(propertyKey("management.endpoints.web.exposure.include"), propertyValue("*"))
+        .set(propertyKey("management.endpoints.access.default"), propertyValue("unrestricted"))
+        .and()
       .build();
     //@formatter:on
   }

--- a/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactory.java
+++ b/src/main/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactory.java
@@ -31,6 +31,8 @@ public class SpringBootActuatorModuleFactory {
         )
         .set(propertyKey("management.endpoint.health.probes.enabled"), propertyValue(true))
         .set(propertyKey("management.endpoint.health.show-details"), propertyValue("always"))
+        .set(propertyKey("management.endpoints.access.default"), propertyValue("none"))
+        .set(propertyKey("management.endpoints.jmx.exposure.exclude"), propertyValue("*"))
         .and()
       .springLocalProperties()
         .set(propertyKey("management.endpoints.web.exposure.include"), propertyValue("*"))

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactoryTest.java
@@ -38,6 +38,11 @@ class SpringBootActuatorModuleFactoryTest {
                 enabled: true
               show-details: always
           endpoints:
+            access:
+              default: none
+            jmx:
+              exposure:
+                exclude: '*'
             web:
               base-path: /management
               exposure:

--- a/src/test/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactoryTest.java
+++ b/src/test/java/tech/jhipster/lite/generator/server/springboot/technicaltools/actuator/domain/SpringBootActuatorModuleFactoryTest.java
@@ -50,6 +50,19 @@ class SpringBootActuatorModuleFactoryTest {
                 - loggers
                 - threaddump
         """
+      )
+      .and()
+      .hasFile("src/main/resources/config/application-local.yml")
+      .containing(
+        """
+        management:
+          endpoints:
+            access:
+              default: unrestricted
+            web:
+              exposure:
+                include: '*'
+        """
       );
   }
 }


### PR DESCRIPTION
It seems to be a safer configuration for security purpose