### PR TITLE
Underscores should be used to make large numbers readable

### DIFF
--- a/src/main/resources/generator/server/javatool/protobuf/test/ProtobufDatesWriterTest.java.mustache
+++ b/src/main/resources/generator/server/javatool/protobuf/test/ProtobufDatesWriterTest.java.mustache
@@ -18,7 +18,7 @@ class ProtobufDatesWriterTest {
   @Test
   void shouldBuildTimestampFromInstant() {
     assertThat(ProtobufDatesWriter.buildTimestamp(Instant.ofEpochMilli(1337))).isEqualTo(
-      Timestamp.newBuilder().setSeconds(1).setNanos(337000000).build()
+      Timestamp.newBuilder().setSeconds(1).setNanos(337_000_000).build()
     );
   }
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/97c15f1f-6d89-44d1-8477-3b77c37f4dd9)
