### PR TITLE
Rename ToggleButtonExpandableVue to ToggleButtonExpandable

### DIFF
--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.component.ts
@@ -2,12 +2,12 @@ import { ModuleRank, RANKS, extractRankLetter } from '@/module/domain/landscape/
 import type { ModuleRankStatistics } from '@/module/domain/ModuleRankStatistics';
 import type { RankDescription } from '@/module/domain/RankDescription';
 import { Optional } from '@/shared/optional/domain/Optional';
-import { ToggleButtonExpandableVue } from '@/shared/toggle-button-expandable/infrastructure/primary';
+import { ToggleButtonExpandable } from '@/shared/toggle-button-expandable/infrastructure/primary';
 import { PropType, defineComponent, ref } from 'vue';
 
 export default defineComponent({
   name: 'LandscapeRankModuleFilterVue',
-  components: { ToggleButtonExpandableVue },
+  components: { ToggleButtonExpandable },
   props: {
     moduleRankStatistics: {
       type: Array as PropType<ModuleRankStatistics>,

--- a/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
+++ b/src/main/webapp/app/module/primary/landscape-rank-module-filter/LandscapeRankModuleFilter.html
@@ -1,6 +1,6 @@
 <div class="landscape-rank-module-filter">
   <div class="jhlite-landscape-rank-module-filter--ranks">
-    <ToggleButtonExpandableVue
+    <ToggleButtonExpandable
       v-for="rank in ranks"
       :key="rank"
       :shortName="formatRankShortName(rank)"

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.component.ts
@@ -1,7 +1,7 @@
 import { defineComponent } from 'vue';
 
 export default defineComponent({
-  name: 'ToggleButtonExpandableVue',
+  name: 'ToggleButtonExpandable',
   props: {
     shortName: {
       type: String,

--- a/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/index.ts
+++ b/src/main/webapp/app/shared/toggle-button-expandable/infrastructure/primary/index.ts
@@ -1,3 +1,3 @@
-import ToggleButtonExpandableVue from './ToggleButtonExpandable.vue';
+import ToggleButtonExpandable from './ToggleButtonExpandable.vue';
 
-export { ToggleButtonExpandableVue };
+export { ToggleButtonExpandable };

--- a/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
+++ b/src/test/webapp/unit/shared/toggle-button-expandable/infrastructure/primary/ToggleButtonExpandable.spec.ts
@@ -1,11 +1,11 @@
-import { ToggleButtonExpandableVue } from '@/shared/toggle-button-expandable/infrastructure/primary';
+import { ToggleButtonExpandable } from '@/shared/toggle-button-expandable/infrastructure/primary';
 import { mount } from '@vue/test-utils';
 import { describe, expect, it } from 'vitest';
 
 describe('ToggleButtonExpandable', () => {
   describe('when initially rendered', () => {
     it('should display short name by default', () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',
@@ -16,7 +16,7 @@ describe('ToggleButtonExpandable', () => {
     });
 
     it('should display full name when initialized as active', () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',
@@ -30,7 +30,7 @@ describe('ToggleButtonExpandable', () => {
 
   describe('when customizing appearance', () => {
     it('should highlight when active', () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',
@@ -42,7 +42,7 @@ describe('ToggleButtonExpandable', () => {
     });
 
     it('should apply additional styling when provided', () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',
@@ -57,7 +57,7 @@ describe('ToggleButtonExpandable', () => {
 
   describe('when interacting with the button', () => {
     it('should notify when clicked', async () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',
@@ -71,7 +71,7 @@ describe('ToggleButtonExpandable', () => {
     });
 
     it('should prevent interaction when disabled', () => {
-      const wrapper = mount(ToggleButtonExpandableVue, {
+      const wrapper = mount(ToggleButtonExpandable, {
         props: {
           shortName: 'S',
           fullName: 'RANK S',


### PR DESCRIPTION
Proposal: rename all Vue components to XxxVue to Xxx (like in this PR and some components like https://github.com/jhipster/jhipster-lite/blob/main/src/main/webapp/app/shared/theme-button/infrastructure/primary/ThemeButton.component.ts )