### PR TITLE
Distribute openrewrite upgrade recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,16 @@ The original JHipster and JHLite are **not the same thing**, they are **not gene
 
 ![Choosing JHipster](documentation/jhlite-choice.png)
 
+## Upgrading an existing generated project
+
+If you have an existing project generated with JHipster Lite, you can handle breaking changes in latest versions by running the following command:
+
+```bash
+mvn -U org.openrewrite.maven:rewrite-maven-plugin:run -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-spring:RELEASE,tech.jhipster.lite:jhlite:RELEASE -Drewrite.activeRecipes=tech.jhipster.lite.UpgradeJhipsterLite
+```
+
+The main interest is for custom-jhlite instances, but it can also be useful if some modules have been renamed: it will update your `.jhipster/history.json` file to use the new module names.
+
 ## Prerequisites
 
 ### Java

--- a/src/main/resources/META-INF/rewrite/upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/upgrade.yml
@@ -1,0 +1,6 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLite
+recipeList:
+  - tech.jhipster.lite.UpgradeJhipsterLite_1.20.0
+  - tech.jhipster.lite.UpgradeJhipsterLite_1.21.0
+  - tech.jhipster.lite.UpgradeJhipsterLite_1.33.0

--- a/src/main/resources/META-INF/rewrite/upgrade.yml
+++ b/src/main/resources/META-INF/rewrite/upgrade.yml
@@ -4,3 +4,4 @@ recipeList:
   - tech.jhipster.lite.UpgradeJhipsterLite_1.20.0
   - tech.jhipster.lite.UpgradeJhipsterLite_1.21.0
   - tech.jhipster.lite.UpgradeJhipsterLite_1.33.0
+  - tech.jhipster.lite.UpgradeJhipsterLite_1.34.0

--- a/src/main/resources/META-INF/rewrite/version-1.20.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.20.0.yml
@@ -1,0 +1,31 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLite_1.20.0
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.shared.base64.domain.Base64Utils
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.base64.domain.Base64Utils
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "mariadb"'
+      replace: '"module": "jpa-mariadb"'
+      filePattern: '.jhipster/modules/history.json'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "mssql"'
+      replace: '"module": "jpa-mssql"'
+      filePattern: '.jhipster/modules/history.json'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "mysql"'
+      replace: '"module": "jpa-mysql"'
+      filePattern: '.jhipster/modules/history.json'
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "postgresql"'
+      replace: '"module": "jpa-postgresql"'
+      filePattern: '.jhipster/modules/history.json'
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jhlite.version
+      newValue: 1.20.0

--- a/src/main/resources/META-INF/rewrite/version-1.20.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.20.0.yml
@@ -1,15 +1,7 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: tech.jhipster.lite.UpgradeJhipsterLite_1.20.0
 recipeList:
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug
-      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug
-      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug
-  - org.openrewrite.java.ChangeType:
-      oldFullyQualifiedTypeName: tech.jhipster.lite.shared.base64.domain.Base64Utils
-      newFullyQualifiedTypeName: tech.jhipster.lite.shared.base64.domain.Base64Utils
+  - tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.20.0
   - org.openrewrite.text.FindAndReplace:
       find: '"module": "mariadb"'
       replace: '"module": "jpa-mariadb"'
@@ -26,6 +18,24 @@ recipeList:
       find: '"module": "postgresql"'
       replace: '"module": "jpa-postgresql"'
       filePattern: '.jhipster/modules/history.json'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.20.0
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: tech.jhipster.lite
+      artifactIdPattern: jhlite
+      version: '[,1.20.0)'
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteModuleSlug
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.slug.domain.JHLiteFeatureSlug
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.generator.base64.domain.Base64Utils
+      newFullyQualifiedTypeName: tech.jhipster.lite.shared.base64.domain.Base64Utils
   - org.openrewrite.maven.ChangePropertyValue:
       key: jhlite.version
       newValue: 1.20.0

--- a/src/main/resources/META-INF/rewrite/version-1.21.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.21.0.yml
@@ -1,0 +1,18 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLite_1.21.0
+recipeList:
+  - org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      oldPropertyKey: jhlite-hidden-resources.slugs
+      newPropertyKey: jhlite.hidden-resources.slugs
+  - org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      oldPropertyKey: jhlite-preset-file.name
+      newPropertyKey: jhlite.preset-file.name
+  - org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      oldPropertyKey: jhlite-hidden-resources
+      newPropertyKey: jhlite.hidden-resources
+  - org.openrewrite.java.spring.ChangeSpringPropertyKey:
+      oldPropertyKey: application.forced-project-folder
+      newPropertyKey: jhlite.forced-project-folder
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jhlite.version
+      newValue: 1.21.0

--- a/src/main/resources/META-INF/rewrite/version-1.21.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.21.0.yml
@@ -1,6 +1,16 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: tech.jhipster.lite.UpgradeJhipsterLite_1.21.0
 recipeList:
+  - tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.21.0
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.21.0
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: tech.jhipster.lite
+      artifactIdPattern: jhlite
+      version: '[,1.21.0)'
+recipeList:
   - org.openrewrite.java.spring.ChangeSpringPropertyKey:
       oldPropertyKey: jhlite-hidden-resources.slugs
       newPropertyKey: jhlite.hidden-resources.slugs

--- a/src/main/resources/META-INF/rewrite/version-1.33.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.33.0.yml
@@ -1,0 +1,33 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLite_1.33.0
+recipeList:
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmVersionSource
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackagesVersionSource
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmVersionSourceFactory
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackagesVersionSourceFactory
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmPackageName
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackageName
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmPackageVersion
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackageVersion
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmPackagesVersions
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackagesVersions
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.infrastructure.secondary.npm.FileSystemNpmVersionReader
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.infrastructure.secondary.nodejs.FileSystemNodePackagesVersionReader
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.infrastructure.secondary.npm.NpmVersionsReader
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.infrastructure.secondary.nodejs.NodePackagesVersionsReader
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.JHLiteNpmVersionSource
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.JHLiteNodePackagesVersionSource
+  - org.openrewrite.java.ChangeType:
+      oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmLazyInstaller
+      newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodeLazyPackagesInstaller
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jhlite.version
+      newValue: 1.33.0

--- a/src/main/resources/META-INF/rewrite/version-1.33.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.33.0.yml
@@ -1,6 +1,16 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: tech.jhipster.lite.UpgradeJhipsterLite_1.33.0
 recipeList:
+  - tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.33.0
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.33.0
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: tech.jhipster.lite
+      artifactIdPattern: jhlite
+      version: '[,1.33.0)'
+recipeList:
   - org.openrewrite.java.ChangeType:
       oldFullyQualifiedTypeName: tech.jhipster.lite.module.domain.npm.NpmVersionSource
       newFullyQualifiedTypeName: tech.jhipster.lite.module.domain.nodejs.NodePackagesVersionSource

--- a/src/main/resources/META-INF/rewrite/version-1.34.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.34.0.yml
@@ -1,0 +1,19 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLite_1.34.0
+recipeList:
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.SONAR_QUBE_JAVA
+      fullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.SONARQUBE_JAVA
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONAR_QUBE_JAVA_BACKEND
+      fullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONARQUBE_JAVA_BACKEND
+  - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
+      existingFullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONAR_QUBE_JAVA_BACKEND_AND_FRONTEND
+      fullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONARQUBE_JAVA_BACKEND_AND_FRONTEND
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "sonar-qube'
+      replace: '"module": "sonarqube'
+      filePattern: '.jhipster/modules/history.json'
+  - org.openrewrite.maven.ChangePropertyValue:
+      key: jhlite.version
+      newValue: 1.34.0

--- a/src/main/resources/META-INF/rewrite/version-1.34.0.yml
+++ b/src/main/resources/META-INF/rewrite/version-1.34.0.yml
@@ -1,6 +1,20 @@
 type: specs.openrewrite.org/v1beta/recipe
 name: tech.jhipster.lite.UpgradeJhipsterLite_1.34.0
 recipeList:
+  - tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.34.0
+  - org.openrewrite.text.FindAndReplace:
+      find: '"module": "sonar-qube'
+      replace: '"module": "sonarqube'
+      filePattern: '.jhipster/modules/history.json'
+---
+type: specs.openrewrite.org/v1beta/recipe
+name: tech.jhipster.lite.UpgradeJhipsterLiteJavaApi_1.34.0
+preconditions:
+  - org.openrewrite.java.dependencies.DependencyInsight:
+      groupIdPattern: tech.jhipster.lite
+      artifactIdPattern: jhlite
+      version: '[,1.34.0)'
+recipeList:
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.SONAR_QUBE_JAVA
       fullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteFeatureSlug.SONARQUBE_JAVA
@@ -10,10 +24,6 @@ recipeList:
   - org.openrewrite.java.ReplaceConstantWithAnotherConstant:
       existingFullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONAR_QUBE_JAVA_BACKEND_AND_FRONTEND
       fullyQualifiedConstantName: tech.jhipster.lite.shared.slug.domain.JHLiteModuleSlug.SONARQUBE_JAVA_BACKEND_AND_FRONTEND
-  - org.openrewrite.text.FindAndReplace:
-      find: '"module": "sonar-qube'
-      replace: '"module": "sonarqube'
-      filePattern: '.jhipster/modules/history.json'
   - org.openrewrite.maven.ChangePropertyValue:
       key: jhlite.version
       newValue: 1.34.0


### PR DESCRIPTION
This would be particularly useful for custom-jhlite instances, but also for generated projects when we rename slugs (as done in https://github.com/jhipster/jhipster-lite/pull/12948/files e.g.)