### PR TITLE
Remove formatter:off

### DIFF
--- a/src/main/resources/generator/server/springboot/mvc/security/jwt/authentication/main/infrastructure/primary/SecurityConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/jwt/authentication/main/infrastructure/primary/SecurityConfiguration.java.mustache
@@ -46,7 +46,6 @@ class SecurityConfiguration {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    // @formatter:off
     http
       .csrf(AbstractHttpConfigurer::disable)
       .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
@@ -87,7 +86,6 @@ class SecurityConfiguration {
       var jwtConfigurer = new JWTConfigurer(authenticationTokenReader());
       http.with(jwtConfigurer, Customizer.withDefaults());
       return http.build();
-    // @formatter:on
   }
 
   @Bean

--- a/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/main/infrastructure/primary/SecurityConfiguration.java.mustache
+++ b/src/main/resources/generator/server/springboot/mvc/security/oauth2/core/main/infrastructure/primary/SecurityConfiguration.java.mustache
@@ -60,7 +60,6 @@ class SecurityConfiguration {
 
   @Bean
   public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-    // @formatter:off
     return http
       .csrf(AbstractHttpConfigurer::disable)
       .addFilterBefore(corsFilter, CsrfFilter.class)
@@ -97,7 +96,6 @@ class SecurityConfiguration {
       )
       .oauth2Client(withDefaults())
       .build();
-    // @formatter:on
   }
 
   private Converter<Jwt, AbstractAuthenticationToken> authenticationConverter() {


### PR DESCRIPTION
After Java Prettier applies:
```java
  @Bean
  public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    http
      .csrf(AbstractHttpConfigurer::disable)
      .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
      .headers(headers ->
        headers
          .contentSecurityPolicy(csp -> csp.policyDirectives(properties.getContentSecurityPolicy()))
          .frameOptions(FrameOptionsConfig::deny)
          .referrerPolicy(referrer -> referrer.policy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN))
          .permissionsPolicyHeader(permissions ->
            permissions.policy(
              "camera=(), fullscreen=(self), geolocation=(), gyroscope=(), magnetometer=(), microphone=(), midi=(), payment=(), sync-xhr=()"
            )
          )
      )
      .formLogin(AbstractHttpConfigurer::disable)
      .httpBasic(AbstractHttpConfigurer::disable)
      .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
      .authorizeHttpRequests(authz ->
        authz
          .requestMatchers(HttpMethod.OPTIONS, "/**")
          .permitAll()
          .requestMatchers("/app/**")
          .permitAll()
          .requestMatchers("/i18n/**")
          .permitAll()
          .requestMatchers("/content/**")
          .permitAll()
          .requestMatchers("/swagger-ui/**")
          .permitAll()
          .requestMatchers("/swagger-ui.html")
          .permitAll()
          .requestMatchers("/v3/api-docs/**")
          .permitAll()
          .requestMatchers("/test/**")
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/authenticate"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/register"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/activate"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/account/reset-password/init"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/account/reset-password/finish"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/admin/**"))
          .hasAuthority(Role.ADMIN.key())
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/api/**"))
          .authenticated()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/management/health"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/management/health/**"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/management/info"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/management/prometheus"))
          .permitAll()
          .requestMatchers(PathPatternRequestMatcher.withDefaults().matcher("/management/**"))
          .hasAuthority(Role.ADMIN.key())
          .anyRequest()
          .authenticated()
      );

    var jwtConfigurer = new JWTConfigurer(authenticationTokenReader());
    http.with(jwtConfigurer, Customizer.withDefaults());
    return http.build();
  }
```