### PR TITLE
Fix: Streams that encapsulate a closeable resource should be closed

### DIFF
--- a/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemProjectFiles.java
+++ b/src/main/java/tech/jhipster/lite/module/infrastructure/secondary/FileSystemProjectFiles.java
@@ -1,5 +1,6 @@
 package tech.jhipster.lite.module.infrastructure.secondary;
 
+import com.google.errorprone.annotations.MustBeClosed;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URISyntaxException;
@@ -123,6 +124,7 @@ public class FileSystemProjectFiles implements ProjectFiles {
     }
   }
 
+  @MustBeClosed
   private static Stream<Path> getWalkStream(Path folder) throws IOException {
     return Files.walk(folder);
   }


### PR DESCRIPTION
`./mvnw clean verify` shows warning
<img width="1562" height="92" alt="image" src="https://github.com/user-attachments/assets/159c57d6-4a33-4578-983c-5fd62dae51a5" />
